### PR TITLE
F5 agent running prevents creation of HA Proxy loadbalancers

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -249,6 +249,7 @@ class iControlDriver(LBaaSBaseDriver):
         self.plugin_rpc = None
         self.__last_connect_attempt = None
         self.connected = False
+        self.driver_name = 'f5-lbaasv2-icontrol'
 
         # BIG-IP® containers
         self.__bigips = {}
@@ -288,6 +289,7 @@ class iControlDriver(LBaaSBaseDriver):
                 self.conf.f5_common_external_networks
             f5const.FDB_POPULATE_STATIC_ARP = self.conf.f5_populate_static_arp
 
+        self.agent_configurations['device_drivers'] = [self.driver_name]
         self._init_bigip_hostnames()
         self._init_bigip_managers()
         self.connect_bigips()


### PR DESCRIPTION
@mattgreene @jlongstaf 
Fixes #88

...


Fixes #88

Problem:
When the haproxy lbaas service is invoked the first thing that
will happen is to find an agent to perform the action. It queries the
database for all active agents of type AGENT_TYPE_LOADBALANCERV2.
The result will be all active loadbalancers, including the f5 loadbalancer.
In the code printed above, it then queries every active agent to see if
the device driver reported in the config matches the one passed in to the
method. The F5 LBaaS driver does not define this key in the agent config
and so the exception results when the F5 LBaaS agent is processed.

This happens when both the LBaaSv2 f5 driver is running in conjunction
with another LBaaSv2 driver that uses the ChanceScheduler.

Analysis:
Add the device_driver attribute to the agent_configuration.

Tests:
Ran manual tests.