### PR TITLE
branding compliance

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -27,10 +27,10 @@
 <Fill in the OpenStack release, such as Kilo>
 
 #### Description
-<Describe the bug in detail, steps taken prior to encountering the issue, yand a short explanation of you have deployed openstack and F5 agent>
+<Describe the bug in detail, steps taken prior to encountering the issue, yand a short explanation of you have deployed openstack and F5® agent>
 
 #### Deployment
-<Explain in reasonable detail your OpenStack deployment, the F5 OpenStack agent, and BIG-IP(s)>
-<Example: Single OpenStack controller with one F5 agent managing a cluster of 4 BIG-IP VEs>
-<Example: Three OpenStack controllers in HA, each with one standalone F5 agent managing a single BIG-IP appliance>
+<Explain in reasonable detail your OpenStack deployment, the F5® OpenStack agent, and BIG-IP®(s)>
+<Example: Single OpenStack controller with one F5® agent managing a cluster of 4 BIG-IP® VEs>
+<Example: Three OpenStack controllers in HA, each with one standalone F5® agent managing a single BIG-IP® appliance>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,4 +77,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
  
 ### Contributor License Agreement
-Individuals or business entities who contribute to this project must have completed and submitted the [F5 Contributor License Agreement](http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html#cla-landing) to Openstack_CLA@f5.com prior to their code submission being included in this project.
+Individuals or business entities who contribute to this project must have completed and submitted the [F5® Contributor License Agreement](http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html#cla-landing) to Openstack_CLA@f5.com prior to their code submission being included in this project.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ limitations under the License.
 [![Build Status](https://travis-ci.org/F5Networks/f5-openstack-agent.svg?branch=master)](https://travis-ci.org/F5Networks/f5-openstack-agent)
 
 ## Introduction
-This repo houses the code for the F5 OpenStack plugin agent. The agent allows you to deploy BIG-IP services in an OpenStack environment. 
+This repo houses the code for the F5® OpenStack plugin agent. The agent allows you to deploy BIG-IP® services in an OpenStack environment. 
 
 ## Documentation
 See [Documentation](http://f5-openstack-lbaasv2.rtfd.org).
@@ -90,4 +90,4 @@ See the License for the specific language governing permissions and
 limitations under the License.
  
 ### Contributor License Agreement
-Individuals or business entities who contribute to this project must have completed and submitted the [F5 Contributor License Agreement](http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html#cla-landing) to Openstack_CLA@f5.com prior to their code submission being included in this project.
+Individuals or business entities who contribute to this project must have completed and submitted the [F5® Contributor License Agreement](http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html#cla-landing) to Openstack_CLA@f5.com prior to their code submission being included in this project.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,5 +1,5 @@
-Maintenance and support of the unmodified F5 code is provided only to customers
-who have an existing support contract, purchased separately subject to F5’s
+Maintenance and support of the unmodified F5® code is provided only to customers
+who have an existing support contract, purchased separately subject to F5®’s
 support policies available at http://www.f5.com/about/guidelines-policies/ and 
-http://askf5.com.  F5 will not provide maintenance and support services of
-modified F5 code or code that does not have an existing support contract.
+http://askf5.com.  F5® will not provide maintenance and support services of
+modified F5® code or code that does not have an existing support contract.

--- a/etc/init.d/f5-oslbaasv2-agent
+++ b/etc/init.d/f5-oslbaasv2-agent
@@ -8,7 +8,7 @@
 # Default-Start:        2 3 4 5
 # Default-Stop:         0 1 6
 # Short-Description:    f5-openstack-agent
-# Description:          Provides the F5 OpenStack agent to configure BIG-IP
+# Description:          Provides the F5® OpenStack agent to configure BIG-IP®
 ### END INIT INFO
 
 PROJECT_NAME=neutron

--- a/etc/neutron/services/f5/f5-openstack-agent.ini
+++ b/etc/neutron/services/f5/f5-openstack-agent.ini
@@ -46,14 +46,14 @@ periodic_interval = 10
 #
 # service_resync_interval = 500
 #
-# Objects created on the BIG-IP by this agent will have their names prefixed
+# Objects created on the BIG-IP® by this agent will have their names prefixed
 # by an environment string. This allows you set this string.  The default is
 # 'uuid'.
 #
 # WARNING - you should only set this before creating any objects.  If you change
 # it with established objects, the objects created with an alternative prefix,
 # will no longer be associated with this agent and all objects in neutron
-# and on the the BIG-IP associated with the old environment will need to be managed
+# and on the the BIG-IP® associated with the old environment will need to be managed
 # manually.
 #
 ###############################################################################
@@ -299,10 +299,10 @@ f5_external_physical_mappings = default:1.1:True
 # Some systems require the need to bind and prune VLANs ids
 # allowed to specific ports, often for security. 
 #
-# An example would be if a LBaaS iControl endpoint is using 
+# An example would be if a LBaaS iControl® endpoint is using
 # tagged VLANs. When a VLAN tagged network is added to a 
-# specific BIG-IP device, the facing switch port will need
-# to allow traffic for that VLAN tag through to the BIG-IP's
+# specific BIG-IP® device, the facing switch port will need
+# to allow traffic for that VLAN tag through to the BIG-IP®'s
 # port for traffic to flow. 
 #
 # What is required is a software hook which allows the binding.
@@ -317,12 +317,12 @@ f5_external_physical_mappings = default:1.1:True
 # any string which is meaningful to a vlan_binding_driver. It can be a 
 # switch_id and port, or it might be a neutron port_id.
 #
-# In addition to any static mappings, when the iControl endpoints
+# In addition to any static mappings, when the iControl® endpoints
 # are initialized, all their TMM interfaces will be collect
 # for each device and neutron will be queried to see if which 
 # device port_ids correspond to known neutron ports. If they do, 
 # automatic entries for all mapped port_ids will be made referencing 
-# the BIG-IP device name and interface and the neutron port_ids. 
+# the BIG-IP® device name and interface and the neutron port_ids.
 #
 # interface_port_static_mappings = {"device_name_1":{"interface_ida":"port_ida","interface_idb":"port_idb"}, {"device_name_2":{"interface_ida":"port_ida","interface_idb":"port_idb"}} 
 #                  
@@ -333,7 +333,7 @@ f5_external_physical_mappings = default:1.1:True
 # Device Tunneling (VTEP) selfips
 #
 # This is a single entry or comma separated list of cidr (h/m) format
-# selfip addresses, one per BIG-IP device, to use for VTEP addresses.
+# selfip addresses, one per BIG-IP® device, to use for VTEP addresses.
 #
 # If no gre or vxlan tunneling is required, these settings should be
 # commented out or set to None.
@@ -377,10 +377,10 @@ f5_vtep_selfip_name = 'vtep'
 #
 # Device Tunneling (VTEP) selfips
 #
-# This is a boolean entry which determines if they BIG-IP will use
+# This is a boolean entry which determines if they BIG-IP® will use
 # L2 Population service to update its fdb tunnel entries. This needs
 # to be setup in accordance with the way the other tunnel agents are
-# setup.  If the BIG-IP agent and other tunnel agents don't match
+# setup.  If the BIG-IP® agent and other tunnel agents don't match
 # the tunnel setup will not work properly.
 #
 l2_population = True
@@ -389,13 +389,13 @@ l2_population = True
 #  L3 Segmentation Mode Settings
 ###############################################################################
 #
-# Global Routing Mode - No L2 or L3 Segmentation on BIG-IP
+# Global Routing Mode - No L2 or L3 Segmentation on BIG-IP®
 #
 # This setting will cause the agent to assume that all VIPs 
 # and pool members will be reachable via global device 
-# L3 routes, which must be already provisioned on the BIG-IPs.
+# L3 routes, which must be already provisioned on the BIG-IP®s.
 #
-# In f5_global_routed_mode, BIG-IP will not assume L2 
+# In f5_global_routed_mode, BIG-IP® will not assume L2
 # adjacentcy to any neutron network, therefore no 
 # L2 segementation between tenant services in the data plane 
 # will be provisioned by the agent. Because the routing 
@@ -406,22 +406,22 @@ l2_population = True
 #
 # WARNING: setting this mode to True will override
 # the use_namespaces, setting it to False, because only 
-# one global routing space will used on the BIG-IP.  This
+# one global routing space will used on the BIG-IP®.  This
 # means overlapping IP addresses between tenants is no 
 # longer supported. 
 #
 # WARNING: setting this mode to True will override
 # the f5_snat_mode, setting it to True, because pool members
-# will never be considered L2 adjacent to the BIG-IP by 
+# will never be considered L2 adjacent to the BIG-IP® by
 # the agent. All member access will be via L3 routing, which
-# will need to be setup on the BIG-IP before LBaaS provisions
+# will need to be setup on the BIG-IP® before LBaaS provisions
 # resources on behalf of tenants.
 #
 # WARNING: setting this mode to True will override the
 # f5_snat_addresses_per_subnet, setting it to 0 (zero).
 # This will force all VIPs to use AutoMap SNAT for which 
 # enough SelfIP will need to be pre-provisioned on the
-# BIG-IP to handle all pool member connections. The SNAT,
+# BIG-IP® to handle all pool member connections. The SNAT,
 # an L3 mechanism, will all be global without reference
 # to any specific tenant SNAT pool.
 #
@@ -430,7 +430,7 @@ l2_population = True
 # because no L2 information will be taken from 
 # neutron, thus making the assumption that all VIP
 # L3 addresses will be globally routable without 
-# segmentation at L2 on the BIG-IP.
+# segmentation at L2 on the BIG-IP®.
 #
 f5_global_routed_mode = True 
 #
@@ -530,16 +530,16 @@ f5_common_external_networks = True
 # separated list where if the name is a neutron
 # network id used for a vip or a pool member, 
 # the network should not be created or deleted
-# on the BIG-IP, but rather assumed that the value
+# on the BIG-IP®, but rather assumed that the value
 # is the name of the network already created in
 # the Common partition with all L3 addresses 
 # assigned to route domain 0.  This is useful
 # for shared networks which are already defined
-# on the BIG-IP prior to LBaaS configuration. The
+# on the BIG-IP® prior to LBaaS configuration. The
 # network should not be managed by the LBaaS agent,
 # but can be used for VIPs or pool members
 #
-# If your Internet VLAN on your BIG-IP is named
+# If your Internet VLAN on your BIG-IP® is named
 # /Common/external, and that corresponds to 
 # Neutron uuid: 71718972-78e2-449e-bb56-ce47cc9d2680
 # then the entry would look like:
@@ -558,7 +558,7 @@ f5_common_external_networks = True
 # Some systems require the need to bind L3 addresses
 # to specific ports, often for security. 
 #
-# An example would be if a LBaaS iControl endpoint is using 
+# An example would be if a LBaaS iControl® endpoint is using
 # untagged VLANs and is a nova guest instance. By 
 # default, neutron will attempt to apply security rule
 # for anti-spoofing which will not allow just any L3
@@ -578,7 +578,7 @@ f5_common_external_networks = True
 # vary between providers. They may look like a neutron port id
 # and a nova guest instance id.
 #
-# In addition to any static mappings, when the iControl endpoints
+# In addition to any static mappings, when the iControl® endpoints
 # are initialized, all their TMM MAC addresses will be collect
 # and neutron will be queried to see if the MAC addresses
 # correspond to known neutron ports. If they do, automatic entries
@@ -597,7 +597,7 @@ f5_bigip_lbaas_device_driver = f5_openstack_agent.lbaasv2.drivers.bigip.icontrol
 #
 #
 ###############################################################################
-#  Device Driver - iControl Driver Setting
+#  Device Driver - iControl® Driver Setting
 ###############################################################################
 #
 # icontrol_hostname is valid for external device type only.
@@ -610,7 +610,7 @@ f5_bigip_lbaas_device_driver = f5_openstack_agent.lbaasv2.drivers.bigip.icontrol
 # is not standalone, all devices in the sync failover
 # device group for the hostname specified must have 
 # there management IP address reachable to the agent.
-# If order to access devices' iControl interfaces via
+# If order to access devices' iControl® interfaces via
 # SelfIPs, you should specify them as a comma 
 # separated list below. 
 #
@@ -643,12 +643,12 @@ icontrol_connection_timeout = 10
 #  Experimental Features
 ###############################################################################
 #
-# iApp Support
+# iApp® Support
 #
 # LBaaS objects can can be provisioned in different modes:
 #
-# icontrol_config_mode = objects - means iControl for all objects 
-# icontrol_config_mode = iapp - means iApps to BIG-IP or BIG-IQ for service objects
+# icontrol_config_mode = objects - means iControl® for all objects
+# icontrol_config_mode = iapp - means iApp®s to BIG-IP® or BIG-IQ® for service objects
 #
 # Default is object mode. iapp mode is experimental in version 1.0.8 
 #
@@ -658,23 +658,23 @@ icontrol_config_mode = objects
 #
 ############################################################################### 
 # 
-# BIG-IQ Single Tenant Support 
+# BIG-IQ® Single Tenant Support
 #
 # If bigiq hostname and password for the admin user are provided
-# bigiq will be queried for single Tenant BIG-IPs which will can 
+# bigiq will be queried for single Tenant BIG-IP®s which will can
 # then be used to provide LBaaS
 #
 # bigiq_hostname = bigiphostname
 # bigiq_admin_password = admin
 #
-# These are the default credentials used by BIG-IQ to manage BIG-IPs
+# These are the default credentials used by BIG-IQ® to manage BIG-IP®s
 #
 # bigip_management_username = admin
 # bigip_management_password = admin
 #
-# These openstack credentials are used when BIG-IQ is configured
-# in order to determine whether the tenant has a BIG-IP that
-# the BIG-IQ can discover.
+# These openstack credentials are used when BIG-IQ® is configured
+# in order to determine whether the tenant has a BIG-IP® that
+# the BIG-IQ® can discover.
 #
 # openstack_keystone_uri = http://[keystoneserver]:5000/v2.0
 # openstack_admin_username = admin

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent.py
@@ -1,4 +1,4 @@
-"""F5 Networks LBaaSv2 agent implementation."""
+"""F5 Networks® LBaaSv2 agent implementation."""
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -1,4 +1,4 @@
-"""F5 Networks LBaaSv2 agent manager implementation."""
+"""F5 Networks® LBaaSv2 agent manager implementation."""
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -218,7 +218,7 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):
         LOG.debug('setting service resync intervl to %d seconds' %
                   self.service_resync_interval)
 
-        # Load the iControl driver.
+        # Load the iControl® driver.
         self.agent_host = conf.host
         self._load_driver(conf)
 
@@ -248,7 +248,7 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):
 
         self.admin_state_up = True
 
-        # Set iControl driver context for RPC.
+        # Set iControl® driver context for RPC.
         self.lbdriver.set_context(self.context)
 
         # Setup RPC:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -42,7 +42,7 @@ LOG = logging.getLogger(__name__)
 NS_PREFIX = 'qlbaas-'
 __VERSION__ = '0.1.1'
 
-# configuration objects specific to iControl driver
+# configuration objects specific to iControl® driver
 OPTS = [
     cfg.StrOpt(
         'bigiq_hostname',
@@ -233,7 +233,7 @@ class iControlDriver(LBaaSBaseDriver):
         self.__last_connect_attempt = None
         self.connected = False
 
-        # BIG-IP containers
+        # BIG-IP® containers
         self.__bigips = {}
         self.__traffic_groups = []
         self.agent_configurations = {}
@@ -375,7 +375,7 @@ class iControlDriver(LBaaSBaseDriver):
             )
 
     def _init_bigips(self):
-        # Connect to all BIG-IPs
+        # Connect to all BIG-IP®s
         if self.connected:
             return
         try:
@@ -729,7 +729,7 @@ class iControlDriver(LBaaSBaseDriver):
                     pool_stats['STATISTIC_SERVER_SIDE_TOTAL_CONNECTIONS']
                 # are there members to update status
                 if 'members' in service:
-                    # only query BIG-IP pool members if they
+                    # only query BIG-IP® pool members if they
                     # not in a state indicating provisioning or error
                     # provisioning the pool member
                     some_members_require_status_update = False
@@ -1189,7 +1189,7 @@ class iControlDriver(LBaaSBaseDriver):
                 greenthread.sleep(retry_delay)
 
     def _validate_bigip_version(self, bigip, hostname):
-        # Ensure the BIG-IP has sufficient version
+        # Ensure the BIG-IP® has sufficient version
         major_version = self.system_helper.get_major_version(bigip)
         if major_version < f5const.MIN_TMOS_MAJOR_VERSION:
             raise f5ex.MajorVersionValidateFailed(

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
@@ -33,7 +33,7 @@ def prefixed(name):
 
 
 def _get_tunnel_name(network):
-    # BIG-IP object name for a tunnel
+    # BIG-IP® object name for a tunnel
     tunnel_type = network['provider:network_type']
     tunnel_id = network['provider:segmentation_id']
     return 'tunnel-' + str(tunnel_type) + '-' + str(tunnel_id)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l3_binding.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l3_binding.py
@@ -1,4 +1,4 @@
-"""Module for managing L3 to L2 port bindings on F5 BIG-IP in Neutron."""
+"""Module for managing L3 to L2 port bindings on F5® BIG-IP® in Neutron."""
 # Copyright 2014 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -58,8 +58,8 @@ class L3BindingBase(object):
             LOG.debug('l3_binding_static_mappings not configured')
 
     def register_bigip_mac_addresses(self):
-        # Delayed binding BIG-IP ports will be called
-        # after BIG-IP endpoints are registered.
+        # Delayed binding BIG-IP® ports will be called
+        # after BIG-IP® endpoints are registered.
         if not self.__initialized__bigip_ports:
             for bigip in self.driver.get_all_bigips():
                 LOG.debug('Request Port information for MACs: %s'

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -26,8 +26,8 @@ LOG = logging.getLogger(__name__)
 
 
 class LBaaSBuilder(object):
-    # F5 LBaaS Driver using iControl for BIG-IP to
-    # create objects (vips, pools) - not using an iApp."""
+    # F5® LBaaS Driver using iControl® for BIG-IP® to
+    # create objects (vips, pools) - not using an iApp®."""
 
     def __init__(self, conf, driver, l2_service=None):
         self.conf = conf

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
@@ -22,11 +22,11 @@ LOG = logging.getLogger(__name__)
 
 
 class ListenerServiceBuilder(object):
-    """Create LBaaS v2 Listener on BIG-IPs.
+    """Create LBaaS v2 Listener on BIG-IP®s.
 
     Handles requests to create, update, delete LBaaS v2 listener
-    objects on one or more BIG-IP systems. Maps LBaaS listener
-    defined in service object to a BIG-IP virtual server.
+    objects on one or more BIG-IP® systems. Maps LBaaS listener
+    defined in service object to a BIG-IP® virtual server.
     """
 
     def __init__(self, service_adapter):
@@ -35,9 +35,9 @@ class ListenerServiceBuilder(object):
         self.service_adapter = service_adapter
 
     def create_listener(self, service, bigips):
-        """Create listener on set of BIG-IPs.
+        """Create listener on set of BIG-IP®s.
 
-        Creates a BIG-IP virtual server to represent an LBaaS
+        Creates a BIG-IP® virtual server to represent an LBaaS
         Listener object.
 
         :param service: Dictionary which contains a both a listener
@@ -58,7 +58,7 @@ class ListenerServiceBuilder(object):
                                             err.message))
 
         # Traffic group is added after create in order to take adavantage
-        # of BIG-IP defaults.
+        # of BIG-IP® defaults.
         traffic_group = self.service_adapter.get_traffic_group(service)
         if traffic_group:
             for bigip in bigips:
@@ -74,7 +74,7 @@ class ListenerServiceBuilder(object):
                                           err.message))
 
     def get_listener(self, service, bigip):
-        """Retrieve BIG-IP virtual from a single BIG-IP system.
+        """Retrieve BIG-IP® virtual from a single BIG-IP® system.
 
         :param service: Dictionary which contains a both a listener
         and load balancer definition.
@@ -96,7 +96,7 @@ class ListenerServiceBuilder(object):
         return obj
 
     def delete_listener(self, service, bigips):
-        """Delete Listener from a set of BIG-IP systems.
+        """Delete Listener from a set of BIG-IP® systems.
 
         Deletes virtual server that represents a Listener object.
 
@@ -120,7 +120,7 @@ class ListenerServiceBuilder(object):
                                       err.message))
 
     def update_listener(self, service, bigips):
-        """Update Listener from a single BIG-IP system.
+        """Update Listener from a single BIG-IP® system.
 
         Updates virtual servers that represents a Listener object.
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/loadbalancer_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/loadbalancer_service.py
@@ -26,16 +26,16 @@ LOG = logging.getLogger(__name__)
 
 
 class LoadBalancerServiceBuilder(object):
-    """Create loadbalancer related objects on BIG-IPs
+    """Create loadbalancer related objects on BIG-IP®s
 
     Handles requests to create and delete LBaaS v2 tenant partition
-    folders on one or more BIG-IP systems.
+    folders on one or more BIG-IP® systems.
     """
     def __init__(self):
         self.folder_helper = BigIPResourceHelper(ResourceType.folder)
 
     def create_partition(self, service, bigips):
-        """Create tenant partition on set of BIG-IPs.
+        """Create tenant partition on set of BIG-IP®s.
 
         Creates a partition if it is not named "Common".
 
@@ -49,7 +49,7 @@ class LoadBalancerServiceBuilder(object):
                 self.folder_helper.create(bigip, folder)
 
     def delete_partition(self, service, bigips):
-        """Deletes partition from a set of BIG-IP systems.
+        """Deletes partition from a set of BIG-IP® systems.
 
         Deletes partition if it is not named "Common".
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
@@ -25,10 +25,10 @@ LOG = logging.getLogger(__name__)
 
 
 class PoolServiceBuilder(object):
-    """Create LBaaS v2 pools and related objects on BIG-IPs.
+    """Create LBaaS v2 pools and related objects on BIG-IP®s.
 
     Handles requests to create, update, delete LBaaS v2 pools,
-    health monitors, and members on one or more BIG-IP systems.
+    health monitors, and members on one or more BIG-IP® systems.
     """
 
     def __init__(self, service_adapter):
@@ -41,9 +41,9 @@ class PoolServiceBuilder(object):
         self.node_helper = BigIPResourceHelper(ResourceType.node)
 
     def create_pool(self, service, bigips):
-        """Create a pool on set of BIG-IPs.
+        """Create a pool on set of BIG-IP®s.
 
-        Creates a BIG-IP pool to represent an LBaaS pool object.
+        Creates a BIG-IP® pool to represent an LBaaS pool object.
 
         :param service: Dictionary which contains a both a pool
         and load balancer definition.
@@ -62,9 +62,9 @@ class PoolServiceBuilder(object):
                                             err.message))
 
     def delete_pool(self, service, bigips):
-        """Delete a pool on set of BIG-IPs.
+        """Delete a pool on set of BIG-IP®s.
 
-        Deletes a BIG-IP pool defined by LBaaS pool object.
+        Deletes a BIG-IP® pool defined by LBaaS pool object.
 
         :param service: Dictionary which contains a both a pool
         and load balancer definition.
@@ -86,7 +86,7 @@ class PoolServiceBuilder(object):
                                             err.message))
 
     def update_pool(self, service, bigips):
-        """Update BIG-IP pool.
+        """Update BIG-IP® pool.
 
         :param service: Dictionary which contains a both a pool
         and load balancer definition.
@@ -175,7 +175,7 @@ class PoolServiceBuilder(object):
 
     # Note: can't use BigIPResourceHelper class because members
     # are created within pool objects. Following member methods
-    # use the F5 SDK directly.
+    # use the F5® SDK directly.
     def create_member(self, service, bigips):
         pool = self.service_adapter.get_pool(service)
         member = self.service_adapter.get_member(service)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
@@ -16,7 +16,7 @@ from enum import Enum
 
 
 class ResourceType(Enum):
-    """Defines supported BIG-IP resource types"""
+    """Defines supported BIG-IP® resource types"""
     nat = 1
     pool = 2
     sys = 3
@@ -31,9 +31,9 @@ class ResourceType(Enum):
 
 
 class BigIPResourceHelper(object):
-    """Helper class for creating, updating and deleting BIG-IP resources.
+    """Helper class for creating, updating and deleting BIG-IP® resources.
 
-    Reduces some of the boilerplate that surrounds using the F5 SDK.
+    Reduces some of the boilerplate that surrounds using the F5® SDK.
     Example usage:
         bigip = BigIP("10.1.1.1", "admin", "admin")
         pool = {"name": "pool1",
@@ -47,14 +47,14 @@ class BigIPResourceHelper(object):
         self.resource_type = resource_type
 
     def create(self, bigip, model):
-        """Create/update resource (e.g., pool) on a BIG-IP system.
+        """Create/update resource (e.g., pool) on a BIG-IP® system.
 
         First checks to see if resource has been created and creates
         it if not. If the resource is already created, updates resource
         with model attributes.
 
         :param bigip: BigIP instance to use for creating resource.
-        :param model: Dictionary of BIG-IP attributes to add resource. Must
+        :param model: Dictionary of BIG-IP® attributes to add resource. Must
         include name and partition.
         :returns: created or updated resource object.
         """
@@ -71,7 +71,7 @@ class BigIPResourceHelper(object):
         return resource
 
     def delete(self, bigip, name=None, partition=None):
-        """Delete a resource on a BIG-IP system.
+        """Delete a resource on a BIG-IP® system.
 
         Checks if resource exists and deletes it. Returns without error
         if resource does not exist.
@@ -86,10 +86,10 @@ class BigIPResourceHelper(object):
             resource.delete()
 
     def load(self, bigip, name=None, partition=None):
-        """Retrieves a BIG-IP resource from a BIG-IP.
+        """Retrieves a BIG-IP® resource from a BIG-IP®.
 
         Populates a resource object with attributes for instance on a
-        BIG-IP system.
+        BIG-IP® system.
 
         :param bigip: BigIP instance to use for creating resource.
         :param name: Name of resource to load.
@@ -102,13 +102,13 @@ class BigIPResourceHelper(object):
         return resource
 
     def update(self, bigip, model):
-        """Updates a resource (e.g., pool) on a BIG-IP system.
+        """Updates a resource (e.g., pool) on a BIG-IP® system.
 
-        Modifies a resource on a BIG-IP system using attributes
+        Modifies a resource on a BIG-IP® system using attributes
         defined in the model object.
 
         :param bigip: BigIP instance to use for creating resource.
-        :param model: Dictionary of BIG-IP attributes to update resource.
+        :param model: Dictionary of BIG-IP® attributes to update resource.
         Must include name and partition in order to identify resource.
         """
         partition = None

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
@@ -76,7 +76,7 @@ class BigipSelfIpManager(object):
                                          ip_address=selfip_address)
 
     def _get_bigip_selfip_address(self, bigip, subnet):
-        # Get ip address for selfip to use on BIG-IP.
+        # Get ip address for selfip to use on BIG-IP®.
         selfip_name = "local-" + bigip.device_name + "-" + subnet['id']
         ports = self.driver.plugin_rpc.get_port_by_name(port_name=selfip_name)
         if len(ports) > 0:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -27,9 +27,9 @@ class UnsupportedProtocolException(Exception):
 
 
 class ServiceModelAdapter(object):
-    """Class to translate LBaaS service objects to BIG-IP model objects.
+    """Class to translate LBaaS service objects to BIG-IP® model objects.
 
-    Creates BIG-IP model objects (dictionary of resource attributes) given
+    Creates BIG-IP® model objects (dictionary of resource attributes) given
     an LBaaS service objet.
     """
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/vcmp.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/vcmp.py
@@ -68,7 +68,7 @@ class VcmpManager(object):
                 system.sys_vcmp.get_management_address(guest_names)
 
             for guest_name, guest_mgmt in zip(guest_names, guest_mgmts):
-                # Only add vCMP Guests with BIG-IP that has been registered
+                # Only add vCMP Guests with BIG-IP® that has been registered
                 if guest_mgmt.address in self.driver.get_bigip_hosts():
                     vcmp_guest = {}
                     vcmp_guest['name'] = guest_name

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/vlan_binding.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/vlan_binding.py
@@ -43,8 +43,8 @@ class VLANBindingBase(object):
             LOG.debug('interface_port_static_mappings not configured')
 
     def register_bigip_interfaces(self):
-        # Delayed binding BIG-IP ports will be called
-        # after BIG-IP endpoints are registered.
+        # Delayed binding BIG-IP® ports will be called
+        # after BIG-IP® endpoints are registered.
         if not self.__initialized__bigip_ports:
             for bigip in self.driver.get_all_bigips():
 

--- a/test/test_listener.py
+++ b/test/test_listener.py
@@ -32,7 +32,7 @@ def test_create_listener():
         # create partition
         lb_service.prep_service(service, bigips)
 
-        # create BIG-IP virtual servers
+        # create BIG-IP® virtual servers
         listeners = service["listeners"]
         loadbalancer = service["loadbalancer"]
 

--- a/test/test_pool.py
+++ b/test/test_pool.py
@@ -32,7 +32,7 @@ def test_create_listener():
         # create partition
         lb_service.prep_service(service, bigips)
 
-        # create BIG-IP virtual servers
+        # create BIG-IP® virtual servers
         pools = service["pools"]
         loadbalancer = service["loadbalancer"]
 


### PR DESCRIPTION
@swormke 

#### What issues does this address?
Fixes #49 

#### What's this change do?
Brings the repo into compliance with F5 branding requirements. All references to F5, F5 Networks, BIG-IP, BIG-IQ, iControl, and iApps that are not objects or references to objects now have the appropriate trademark.

#### Where should the reviewer start?
Review the changes below. You can also view the docs locally:  clone my fork; pip install `sphinx` and `sphinx-autobuild`; cd docs, make html; view docs in browser.


#### Any background context?

