### PR TITLE
Agent fails to start with f5_ha_type not set to standalone

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -541,7 +541,7 @@ class iControlDriver(LBaaSBaseDriver):
         if self.conf.f5_ha_type == 'scalen' and \
                 self.cluster_manager.get_sync_status(bigip) == 'Standalone':
             raise f5ex.BigIPClusterInvalidHA(
-                'HA mode is pair and bigip %s in standalone mode'
+                'HA mode is scalen and bigip %s in standalone mode'
                 % hostname)
 
         if self.conf.f5_ha_type != 'standalone':
@@ -578,10 +578,10 @@ class iControlDriver(LBaaSBaseDriver):
 
         if self.conf.f5_ha_type != 'standalone':
             if self.conf.f5_sync_mode == 'autosync':
-                self.cluster_manager.enable_auto_sync(bigip, device_group_name)
+                self.cluster_manager.enable_auto_sync(device_group_name, bigip)
             else:
-                self.cluster_manager.disable_auto_sync(bigip,
-                                                       device_group_name)
+                self.cluster_manager.disable_auto_sync(device_group_name,
+                                                       bigip)
 
         # Turn off tunnel syncing... our VTEPs are local SelfIPs
         if self.system_helper.get_tunnel_sync(bigip) == 'enable':


### PR DESCRIPTION
@mattgreene 
#### What issues does this address?
Fixes #130

#### What's this change do?
Two things:
  1) fixes passing positional arguments to enable/disable_auto_sync()
in the correct order, and
  2) fixes an incorrect exeption message.
#### Where should the reviewer start?
  Compare enable/disable_auto_sync change with method signature defined in cluster_manager.py.

#### Any background context?
No.

Issues:
Fixes #130

Problem: Agent fails to start when f5_ha_type is set to pair
or scalen (not standalone).

Analysis: When f5_ha_type is not standalone, the agent either
enables or disables auto sync. icontrol driver code was passing
positional arguments to cluster_manager.enable_auto_sync in
wrong order. Fixed to pass arguments in correct order.

Tests: Manual