### PR TITLE
Error creating snatpool

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
@@ -220,9 +220,13 @@ class BigipSnatManager(object):
 
     def _delete_bigip_snats(self, bigip, subnetinfo, tenant_id):
         # Assure snats deleted in standalone mode """
-        # Assure snats deleted in standalone mode """
         subnet = subnetinfo['subnet']
-        partition = self.driver.service_adapter.get_folder_name(tenant_id)
+        network = subnetinfo['network']
+        if self.l2_service.is_common_network(network):
+            partition = 'Common'
+        else:
+            partition = self.driver.service_adapter.get_folder_name(tenant_id)
+        snat_pool_name = self.driver.service_adapter.get_folder_name(tenant_id)
         deleted_names = set()
         in_use_subnets = set()
         # Delete SNATs on traffic-group-local-only
@@ -251,7 +255,7 @@ class BigipSnatManager(object):
             LOG.debug('Remove translation address from tenant SNAT pool')
             try:
                 snatpool = self.snatpool_manager.load(bigip,
-                                                      index_snat_name,
+                                                      snat_pool_name,
                                                       partition)
 
                 snatpool.members = [


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
Fixes #97

#### What's this change do?
Modifies delete snatpool function to use correct snatpool name and parition.

#### Any background context?
Snatpool create was updated to use correct name, and this change adds the
same logic to deleting snatpools

Issues:
Fixes #97

Problem: Deleting snat pool throws exception.

Analysis: SNAT pool name is incorect for delete functions.
Corrected to use tenant ID and correct partition name.

Tests: Manual