### PR TITLE
Modify agent initialization file for v2

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,8 +3,8 @@
 * Milestone: Leave this field empty.
 * Assignee: If you're not fixing the issue, leave this field empty.
 * Attachments: For bugs, attach the agent log and configuration files
-  * /etc/neutron/f5-oslbaasv1-agent.ini
-  * /var/log/neutron/f5-oslbaasv1-agent.log
+  * /etc/neutron//services/f5/f5-openstack-agent.ini
+  * /var/log/neutron/f5-openstack-agent.log
 
 * Details: For enhancements, fill out the template below.
 
@@ -18,13 +18,13 @@
 * Details: For bugs, fill out the template below.
 
 #### Agent Version
-<Fill in the version you have installed, such as 1.0.12>
+<Fill in the version you have installed, such as 2.0.1>
 
 #### Operating System
-<Fill in the host OS of the machine running the agent, such as Ubuntu 14.04>
+<Fill in the host OS of the machine running the agent, such as Centos 7>
 
 #### OpenStack Release
-<Fill in the OpenStack release, such as Kilo>
+<Fill in the OpenStack release, such as Liberty>
 
 #### Description
 <Describe the bug in detail, steps taken prior to encountering the issue, yand a short explanation of you have deployed openstack and F5® agent>

--- a/etc/neutron/services/f5/f5-openstack-agent.ini
+++ b/etc/neutron/services/f5/f5-openstack-agent.ini
@@ -60,7 +60,7 @@ periodic_interval = 10
 #  Environment Settings
 ###############################################################################
 #
-# Since many TMOS object names must start with an alpha character
+# Since many TMOS® object names must start with an alpha character
 # the environment_prefix is used to prefix all service objects.
 #
 # environment_prefix = uuid
@@ -71,11 +71,11 @@ periodic_interval = 10
 # environments, or you can create your own customer environment drivers 
 # using the included python module as detailed below.
 #
-# WARNING: Service differentiated environments only work with separate TMOS
+# WARNING: Service differentiated environments only work with separate TMOS®
 # devices. Each environment has to point to a completely separate device service
-# cluster which share nothing. These can be hardware or VE TMOS devices. 
-# vCMP usage with VLAN based tenant networks, because vCMP does not virtualize
-# VLAN ids per TMOS instance, are not viable as distinct differentiated environments.
+# cluster which share nothing. These can be hardware or VE TMOS® devices.
+# vCMP® usage with VLAN based tenant networks, because vCMP® does not virtualize
+# VLAN ids per TMOS® instance, are not viable as distinct differentiated environments.
 #
 # If the neutron service plugin is using a service differentiated environment
 # specific plugin class, as illustrated above, you still need to set 
@@ -200,16 +200,16 @@ periodic_interval = 10
 #
 # The following metrics are implemented by the icontrol_driver.iControlDriver:
 #
-# throughput - total throughput in bps of the TMOS devices
-# inbound_throughput - throughput in bps inbound to TMOS devices
-# outbound_throughput - throughput in bps outbound from TMOS devices
-# active_connections - number of concurrent active actions on a TMOS device
-# tenant_count - number of tenants associated with a TMOS device
-# node_count - number of nodes provisioned on a TMOS device
-# route_domain_count - number of route domains on a TMOS device
-# vlan_count - number of VLANs on a TMOS device
-# tunnel_count - number of GRE and VxLAN overlay tunnels on a TMOS device
-# ssltps - the current measured SSL TPS count on a TMOS device
+# throughput - total throughput in bps of the TMOS® devices
+# inbound_throughput - throughput in bps inbound to TMOS® devices
+# outbound_throughput - throughput in bps outbound from TMOS® devices
+# active_connections - number of concurrent active actions on a TMOS® device
+# tenant_count - number of tenants associated with a TMOS® device
+# node_count - number of nodes provisioned on a TMOS® device
+# route_domain_count - number of route domains on a TMOS® device
+# vlan_count - number of VLANs on a TMOS® device
+# tunnel_count - number of GRE and VxLAN overlay tunnels on a TMOS® device
+# ssltps - the current measured SSL TPS count on a TMOS® device
 # clientssl_profile_count - the number of clientside SSL profiles defined
 #
 # You can specify one or multiple metrics.
@@ -607,11 +607,11 @@ f5_bigip_lbaas_device_driver = f5_openstack_agent.lbaasv2.drivers.bigip.icontrol
 #
 icontrol_hostname = 10.190.6.105
 #
-# If you are using VCMP with VLANs, you will need to configure
-# your vcmp host addresses, in addition to the guests addresses.
-# VCMP Host access is necessary for provisioning VLANs to a guest.
-# Use icontrol_hostname for VCMP guests and icontrol_vcmp_hostname
-# for VCMP hosts. The plug-in will automatically determine
+# If you are using vCMP® with VLANs, you will need to configure
+# your vCMP® host addresses, in addition to the guests addresses.
+# vCMP® Host access is necessary for provisioning VLANs to a guest.
+# Use icontrol_hostname for vCMP® guests and icontrol_vcmp_hostname
+# for vCMP® hosts. The plug-in will automatically determine
 # which host corresponds to each guest.
 #
 # icontrol_vcmp_hostname = 192.168.1.245

--- a/etc/neutron/services/f5/f5-openstack-agent.ini
+++ b/etc/neutron/services/f5/f5-openstack-agent.ini
@@ -305,7 +305,7 @@ f5_external_physical_mappings = default:1.1:True
 # vlan_binding_driver = f5.oslbaasv1agent.drivers.bigip.vlan_binding.NullBinding
 #
 # The interface_port_static_mappings allows for a JSON encoded dictionary
-# mapping BigIP devices and interfaces to corresponding ports. A port id can be
+# mapping BIG-IP® devices and interfaces to corresponding ports. A port id can be
 # any string which is meaningful to a vlan_binding_driver. It can be a 
 # switch_id and port, or it might be a neutron port_id.
 #
@@ -322,9 +322,9 @@ f5_external_physical_mappings = default:1.1:True
 #
 # interface_port_static_mappings = {"bigip1":{"1.1":"switch1:g2/32","1.2":"switch1:g2/33"},"bigip2":{"1.1":"switch1:g3/32","1.2":"switch1:g3/33"}}
 #
-# Device Tunneling (VTEP) selfips
+# Device Tunneling (VTEP) Self IPs
 #
-# This is the name of a selfip address to use for VTEP addresses.
+# This is the name of a BIG-IP® self IP address to use for VTEP addresses.
 #
 # If no gre or vxlan tunneling is required, these settings should be
 # commented out or set to None.
@@ -366,9 +366,9 @@ f5_vtep_selfip_name = 'vtep'
 #
 # f5_populate_static_arp = True
 #
-# Device Tunneling (VTEP) selfips
+# Device Tunneling (VTEP) self IPs
 #
-# This is a boolean entry which determines if they BIG-IP® will use
+# This is a boolean entry which determines if the BIG-IP® will use
 # L2 Population service to update its fdb tunnel entries. This needs
 # to be set up in accordance with the way the other tunnel agents are
 # set up.  If the BIG-IP® agent and other tunnel agents don't match
@@ -380,7 +380,7 @@ l2_population = True
 #  L3 Segmentation Mode Settings
 ###############################################################################
 #
-# Global Routing Mode - No L2 or L3 Segmentation on BIG-IP®
+# Global Routed Mode - No L2 or L3 Segmentation on BIG-IP®
 #
 # This setting will cause the agent to assume that all VIPs 
 # and pool members will be reachable via global device 
@@ -390,7 +390,7 @@ l2_population = True
 # adjacentcy to any neutron network, therefore no 
 # L2 segementation between tenant services in the data plane 
 # will be provisioned by the agent. Because the routing 
-# is global, no L3 SelfIPs or SNATs will be provisioned 
+# is global, no L3 self IPs or SNATs will be provisioned
 # by the agent on behalf of tenants either. You must have 
 # all necessary L3 routes (including TMM default routes) 
 # provisioned before LBaaS resources are provisioned for tenants. 
@@ -411,7 +411,7 @@ l2_population = True
 # WARNING: setting this mode to True will override the
 # f5_snat_addresses_per_subnet, setting it to 0 (zero).
 # This will force all VIPs to use AutoMap SNAT for which 
-# enough SelfIP will need to be pre-provisioned on the
+# enough Self IP will need to be pre-provisioned on the
 # BIG-IP® to handle all pool member connections. The SNAT,
 # an L3 mechanism, will all be global without reference
 # to any specific tenant SNAT pool.
@@ -476,14 +476,14 @@ f5_route_domain_strictness = False
 # This setting will force the use of SNATs. 
 #
 # If this is set to False, a SNAT will not
-# be created (routed mode) and the BigIP
-# will attempt to set up a floating SelfIP
+# be created (routed mode) and the BIG-IP®
+# will attempt to set up a floating self IP
 # as the subnet's default gateway address.
 # and a wild card IP forwarding virtual
 # server will be set up on member's network.
 # Setting this to False will mean Neutron
-# Floating Self IPs will not longer work 
-# if the same BigIP device is not being used
+# floating self IPs will not longer work
+# if the same BIG-IP® device is not being used
 # as the Neutron Router implementation.
 #
 # This setting will be forced to True if 
@@ -493,10 +493,10 @@ f5_snat_mode = True
 #
 # This setting will specify the number of snat 
 # addresses to put in a snat pool for each 
-# subnet associated with a created local Self IP. 
+# subnet associated with a created local self IP.
 # 
 # Setting to 0 (zero) will set VIPs to AutoMap 
-# SNAT and the device's local Self IP will 
+# SNAT and the device's local self IP will
 # be used to SNAT traffic.
 #
 # In scalen HA mode, this is the number of snat
@@ -602,7 +602,7 @@ f5_bigip_lbaas_device_driver = f5_openstack_agent.lbaasv2.drivers.bigip.icontrol
 # device group for the hostname specified must have 
 # their management IP address reachable to the agent.
 # If order to access devices' iControl® interfaces via
-# SelfIPs, you should specify them as a comma 
+# self IPs, you should specify them as a comma
 # separated list below. 
 #
 icontrol_hostname = 10.190.6.105

--- a/etc/neutron/services/f5/f5-openstack-agent.ini
+++ b/etc/neutron/services/f5/f5-openstack-agent.ini
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015 F5 Networks Inc.
+# Copyright 2015-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -232,14 +232,6 @@ periodic_interval = 10
 #  Device Setting
 ###############################################################################
 #
-# Device type for LBaaS: valid type are:
-#
-#   external - external  (hardware of VE)
-#   guest_admin - VE created under the admin tenant
-#   guest_tenant - VE created under the pool tenant
-#
-f5_device_type = external
-#
 # HA model
 #
 # Device can be required to be: 
@@ -332,8 +324,7 @@ f5_external_physical_mappings = default:1.1:True
 #
 # Device Tunneling (VTEP) selfips
 #
-# This is a single entry or comma separated list of cidr (h/m) format
-# selfip addresses, one per BIG-IP® device, to use for VTEP addresses.
+# This is the name of a selfip address to use for VTEP addresses.
 #
 # If no gre or vxlan tunneling is required, these settings should be
 # commented out or set to None.
@@ -379,8 +370,8 @@ f5_vtep_selfip_name = 'vtep'
 #
 # This is a boolean entry which determines if they BIG-IP® will use
 # L2 Population service to update its fdb tunnel entries. This needs
-# to be setup in accordance with the way the other tunnel agents are
-# setup.  If the BIG-IP® agent and other tunnel agents don't match
+# to be set up in accordance with the way the other tunnel agents are
+# set up.  If the BIG-IP® agent and other tunnel agents don't match
 # the tunnel setup will not work properly.
 #
 l2_population = True
@@ -414,7 +405,7 @@ l2_population = True
 # the f5_snat_mode, setting it to True, because pool members
 # will never be considered L2 adjacent to the BIG-IP® by
 # the agent. All member access will be via L3 routing, which
-# will need to be setup on the BIG-IP® before LBaaS provisions
+# will need to be set up on the BIG-IP® before LBaaS provisions
 # resources on behalf of tenants.
 #
 # WARNING: setting this mode to True will override the
@@ -425,7 +416,7 @@ l2_population = True
 # an L3 mechanism, will all be global without reference
 # to any specific tenant SNAT pool.
 #
-# WARNIG: setting this mode will make the VIPs listen
+# WARNING: setting this mode will make the VIPs listen
 # on all provisioned L2 segments (All VLANs). This is 
 # because no L2 information will be taken from 
 # neutron, thus making the assumption that all VIP
@@ -486,10 +477,10 @@ f5_route_domain_strictness = False
 #
 # If this is set to False, a SNAT will not
 # be created (routed mode) and the BigIP
-# will attempt to setup a floating SelfIP
+# will attempt to set up a floating SelfIP
 # as the subnet's default gateway address.
 # and a wild card IP forwarding virtual
-# server will be setup on member's network. 
+# server will be set up on member's network.
 # Setting this to False will mean Neutron
 # Floating Self IPs will not longer work 
 # if the same BigIP device is not being used
@@ -609,7 +600,7 @@ f5_bigip_lbaas_device_driver = f5_openstack_agent.lbaasv2.drivers.bigip.icontrol
 # If a single IP address is used and the HA model 
 # is not standalone, all devices in the sync failover
 # device group for the hostname specified must have 
-# there management IP address reachable to the agent.
+# their management IP address reachable to the agent.
 # If order to access devices' iControl® interfaces via
 # SelfIPs, you should specify them as a comma 
 # separated list below. 
@@ -634,50 +625,3 @@ icontrol_username = admin
 # on all devices in a device sync failover group.
 #
 icontrol_password = admin
-#
-icontrol_connection_retry_interval = 10
-#
-icontrol_connection_timeout = 10
-#
-###############################################################################
-#  Experimental Features
-###############################################################################
-#
-# iApp® Support
-#
-# LBaaS objects can can be provisioned in different modes:
-#
-# icontrol_config_mode = objects - means iControl® for all objects
-# icontrol_config_mode = iapp - means iApp®s to BIG-IP® or BIG-IQ® for service objects
-#
-# Default is object mode. iapp mode is experimental in version 1.0.8 
-#
-# icontrol_config_mode = [ iapp | objects ]
-#
-icontrol_config_mode = objects
-#
-############################################################################### 
-# 
-# BIG-IQ® Single Tenant Support
-#
-# If bigiq hostname and password for the admin user are provided
-# bigiq will be queried for single Tenant BIG-IP®s which will can
-# then be used to provide LBaaS
-#
-# bigiq_hostname = bigiphostname
-# bigiq_admin_password = admin
-#
-# These are the default credentials used by BIG-IQ® to manage BIG-IP®s
-#
-# bigip_management_username = admin
-# bigip_management_password = admin
-#
-# These openstack credentials are used when BIG-IQ® is configured
-# in order to determine whether the tenant has a BIG-IP® that
-# the BIG-IQ® can discover.
-#
-# openstack_keystone_uri = http://[keystoneserver]:5000/v2.0
-# openstack_admin_username = admin
-# openstack_admin_password = adminpassword
-#
-#

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
@@ -134,6 +134,7 @@ class ListenerServiceBuilder(object):
         for bigip in bigips:
             try:
                 self.vs_helper.update(bigip, vip)
+
             except HTTPError as err:
                 LOG.error(
                     "Error updating virtual server for listener %s "
@@ -142,3 +143,195 @@ class ListenerServiceBuilder(object):
                                       bigip.device_name,
                                       err.response.status_code,
                                       err.message))
+
+    def update_listener_pool(self, service, name, bigips):
+        """Update virtual server's default pool attribute.
+
+        Sets the virutal server's pool attribute to the name of the
+        pool (or empty when deleting pool). For LBaaS, this should be
+        call when the pool is created.
+
+        :param service: Dictionary which contains a listener, pool,
+        and load balancer definition.
+        :param name: Name of pool (empty string to unset).
+        :param bigips: Array of BigIP class instances to update.
+        """
+        vip = self.service_adapter.get_virtual_name(service)
+        vip["pool"] = name
+        for bigip in bigips:
+            v = bigip.ltm.virtuals.virtual
+            if v.exists(name=vip["name"], partition=vip["partition"]):
+                v.load(name=vip["name"], partition=vip["partition"])
+                v.update(**vip)
+
+    def update_session_persistence(self, service, bigips):
+        """Update session persistence for virtual server.
+
+        Handles setting persistence type and creating associated
+        profiles if necessary. This should be called when the pool
+        is created because LBaaS pools define persistence types, not
+        listener objects.
+
+        :param service: Dictionary which contains a listener, pool,
+        and load balancer definition.
+        :param bigips: Array of BigIP class instances to update.
+        """
+        pool = service["pool"]
+        if "session_persistence" in pool:
+            vip = self.service_adapter.get_virtual_name(service)
+            persistence = pool['session_persistence']
+            persistence_type = persistence['type']
+            vip_persist = self.service_adapter.get_session_persistence(service)
+            for bigip in bigips:
+                if persistence_type == 'HTTP_COOKIE':
+                    self._add_profile(vip, 'http', bigip)
+                elif persistence_type == 'APP_COOKIE':
+                    self._add_profile(vip, 'http', bigip)
+                    if 'cookie_name' in persistence:
+                        self._add_cookie_persist_rule(vip, persistence, bigip)
+
+                # profiles must be added before setting profile attribute
+                self.vs_helper.update(bigip, vip_persist)
+                LOG.debug("Set persist %s" % vip["name"])
+
+    def _add_profile(self, vip, profile_name, bigip):
+        """Adds profile to virtual server instance. Assumes Common.
+
+        :param vip: Dictionary which contains name and partition of
+        virtual server.
+        :param profile_name: Name of profile to add.
+        :param bigip: Single BigIP instances to update.
+        """
+        v = bigip.ltm.virtuals.virtual
+        v.load(name=vip["name"], partition=vip["partition"])
+        p = v.profiles_s
+        profiles = p.get_collection()
+
+        # see if profile exists
+        for profile in profiles:
+            if profile.name == profile_name:
+                return
+
+        # not found -- add profile (assumes Common partition)
+        p.profiles.create(name=profile_name, context='all')
+        LOG.debug("Created profile %s" % profile_name)
+
+    def _add_cookie_persist_rule(self, vip, persistence, bigip):
+        """Adds cookie persist rules to virtual server instance.
+
+        :param vip: Dictionary which contains name and partition of
+        virtual server.
+        :param persistence: Persistence definition.
+        :param bigip: Single BigIP instances to update.
+        """
+        cookie_name = persistence['cookie_name']
+        rule_def = self._create_app_cookie_persist_rule(cookie_name)
+        rule_name = 'app_cookie_' + vip['name']
+
+        r = bigip.ltm.rules.rule
+        if not r.exists(name=rule_name, partition=vip["partition"]):
+            r.create(name=rule_name,
+                     apiAnonymous=rule_def,
+                     partition=vip["partition"])
+            LOG.debug("Created rule %s" % rule_name)
+
+        u = bigip.ltm.persistences.universals.universal
+        if not u.exists(name=rule_name, partition=vip["partition"]):
+            u.create(name=rule_name,
+                     rule=rule_name,
+                     partition=vip["partition"])
+            LOG.debug("Created persistence universal %s" % rule_name)
+
+    def _create_app_cookie_persist_rule(self, cookiename):
+        """Creates cookie persistence rule.
+
+        :param cookiename: Name to substitute in rule.
+        """
+        rule_text = "when HTTP_REQUEST {\n"
+        rule_text += " if { [HTTP::cookie " + str(cookiename)
+        rule_text += "] ne \"\" }{\n"
+        rule_text += "     persist uie [string tolower [HTTP::cookie \""
+        rule_text += cookiename + "\"]] 3600\n"
+        rule_text += " }\n"
+        rule_text += "}\n\n"
+        rule_text += "when HTTP_RESPONSE {\n"
+        rule_text += " if { [HTTP::cookie \"" + str(cookiename)
+        rule_text += "\"] ne \"\" }{\n"
+        rule_text += "     persist add uie [string tolower [HTTP::cookie \""
+        rule_text += cookiename + "\"]] 3600\n"
+        rule_text += " }\n"
+        rule_text += "}\n\n"
+        return rule_text
+
+    def remove_session_persistence(self, service, bigips):
+        """Resest persistence for virtual server instance.
+
+        Clears persistence and deletes profiles.
+
+        :param service: Dictionary which contains a listener, pool
+        and load balancer definition.
+        :param bigips: Single BigIP instances to update.
+        """
+        pool = service["pool"]
+        if "session_persistence" in pool:
+            vip = self.service_adapter.get_virtual_name(service)
+            vip["persist"] = []
+            vip["fallbackPersistence"] = ""
+            persistence = pool['session_persistence']
+            persistence_type = persistence['type']
+
+            for bigip in bigips:
+                # remove persistence
+                self.vs_helper.update(bigip, vip)
+                LOG.debug("Cleared session persistence for %s" % vip["name"])
+
+                # remove profiles and rules
+                if persistence_type == 'HTTP_COOKIE':
+                    self._remove_profile(vip, 'http', bigip)
+                elif persistence_type == 'APP_COOKIE':
+                    self._remove_profile(vip, 'http', bigip)
+                    if 'cookie_name' in persistence:
+                        self._remove_cookie_persist_rule(
+                            vip, bigip)
+
+    def _remove_profile(self, vip, profile_name, bigip):
+        """Deletes profile.
+
+        :param vip: Dictionary which contains name and partition of
+        virtual server.
+        :param profile_name: Name of profile to delete.
+        :param bigip: Single BigIP instances to update.
+        """
+        v = bigip.ltm.virtuals.virtual
+        v.load(name=vip["name"], partition=vip["partition"])
+        p = v.profiles_s
+        profiles = p.get_collection()
+
+        # see if profile exists
+        for profile in profiles:
+            if profile.name == profile_name:
+                pr = p.profiles.load(name=profile_name)
+                pr.delete()
+                LOG.debug("Deleted profile %s" % profile)
+                return
+
+    def _remove_cookie_persist_rule(self, vip, bigip):
+        """Deletes cookie persist rule.
+
+        :param vip: Dictionary which contains name and partition of
+        virtual server.
+        :param bigips: Single BigIP instances to update.
+        """
+        rule_name = 'app_cookie_' + vip['name']
+
+        u = bigip.ltm.persistences.universals.universal
+        if u.exists(name=rule_name, partition=vip["partition"]):
+            u.load(name=rule_name, partition=vip["partition"])
+            u.delete()
+            LOG.debug("Deleted persistence universal %s" % rule_name)
+
+        r = bigip.ltm.rules.rule
+        if r.exists(name=rule_name, partition=vip["partition"]):
+            r.load(name=rule_name, partition=vip["partition"])
+            r.delete()
+            LOG.debug("Deleted rule %s" % rule_name)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
@@ -49,7 +49,7 @@ class PoolServiceBuilder(object):
 
         :param service: Dictionary which contains a both a pool
         and load balancer definition.
-        :param bigips: Array of BigIP class instances to create Listener.
+        :param bigips: Array of BigIP class instances to create pool.
         """
         pool = self.service_adapter.get_pool(service)
         for bigip in bigips:
@@ -92,7 +92,7 @@ class PoolServiceBuilder(object):
 
         :param service: Dictionary which contains a both a pool
         and load balancer definition.
-        :param bigips: Array of BigIP class instances to create Listener.
+        :param bigips: Array of BigIP class instances to create pool.
         """
         pool = self.service_adapter.get_pool(service)
         for bigip in bigips:
@@ -110,10 +110,15 @@ class PoolServiceBuilder(object):
         # create member
         hm = self.service_adapter.get_healthmonitor(service)
         hm_helper = self._get_monitor_helper(service)
+        pool = self.service_adapter.get_pool(service)
 
         for bigip in bigips:
             try:
                 hm_helper.create(bigip, hm)
+
+                # update pool with new health monitor
+                self.pool_helper.update(bigip, pool)
+
             except HTTPError as err:
                 LOG.error("Error creating health monitor %s on BIG-IP %s. "
                           "Repsponse status code: %s. Response "
@@ -121,11 +126,6 @@ class PoolServiceBuilder(object):
                                             bigip.device_name,
                                             err.response.status_code,
                                             err.message))
-
-        # update pool with new health monitor
-        pool = self.service_adapter.get_pool(service)
-        for bigip in bigips:
-            self.pool_helper.update(bigip, pool)
 
     def delete_healthmonitor(self, service, bigips):
         # delete health monitor


### PR DESCRIPTION
@richbrowne @mattgreene @jputrino 
#### What issues does this address?
Fixes #70

#### What's this change do?
Removes unused agent ini options.

#### Any background context?
LBaaS v1 code allowed using iApps and BIG-IQ for configuring BIG-IPs, but
LBaaS v2 does not.

Issues:
Fixes #70

Problem: Agent ini file contains options that are not used in LBaaS v2.

Analysis: Removed unused options (BIG-IQ, etc.). Fixed some spelling
errors.

Tests: