### PR TITLE
Error creating snatpool

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
@@ -157,7 +157,7 @@ class BigipSnatManager(object):
                     partition=snat_info['network_folder'])
 
             model = {
-                "name": index_snat_name,
+                "name": snat_info['pool_name'],
                 "partition": snat_info['pool_folder'],
             }
             model["members"] = ['/' + model["partition"] + '/' +


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
Fixes #97

#### What's this change do?
Changes the snatpool name used to create a snatpool.

#### Where should the reviewer start?
Probably best to compare this code with the v1 code. To do so, look at snats.py in the agent (https://github.com/F5Networks/f5-openstack-lbaasv1/blob/master/agent/f5/oslbaasv1agent/drivers/bigip/snats.py) and snat.py in the bigip interfaces directory (https://github.com/F5Networks/f5-openstack-lbaasv1/blob/master/common/f5/bigip/interfaces/snat.py).

#### Any background context?
NOTE: previous v2 code had the correct snat pool name BUT the incorrect member path. The code was inadvertently changed to use the wrong snat pool name but the correct member path. This change should have the correct snat pool name and leave member path as is. To be sure, check this change against the v1 files listed above. 

Issues:
Fixes #97

Problem: Creating a snat pool genereates an exception from BIG-IP REST
interface.

Analysis: An incorrect snat pool name is used when creating the snat pool
The name should be the snat pool name as defined in snat_info['pool_name'].
Changed the create to use this instead of index_snat_name.

Tests: