### PR TITLE
Add support for parent client SSL profile

### DIFF
--- a/etc/neutron/services/f5/f5-openstack-agent.ini
+++ b/etc/neutron/services/f5/f5-openstack-agent.ini
@@ -502,3 +502,13 @@ os_password = changeme
 os_user_domain_name = default
 os_project_name = admin
 os_project_domain_name = default
+#
+# Parent SSL profile name
+#
+# A client SSL profile is created for LBaaS listeners that use TERMINATED_HTTPS
+# protocol. You can define the parent profile for this profile by setting
+# f5_parent_ssl_profile. The profile created to support TERMINATTED_HTTPS will
+# inherit settings from the parent you define. This must be an existing profile,
+# and if it does not exist on your BIG-IP system the agent will use the default
+# profile, clientssl.
+f5_parent_ssl_profile = clientssl

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -266,6 +266,12 @@ OPTS = [
         'os_password',
         default=None,
         help='OpenStack user password for Keystone authentication.'
+    ),
+    cfg.StrOpt(
+        'f5_parent_ssl_profile',
+        default='clientssl',
+        help='Parent profile used when creating client SSL profiles '
+        'for listeners with TERMINATED_HTTPS protocols.'
     )
 ]
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -37,7 +37,9 @@ class LBaaSBuilder(object):
         self.l2_service = l2_service
         self.service_adapter = driver.service_adapter
         self.listener_builder = listener_service.ListenerServiceBuilder(
-            self.service_adapter, driver.cert_manager)
+            self.service_adapter,
+            driver.cert_manager,
+            conf.f5_parent_ssl_profile)
         self.pool_builder = pool_service.PoolServiceBuilder(
             self.service_adapter
         )

--- a/test/test_ssl_profile.py
+++ b/test/test_ssl_profile.py
@@ -1,0 +1,93 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import random
+import string
+
+from f5.bigip import ManagementRoot
+from f5_openstack_agent.lbaasv2.drivers.bigip.ssl_profile import \
+    SSLProfileHelper
+
+FAKE_CERT = """-----BEGIN CERTIFICATE-----
+MIIBozCCAQwCAQEwDQYJKoZIhvcNAQEFBQAwGjEYMBYGA1UEAxQPY2EtaW50QGFj
+bWUuY29tMB4XDTE2MDUxMTE2MjcyN1oXDTI2MDUwOTE2MjcyN1owGjEYMBYGA1UE
+AxQPc2VydmVyQGFjbWUuY29tMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCn
+48EdxKMaBvd2nBY4Pt3UI9OhWfDt0JHF/FnE0MOR1DYEP9WqlRlDorojVSignlne
+febsSOFxciUGkeYvGTycR58/aAcWfp6lz6gLoTydfi7/XdReQt4JLzH9f0HYdKzz
+z06PjNTOGKtcBipUQjAjtH8HRIfOyatIAiUAHHBrBwIDAQABMA0GCSqGSIb3DQEB
+BQUAA4GBACvhrSKPtZVMvTUz4I0oxpl85IeM6p2X1qNjlSreCtLLp8o55HF1BEdI
+gLdNgzCs1x9/Mi7ZIwA0FySS4s6E8hMA3OG5Z/42aKGCJyHybeoWXsiVYIwkQi/J
+7293ACoLewtjwaGAFeSijukgyHooJUkqWi/oG8qc+K2GwZ8yeYYi
+-----END CERTIFICATE-----"""
+
+FAKE_KEY = """-----BEGIN RSA PRIVATE KEY-----
+MIICXQIBAAKBgQCn48EdxKMaBvd2nBY4Pt3UI9OhWfDt0JHF/FnE0MOR1DYEP9Wq
+lRlDorojVSignlnefebsSOFxciUGkeYvGTycR58/aAcWfp6lz6gLoTydfi7/XdRe
+Qt4JLzH9f0HYdKzzz06PjNTOGKtcBipUQjAjtH8HRIfOyatIAiUAHHBrBwIDAQAB
+AoGBAIKTPZBEbkIA5xhlv1ZRdr/WeXNFe3/KtoWQhdTwNRrHPJfDeg+o1LRo7HIs
+emOppOXJb/+Xk1djWm6orKk27I6wgIGcLJv61jRq9mOG3Hlfs9ZSkVsQIqutUSVm
+amhp3uwK3KIk3k7yv16+VTGfsXsPWsT1oWd4CWmWNAjMol9JAkEA3IloSbt+orEf
+x36qv//jsq87gOr5eUmwXTySMHaxbXmkIjaCjZHAb70/kWewXZMoj7k6c1Pj9i3T
+Tdfhgl3eLQJBAMLjFS1xIqXKLeBzMjcBfVlDF/ZJa4e2EZd1OOJreGkllx3j23fU
+NBdsN71XGr16RuxkLo/4HozequTCh5fU4oMCQAfFG5SFc5e9z9XSg6eSF26jN+B5
+5uI8E2eli60DcYre30aJTx43xWTqcQPpeFBDsAkoSIPpr71rrecvNPXH4t0CQGGB
+JbZPlUsnZV6Xo/b7StCfDd0ODLugbxq87lHx/RN2WC3/M223gLx7S0Py0ZEdHWDm
+GpmzRO2r9gpv/VEMlKsCQQCV+EffCQ4wKBIYeCchdntop1/A9PWWCS+pjUNdIJNR
+CKxlxUfEZw9yNfLw9g0FKxrdSZiHCAw7fwN7s+CszjT4
+-----END RSA PRIVATE KEY-----"""
+
+def test_create_client_ssl_profile():
+
+    # set of valid and invalid parent profile names
+    test_parents = [None,
+                    "",
+                    "INVALID",
+                    "clientssl",
+                    "clientssl-insecure-compatible"]
+
+    bigip = ManagementRoot('10.190.7.235', 'admin', 'admin')
+
+    for parent in test_parents:
+        name = random_name('Project_', 16)
+
+        # create client ssl profile
+        SSLProfileHelper.create_client_ssl_profile(
+            bigip,
+            name,
+            FAKE_CERT,
+            FAKE_KEY,
+            parent_profile=parent)
+
+        # created?
+        client_ssl = bigip.tm.ltm.profile.client_ssls.client_ssl
+        assert client_ssl.exists(name=name, partition='Common')
+
+        # parent set correctly?
+        sp = client_ssl.load(name=name, partition='Common')
+        if not parent or parent == "INVALID":
+            path = '/Common/' + 'clientssl'
+        else:
+            path = '/Common/' + parent
+
+        assert sp.defaultsFrom == path
+
+        # clean up
+        sp.delete()
+
+def random_name(prefix, N):
+    # create a name with random characters and digits
+    return prefix + ''.join(
+        random.SystemRandom().choice(
+            string.ascii_uppercase + string.digits) for _ in range(N))


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
Fixes #146 

#### What's this change do?
Adds an option to f5-openstack-agent.ini that allows user to define the parent client SSL profile used when creating client SSL profiles for TERMINATED_HTTPS listeners. Modifies client SSL creation to use this setting as the 'defaultsFrom' attribute of the profile. Includes a test of creating SSL profiles with both valid and invalid parent names.

#### Where should the reviewer start?
Check the new option in the ini file and then look at ssl_profile.py (helper class that create profiles).

#### Any background context?
No.
