### PR TITLE
Make some service translation fixups

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -284,6 +284,8 @@ class iControlDriver(LBaaSBaseDriver):
                 self.conf.common_network_ids
             LOG.debug('Setting static ARP population to %s'
                       % self.conf.f5_populate_static_arp)
+            self.agent_configurations['f5_common_external_networks'] = \
+                self.conf.f5_common_external_networks
             f5const.FDB_POPULATE_STATIC_ARP = self.conf.f5_populate_static_arp
 
         self._init_bigip_hostnames()

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -892,7 +892,7 @@ class iControlDriver(LBaaSBaseDriver):
             service = self.plugin_rpc.get_service_by_loadbalancer_id(
                 service['loadbalancer']['id']
             )
-        if service['pool']:
+        if service['loadbalancer']:
             self._common_service_handler(service)
         else:
             LOG.debug("Attempted sync of deleted pool")

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
@@ -177,7 +177,7 @@ class ListenerServiceBuilder(object):
         :param bigips: Array of BigIP class instances to update.
         """
         pool = service["pool"]
-        if "session_persistence" in pool:
+        if "session_persistence" in pool and pool['session_persistence']:
             vip = self.service_adapter.get_virtual_name(service)
             persistence = pool['session_persistence']
             persistence_type = persistence['type']

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
@@ -19,6 +19,8 @@ from oslo_log import log as logging
 import oslo_messaging as messaging
 
 from neutron.common import rpc
+from neutron.plugins.common import constants as plugin_const
+from neutron_lbaas.services.loadbalancer import constants as lb_const
 
 from f5_openstack_agent.lbaasv2.drivers.bigip import constants_v2 as constants
 
@@ -89,8 +91,8 @@ class LBaaSv2PluginRPC(object):
     @log_helpers.log_method_call
     def update_loadbalancer_status(self,
                                    lb_id,
-                                   provisioning_status,
-                                   operating_status):
+                                   provisioning_status=plugin_const.ERROR,
+                                   operating_status=lb_const.OFFLINE):
         """Update the database with loadbalancer status."""
         return self._cast(
             self.context,


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
Fixes #81 #82 #84 #85 


#### What's this change do?
We were seeing errors in the logs around synchronizing a 'pending' service, and a usage of a None type
object on pool creation.  This change fixes those.

Adding some error handling around the prep_service_networking()

Adding flag to agent configuration for instructions on how to interpret "router:external" for network

#### Where should the reviewer start?

#### Any background context?
