### PR TITLE
Exception: icontrol_driver: instance names and partitions cannot cont…

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
@@ -155,7 +155,6 @@ class BigipSelfIpManager(object):
 
         if self.l2_service.is_common_network(network):
             network_folder = 'Common'
-            network_name = '/Common/' + network_name
         else:
             network_folder = self.driver.service_adapter.\
                 get_folder_name(subnet['tenant_id'])

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
@@ -220,7 +220,7 @@ class BigipSnatManager(object):
 
     def _delete_bigip_snats(self, bigip, subnetinfo, tenant_id):
         # Assure snats deleted in standalone mode """
-        network = subnetinfo['network']
+        # Assure snats deleted in standalone mode """
         subnet = subnetinfo['subnet']
         partition = self.driver.service_adapter.get_folder_name(tenant_id)
         deleted_names = set()

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
@@ -128,8 +128,6 @@ class BigipSnatManager(object):
             ip_address = snat_info['addrs'][i] + \
                 '%' + str(network['route_domain_id'])
             index_snat_name = snat_name + "_" + str(i)
-            if self.l2_service.is_common_network(network):
-                index_snat_name = '/Common/' + index_snat_name
 
             snat_traffic_group = self._get_snat_traffic_group(tenant_id)
             # snat.create() did  the following in LBaaSv1
@@ -231,10 +229,7 @@ class BigipSnatManager(object):
         snat_name = self._get_snat_name(subnet, tenant_id)
         for i in range(self.driver.conf.f5_snat_addresses_per_subnet):
             index_snat_name = snat_name + "_" + str(i)
-            if self.l2_service.is_common_network(network):
-                tmos_snat_name = '/Common/' + index_snat_name
-            else:
-                tmos_snat_name = index_snat_name
+            tmos_snat_name = index_snat_name
 
             if self.l3_binding:
                 try:


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
Fixes #91 

#### What's this change do?
Removes prepending '/Common/' to SNAT names.

#### Any background context?
Found by Johnny Schmidt when testing common external networks.

Issues:
Fixes #91

Problem:
SNAT names created in common partition incorrectly have '/Common/' preprended
to name, causing invalid name exception.

Analysis: This is an artifact from v1 code and does not apply to
v2 code using the f5-sdk. Removed code to prepend Common.

Tests: