### PR TITLE
Fix system V init script to return correct status.

### DIFF
--- a/etc/init.d/f5-oslbaasv2-agent
+++ b/etc/init.d/f5-oslbaasv2-agent
@@ -94,7 +94,16 @@ force_reload() {
 }
 
 rh_status() {
-    status $SERVICE
+    if [ ! -f $PIDFILE ]; then
+	return 3
+    fi
+
+    pid=$(cat $PIDFILE)
+    if ! ps --no-headers p "$pid" | grep ${NAME} > /dev/null; then
+	return 1
+    fi
+
+    return 0
 }
 
 rh_status_q() {


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
Fixes #106 


#### What's this change do?
Modifies the system V init script f5-oslbaasv2-agent to return a numerical status for:
service f5-oslbaasv2-agent status

#### Where should the reviewer start?
etc/init.d/f5-oslbaasv2-agent

#### Any background context?

Issues:
Fixes #106

Problem:
The initialization script does not return status for the
agent daemon.

Analysis:
Fix logic to find agent daemon in ps output.

Test:
Run service f5-oslbaasv2-agent status.