### PR TITLE
RTD build broken because Sphinx version needs to be >=1.4 

### DIFF
--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,3 +1,3 @@
-Sphinx
+Sphinx>=1.4
 sphinx_rtd_theme
 six>=1.10.0


### PR DESCRIPTION
@jlongstaf 

#### What issues does this address?
Fixes #119 

#### What's this change do?
- changes requirements.docs.txt to require at least v1.4 of Sphinx

#### Where should the reviewer start?
see change below

#### Any background context?
I'm using the sphinx [auto-section label extension](http://www.sphinx-doc.org/en/latest/ext/autosectionlabel.html) to automatically create section headers. These section headers are used for cross-referencing across our doc sets via intersphinx mapping.