### PR TITLE
Refactor snats.py to use f5-sdk #42

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import os
 
 import constants_v2 as const
 import netaddr
@@ -316,3 +317,12 @@ class NetworkHelper(object):
                 mac_addresses.append(arp.macAddress)
                 arp.delete()
         return mac_addresses
+
+    def get_snatpool_member_use_count(self, bigip, member_name):
+        snat_count = 0
+        snatpools = bigip.ltm.snatpools.get_collection()
+        for snatpool in snatpools:
+            for member in snatpool.members:
+                if member_name == os.path.basename(member):
+                    snat_count += 1
+        return snat_count

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
@@ -135,6 +135,10 @@ class BigIPResourceHelper(object):
                 lambda bigip: bigip.ltm.monitor.tcps.tcp,
             ResourceType.ping_monitor:
                 lambda bigip: bigip.ltm.monitor.gateway_icmps.gateway_icmp,
-            ResourceType.node: lambda bigip: bigip.ltm.nodes.node
-
+            ResourceType.node: lambda bigip: bigip.ltm.nodes.node,
+            ResourceType.snat: lambda bigip: bigip.ltm.snats.snat,
+            ResourceType.snatpool:
+                lambda bigip: bigip.ltm.snatpools.snatpool,
+            ResourceType.snat_translation:
+                lambda bigip: bigip.ltm.snat_translations.snat_translation
         }[self.resource_type](bigip)


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
Fixes #42 

#### What's this change do?
Refactor snat.py to use the f5-sdk code.

#### Where should the reviewer start?
Look at the snat.py file and the additional network_helper

#### Any background context?
I put in comments where I made the changes to document what I thought the old code was doing according to my reading of the agent and common code.

Issues:
Fixes #42

Problem:
The snats.py library needs to be refactored to use the API instead
of the old common code.

Analysis:
* Created some new ResourceHelpers for snats, snatpools, and snat-translations
* Refactored code and added comments as to why I was doing the things I was doing

Tests:
* Flake8
* Meeting with team to determine how we test these changes befor we merge them.