### PR TITLE
Add source character encoding definition.

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent.py
@@ -1,4 +1,4 @@
-"""F5 Networks® LBaaSv2 agent implementation."""
+# coding=utf-8
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -1,4 +1,4 @@
-"""F5 Networks® LBaaSv2 agent manager implementation."""
+# coding=utf-8
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import datetime
 import hashlib
 import logging as std_logging

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # Copyright 2014-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l3_binding.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l3_binding.py
@@ -1,4 +1,4 @@
-"""Module for managing L3 to L2 port bindings on F5® BIG-IP® in Neutron."""
+# coding=utf-8
 # Copyright 2014 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # Copyright 2014-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # Copyright 2014-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/loadbalancer_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/loadbalancer_service.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # Copyright 2014-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # Copyright 2014-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # Copyright 2014-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # Copyright 2014-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/vcmp.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/vcmp.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # Copyright 2014-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/vlan_binding.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/vlan_binding.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 # Copyright 2014-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
@jputrino @richbrowne 
#### What issues does this address?

#### What's this change do?
Adds character encoding definition to top of files: # coding=utf-8

#### Where should the reviewer start?
Any file.

#### Any background context?
Previous change to add F5 trademarks included non-ASCII characters which causes imports to fail.
