### PR TITLE
SNAT creation failure for 'Common' network

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
@@ -166,7 +166,7 @@ class BigipSnatManager(object):
 
             model = {
                 "name": snat_info['pool_name'],
-                "partition": snat_info['pool_folder'],
+                "partition": snat_info['network_folder'],
             }
             model["members"] = ['/' + model["partition"] + '/' +
                                 index_snat_name]


### PR DESCRIPTION
@jlongstaf 

#### What issues does this address?
Fixes #156 


#### What's this change do?
Fixes a bug in SNAT pool creation for networks where the VIP is on a shared/common network.

#### Where should the reviewer start?
snats.py


Issues:
Fixes #156

Problem:
When the VIP network is assigned in the common folder the creation of a SNAT address
is successful; however, the SNAT pool creation in the tenant folder fails b/c the
code attempts to assign a translation from the tenant folder, and not the one created
in the Common folder. Since there is no SNAT translation address in the tenant
folder the pool creation fails.

Analysis:
Create the pool by correctly passing in the network folder which contains the
SNAT translation address.

Tests:
Set the VIP network to shared.
Run Traffic tests.