### PR TITLE
Add backup support

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/cluster_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/cluster_manager.py
@@ -14,6 +14,8 @@
 #
 
 from oslo_log import log as logging
+from requests.exceptions import HTTPError
+
 import time
 
 from f5_openstack_agent.lbaasv2.drivers.bigip import constants_v2 as const
@@ -58,8 +60,14 @@ class ClusterManager(object):
         return traffic_groups
 
     def save_config(self, bigip):
-        # not used?
-        pass
+        try:
+            c = bigip.sys.config
+            c.save()
+        except HTTPError as err:
+            LOG.error("Error saving config."
+                      "Repsponse status code: %s. Response "
+                      "message: %s." % (err.response.status_code,
+                                        err.message))
 
     def get_device_group(self, bigip):
         dgs = bigip.cm.device_groups.get_collection()


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
Fixes #76 

#### What's this change do?
Implements save_config() used for backup.

#### Where should the reviewer start?
Review save_config.

#### Any background context?
The icontrol_driver support is in place, but agent_manager and the driver
side need to add support to call icontrol_driver.backup_configuration()
Issues:
Fixes #76

Problem: Add support for saving configurations.

Analysis: Completed implementation of save_config in cluster_manager
using new f5-sdk method.

Tests: