### PR TITLE
Fix system V init script to reuturn correct status.

### DIFF
--- a/etc/init.d/f5-oslbaasv2-agent
+++ b/etc/init.d/f5-oslbaasv2-agent
@@ -94,7 +94,16 @@ force_reload() {
 }
 
 rh_status() {
-    status $SERVICE
+    if [ ! -f $PIDFILE ]; then
+	return 3
+    fi
+
+    pid=$(cat $PIDFILE)
+    if ! ps --no-headers p "$pid" | grep ${NAME} > /dev/null; then
+	return 1
+    fi
+
+    return 0
 }
 
 rh_status_q() {

--- a/etc/neutron/services/f5/f5-openstack-agent.ini
+++ b/etc/neutron/services/f5/f5-openstack-agent.ini
@@ -425,8 +425,7 @@ f5_common_external_networks = True
 # for all mapped fixed_ips will be made referencing the ports id
 # and the ports device_id.
 #
-# l3_binding_static_mappings = 'subnet_a':[('port_a','device_a'),('port_b','device_b')], 'subnet_b':[('port_c','device_a'),('port_d','device_b')]
-#
+# l3_binding_static_mappings = {"subnet_b": [["port_c", "device_a"], ["port_d", "device_b"]], "subnet_a": [["port_a", "device_a"], ["port_b", "device_b"]]}
 #
 #
 ###############################################################################
@@ -454,7 +453,7 @@ f5_bigip_lbaas_device_driver = f5_openstack_agent.lbaasv2.drivers.bigip.icontrol
 # self IPs, you should specify them as a comma
 # separated list below. 
 #
-icontrol_hostname = 10.190.7.232
+icontrol_hostname = 10.190.7.116
 #
 # If you are using vCMP® with VLANs, you will need to configure
 # your vCMP® host addresses, in addition to the guests addresses.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/exceptions.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/exceptions.py
@@ -74,6 +74,10 @@ class StaticARPDeleteException(Exception):
     pass
 
 
+class L3BindingInitializationException(Exception):
+    pass
+
+
 class ClusterCreationException(Exception):
     pass
 


### PR DESCRIPTION
@jlongstaf @mattgreene 
#### What issues does this address?
Fixes #106 
...

#### What's this change do?
Fixes service status for agent daemon

#### Where should the reviewer start?
f5-oslbaasv2-init

#### Any background context?

Issues:
Fixes #106

Problem:
The initialization script does not return status for the
agent daemon.

Analysis:
Fix logic to find agent daemon in ps output.

Test:
Run service f5-oslbaasv2-agent status.