### PR TITLE
Refactor/cleanup selfips

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/exceptions.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/exceptions.py
@@ -14,321 +14,325 @@
 #
 
 
-class MinorVersionValidateFailed(Exception):
+class F5AgentException(Exception):
     pass
 
 
-class MajorVersionValidateFailed(Exception):
+class MinorVersionValidateFailed(F5AgentException):
     pass
 
 
-class ProvisioningExtraMBValidateFailed(Exception):
+class MajorVersionValidateFailed(F5AgentException):
     pass
 
 
-class BigIPDeviceLockAcquireFailed(Exception):
+class ProvisioningExtraMBValidateFailed(F5AgentException):
     pass
 
 
-class BigIPClusterInvalidHA(Exception):
+class BigIPDeviceLockAcquireFailed(F5AgentException):
     pass
 
 
-class BigIPClusterSyncFailure(Exception):
+class BigIPClusterInvalidHA(F5AgentException):
     pass
 
 
-class BigIPClusterPeerAddFailure(Exception):
+class BigIPClusterSyncFailure(F5AgentException):
     pass
 
 
-class BigIPClusterConfigSaveFailure(Exception):
+class BigIPClusterPeerAddFailure(F5AgentException):
     pass
 
 
-class UnknownMonitorType(Exception):
+class BigIPClusterConfigSaveFailure(F5AgentException):
     pass
 
 
-class MissingVTEPAddress(Exception):
+class UnknownMonitorType(F5AgentException):
     pass
 
 
-class MissingNetwork(Exception):
+class MissingVTEPAddress(F5AgentException):
     pass
 
 
-class InvalidNetworkType(Exception):
+class MissingNetwork(F5AgentException):
     pass
 
 
-class StaticARPCreationException(Exception):
+class InvalidNetworkType(F5AgentException):
     pass
 
 
-class StaticARPQueryException(Exception):
+class StaticARPCreationException(F5AgentException):
     pass
 
 
-class StaticARPDeleteException(Exception):
+class StaticARPQueryException(F5AgentException):
     pass
 
 
-class ClusterCreationException(Exception):
+class StaticARPDeleteException(F5AgentException):
     pass
 
 
-class ClusterUpdateException(Exception):
+class ClusterCreationException(F5AgentException):
     pass
 
 
-class ClusterQueryException(Exception):
+class ClusterUpdateException(F5AgentException):
     pass
 
 
-class ClusterDeleteException(Exception):
+class ClusterQueryException(F5AgentException):
     pass
 
 
-class DeviceCreationException(Exception):
+class ClusterDeleteException(F5AgentException):
     pass
 
 
-class DeviceUpdateException(Exception):
+class DeviceCreationException(F5AgentException):
     pass
 
 
-class DeviceQueryException(Exception):
+class DeviceUpdateException(F5AgentException):
     pass
 
 
-class DeviceDeleteException(Exception):
+class DeviceQueryException(F5AgentException):
     pass
 
 
-class InterfaceQueryException(Exception):
+class DeviceDeleteException(F5AgentException):
     pass
 
 
-class IAppCreationException(Exception):
+class InterfaceQueryException(F5AgentException):
     pass
 
 
-class IAppQueryException(Exception):
+class IAppCreationException(F5AgentException):
     pass
 
 
-class IAppUpdateException(Exception):
+class IAppQueryException(F5AgentException):
     pass
 
 
-class IAppDeleteException(Exception):
+class IAppUpdateException(F5AgentException):
     pass
 
 
-class L2GRETunnelCreationException(Exception):
+class IAppDeleteException(F5AgentException):
     pass
 
 
-class L2GRETunnelQueryException(Exception):
+class L2GRETunnelCreationException(F5AgentException):
     pass
 
 
-class L2GRETunnelUpdateException(Exception):
+class L2GRETunnelQueryException(F5AgentException):
     pass
 
 
-class L2GRETunnelDeleteException(Exception):
+class L2GRETunnelUpdateException(F5AgentException):
     pass
 
 
-class MonitorCreationException(Exception):
+class L2GRETunnelDeleteException(F5AgentException):
     pass
 
 
-class MonitorQueryException(Exception):
+class MonitorCreationException(F5AgentException):
     pass
 
 
-class MonitorUpdateException(Exception):
+class MonitorQueryException(F5AgentException):
     pass
 
 
-class MonitorDeleteException(Exception):
+class MonitorUpdateException(F5AgentException):
     pass
 
 
-class NATCreationException(Exception):
+class MonitorDeleteException(F5AgentException):
     pass
 
 
-class NATQueryException(Exception):
+class NATCreationException(F5AgentException):
     pass
 
 
-class NATUpdateException(Exception):
+class NATQueryException(F5AgentException):
     pass
 
 
-class NATDeleteException(Exception):
+class NATUpdateException(F5AgentException):
     pass
 
 
-class PoolCreationException(Exception):
+class NATDeleteException(F5AgentException):
     pass
 
 
-class PoolQueryException(Exception):
+class PoolCreationException(F5AgentException):
     pass
 
 
-class PoolUpdateException(Exception):
+class PoolQueryException(F5AgentException):
     pass
 
 
-class PoolDeleteException(Exception):
+class PoolUpdateException(F5AgentException):
     pass
 
 
-class RouteCreationException(Exception):
+class PoolDeleteException(F5AgentException):
     pass
 
 
-class RouteQueryException(Exception):
+class RouteCreationException(F5AgentException):
     pass
 
 
-class RouteUpdateException(Exception):
+class RouteQueryException(F5AgentException):
     pass
 
 
-class RouteDeleteException(Exception):
+class RouteUpdateException(F5AgentException):
     pass
 
 
-class RouteDomainCreationException(Exception):
+class RouteDeleteException(F5AgentException):
     pass
 
 
-class RouteDomainQueryException(Exception):
+class RouteDomainCreationException(F5AgentException):
     pass
 
 
-class RouteDomainUpdateException(Exception):
+class RouteDomainQueryException(F5AgentException):
     pass
 
 
-class RouteDomainDeleteException(Exception):
+class RouteDomainUpdateException(F5AgentException):
     pass
 
 
-class RuleCreationException(Exception):
+class RouteDomainDeleteException(F5AgentException):
     pass
 
 
-class RuleQueryException(Exception):
+class RuleCreationException(F5AgentException):
     pass
 
 
-class RuleUpdateException(Exception):
+class RuleQueryException(F5AgentException):
     pass
 
 
-class RuleDeleteException(Exception):
+class RuleUpdateException(F5AgentException):
     pass
 
 
-class SelfIPCreationException(Exception):
+class RuleDeleteException(F5AgentException):
     pass
 
 
-class SelfIPQueryException(Exception):
+class SelfIPCreationException(F5AgentException):
     pass
 
 
-class SelfIPUpdateException(Exception):
+class SelfIPQueryException(F5AgentException):
     pass
 
 
-class SelfIPDeleteException(Exception):
+class SelfIPUpdateException(F5AgentException):
     pass
 
 
-class SNATCreationException(Exception):
+class SelfIPDeleteException(F5AgentException):
     pass
 
 
-class SNATQueryException(Exception):
+class SNATCreationException(F5AgentException):
     pass
 
 
-class SNATUpdateException(Exception):
+class SNATQueryException(F5AgentException):
     pass
 
 
-class SNATDeleteException(Exception):
+class SNATUpdateException(F5AgentException):
     pass
 
 
-class SystemCreationException(Exception):
+class SNATDeleteException(F5AgentException):
     pass
 
 
-class SystemQueryException(Exception):
+class SystemCreationException(F5AgentException):
     pass
 
 
-class SystemUpdateException(Exception):
+class SystemQueryException(F5AgentException):
     pass
 
 
-class SystemDeleteException(Exception):
+class SystemUpdateException(F5AgentException):
     pass
 
 
-class VirtualServerCreationException(Exception):
+class SystemDeleteException(F5AgentException):
     pass
 
 
-class VirtualServerQueryException(Exception):
+class VirtualServerCreationException(F5AgentException):
     pass
 
 
-class VirtualServerUpdateException(Exception):
+class VirtualServerQueryException(F5AgentException):
     pass
 
 
-class VirtualServerDeleteException(Exception):
+class VirtualServerUpdateException(F5AgentException):
     pass
 
 
-class VLANCreationException(Exception):
+class VirtualServerDeleteException(F5AgentException):
     pass
 
 
-class VLANQueryException(Exception):
+class VLANCreationException(F5AgentException):
     pass
 
 
-class VLANUpdateException(Exception):
+class VLANQueryException(F5AgentException):
     pass
 
 
-class VLANDeleteException(Exception):
+class VLANUpdateException(F5AgentException):
     pass
 
 
-class VXLANCreationException(Exception):
+class VLANDeleteException(F5AgentException):
     pass
 
 
-class VXLANQueryException(Exception):
+class VXLANCreationException(F5AgentException):
     pass
 
 
-class VXLANUpdateException(Exception):
+class VXLANQueryException(F5AgentException):
     pass
 
 
-class VXLANDeleteException(Exception):
+class VXLANUpdateException(F5AgentException):
+    pass
+
+
+class VXLANDeleteException(F5AgentException):
     pass

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
@@ -135,41 +135,6 @@ class NetworkHelper(object):
                                         err.message))
         return None
 
-    @log_helpers.log_method_call
-    def get_selfips(self, bigip, partition=const.DEFAULT_PARTITION,
-                    vlan_name=None):
-        if not vlan_name.startswith('/'):
-            vlan_name = "/%s/%s" % (partition, vlan_name)
-        sc = bigip.tm.net.selfips
-        params = {'params': {'$filter': 'partition eq %s' % partition}}
-        selfips = sc.get_collection(requests_params=params)
-        selfips_list = []
-        for selfip in selfips:
-            if vlan_name and selfip.vlan != vlan_name:
-                LOG.debug("XXXXXXX vlan names don't match selfip.vlan %s "
-                          "and constructed vlan name %s",
-                          selfip.vlan, vlan_name)
-                continue
-            selfip.name = selfip.name
-            selfips_list.append(selfip)
-        return selfips_list
-
-    @log_helpers.log_method_call
-    def delete_selfip(self, bigip, name, partition=const.DEFAULT_PARTITION):
-        """Delete the selfip if it exists."""
-        try:
-            s = bigip.tm.net.selfips.selfip
-            if s.exists(name=name, partition=partition):
-                s.load(name=name, partition=partition)
-                s.delete()
-        except HTTPError as err:
-            LOG.error("Error deleting selfip %s. "
-                      "Repsponse status code: %s. Response "
-                      "message: %s." % (name,
-                                        err.response.status_code,
-                                        err.message))
-
-    @log_helpers.log_method_call
     def route_domain_exists(self, bigip, partition=const.DEFAULT_PARTITION,
                             domain_id=None):
         if partition == 'Common':

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
@@ -307,7 +307,7 @@ class LBaaSv2PluginRPC(object):
         try:
             port = self._call(
                 self.context,
-                self._make_msg('create_port_on_subnet',
+                self._make_msg('create_port_on_subnet_with_specific_ip',
                                subnet_id=subnet_id,
                                mac_address=mac_address,
                                name=name,


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
Fixes #126

#### What's this change do?
Reorganizes some error handling in the selfip code to allow errors to be logged and handled at top layers of the code.  There are some bug fixes to selfip.

#### Where should the reviewer start?
selfip.py

#### Any background context?
N/A

Issues:
Fixes #126

Problem:
Some error handling and defensive programming changes were made
to public functions.

Assure gateway was not functional.  This adds support for deployments
where snat-enabled is False.

Moved over some selfip functionality from network_helper.

Analysis:
Refactored exceptions, moved all selfip code from network helper to
selfip, and fixed gateway creationg.

Tests:
Pass traffic.