### PR TITLE
Replace tmp file cert/key upload with memory buffer upload.

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/barbican_cert.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/barbican_cert.py
@@ -30,6 +30,7 @@ class InvalidBarbicanConfig(Exception):
 
 
 class BarbicanCertManager(cert_manager.CertManagerBase):
+    """Concrete class for retrieving certs/keys from Barbican service."""
 
     def __init__(self, conf):
         super(BarbicanCertManager, self).__init__()
@@ -82,13 +83,38 @@ class BarbicanCertManager(cert_manager.CertManagerBase):
                       "%s and project-id %s." % (endpoint, project_id))
 
     def get_certificate(self, container_ref):
+        """Retrieves certificate from certificate manager.
+
+        :param string ref: Reference to certificate stored in a certificate
+        manager.
+        :returns string: Certificate data.
+        """
         container = self.barbican.containers.get(container_ref)
         return container.certificate.payload
 
     def get_private_key(self, container_ref):
+        """Retrieves key from certificate manager.
+
+        :param string ref: Reference to key stored in a certificate manager.
+        :returns string: Key data.
+        """
         container = self.barbican.containers.get(container_ref)
         return container.private_key.payload
 
-    def get_name(self, container_ref):
-        container = self.barbican.containers.get(container_ref)
-        return container.name
+    def get_name(self, container_ref, prefix):
+        """Returns a name that uniquely identifies cert/key pair.
+
+        Barbican conatainers have a name attribute, but there is
+        no guarantee that the name is unique. Instead of using the
+        container name, create a unique name by parsing UUID from
+        container_ref and prepending prefix.
+
+        :param string ref: Reference to certificate/key container stored in a
+        certificate manager.
+        :param string prefix: The environment prefix. Can be optionally
+        used to
+        :returns string: Name. Unique name with prefix.
+        """
+
+        i = container_ref.rindex("/") + 1
+        return prefix + container_ref[i:]

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/cert_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/cert_manager.py
@@ -15,13 +15,32 @@
 
 
 class CertManagerBase(object):
-    """Base class for certificate/key manager"""
+    """Base class for custom implementations to get certs/keys."""
 
     def get_certificate(self, ref):
-        pass
+        """Retrieves certificate from certificate manager.
+
+        :param string ref: Reference to certificate stored in a certificate
+        manager.
+        :returns string: Certificate data.
+        """
+        raise NotImplementedError()
 
     def get_private_key(self, ref):
-        pass
+        """Retrieves key from certificate manager.
 
-    def get_name(self, ref):
-        pass
+        :param string ref: Reference to key stored in a certificate manager.
+        :returns string: Key data.
+        """
+        raise NotImplementedError()
+
+    def get_name(self, ref, prefix):
+        """Returns a name that uniquely identifies cert/key pair.
+
+        :param string ref: Reference to certificate/key container stored in a
+        certificate manager.
+        :param string prefix: The environment prefix. Can be optionally
+        used to add name.
+        :returns string: Unique name for cert/key pair.
+        """
+        raise NotImplementedError()

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/ssl_profile.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/ssl_profile.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import os
 from oslo_log import log as logging
 
 LOG = logging.getLogger(__name__)
@@ -48,14 +49,14 @@ class SSLProfileHelper(object):
             # import certificate
             param_set = {}
             param_set['name'] = certfilename
-            param_set['from-local-file'] = \
-                '/var/config/rest/downloads/' + certfilename
+            param_set['from-local-file'] = os.path.join(
+                '/var/config/rest/downloads/', certfilename)
             cert_registrar.exec_cmd('install', **param_set)
 
             # import key
             param_set['name'] = keyfilename
-            param_set['from-local-file'] = \
-                '/var/config/rest/downloads/' + keyfilename
+            param_set['from-local-file'] = os.path.join(
+                '/var/config/rest/downloads/', keyfilename)
             key_registrar.exec_cmd('install', **param_set)
 
             # create ssl-client profile from cert/key pair


### PR DESCRIPTION
@<reviewer_id>
#### What issues does this address?
Fixes #127 

#### What's this change do?

#### Where should the reviewer start?
ssl_profile.py

#### Any background context?
New method to pass in bytes instead of file name was added to f5-sdk. Replaced
creating tmp file with byte method to keep it in-memory.

Issues:
Fixes #127

Problem: Replace creating a tmp file for cert/key upload with
string buffer.

Analysis: Used new interface in f5-sdk to keep cert/key data
in memory.

Tests: ssl_profile test.