### PR TITLE
Default pool not set on virtual server when creating pool without nam…

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -127,8 +127,10 @@ class LBaaSBuilder(object):
                     self.pool_builder.create_pool(svc, bigips)
 
                     # assign pool name to virtual
+                    pool_name = self.service_adapter.init_pool_name(
+                        loadbalancer, pool)
                     self.listener_builder.update_listener_pool(
-                        svc, pool["name"], bigips)
+                        svc, pool_name["name"], bigips)
 
                     # update virtual sever pool name, session persistence
                     self.listener_builder.update_session_persistence(


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
Fixes #104

Problem: The agent sets the default pool attribute of a BIG-IP virtual
server when an LBaaS pool is created. If the lbaas command used to create
does not include the optional --name parameter, the virtual server pool
attribute is set to an empty string.

Analysis: Modified the agent to define a valid value for the pool name. If
the name parameter is included in the command, that name is used. If the
name parameter is not used, the agent constructs the name using the tenant
ID and prefix.

Tests: Command scripts, test_balancer_updates_scans.py