### PR TITLE
Virtual Server should not listen on all tunnels/vlans

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -582,7 +582,7 @@ class iControlDriver(LBaaSBaseDriver):
                   (bigip.device_name, ', '.join(bigip.mac_addresses)))
         bigip.device_interfaces = \
             self.system_helper.get_interface_macaddresses_dict(bigip)
-        bigip.assured_networks = []
+        bigip.assured_networks = {}
         bigip.assured_tenant_snat_subnets = {}
         bigip.assured_gateway_subnets = []
 
@@ -691,7 +691,7 @@ class iControlDriver(LBaaSBaseDriver):
     def flush_cache(self):
         # Remove cached objects so they can be created if necessary
         for bigip in self.get_all_bigips():
-            bigip.assured_networks = []
+            bigip.assured_networks = {}
             bigip.assured_tenant_snat_subnets = {}
             bigip.assured_gateway_subnets = []
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
@@ -56,7 +56,9 @@ class ListenerServiceBuilder(object):
             tls['name'] = vip['name']
             tls['partition'] = vip['partition']
 
+        network_id = service['loadbalancer']['network_id']
         for bigip in bigips:
+            self.service_adapter.get_vlan(vip, bigip, network_id)
             self.vs_helper.create(bigip, vip)
 
             if tls:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -340,6 +340,12 @@ class ServiceModelAdapter(object):
 
         return vip
 
+    def get_vlan(self, vip, bigip, network_id):
+        if network_id in bigip.assured_networks:
+            vip['vlans'].append(
+                bigip.assured_networks[network_id])
+            vip['vlansEnabled'] = True
+
     def _add_bigip_items(self, listener, vip):
         # following are needed to complete a create()
 
@@ -373,10 +379,6 @@ class ServiceModelAdapter(object):
             if '.' in ip_address:
                 vip["mask"] = '255.255.255.255'
 
-        # vlan_name
-        if "network_name" in listener:
-            vip["vlan_name"] = listener["network_name"]
-
         # snat
         if "use_snat" in listener and listener["use_snat"]:
             vip['sourceAddressTranslation'] = {}
@@ -386,6 +388,10 @@ class ServiceModelAdapter(object):
                     listener["snat_pool_name"]
             else:
                 vip['sourceAddressTranslation']['type'] = 'automap'
+
+        # default values for pinning the VS to a specific VLAN set
+        vip['vlansEnabled'] = False
+        vip['vlans'] = []
 
     def _map_member(self, loadbalancer, lbaas_member):
         member = {}


### PR DESCRIPTION
@jlongstaf @mattgreene 
#### What issues does this address?
Fixes #137 


#### What's this change do?
Pins Virtual Server to the specific VLAN/Tunnel of the VIP.

#### Where should the reviewer start?

#### Any background context?

Issues:
Fixes #137

Problem:
The virtual server is not constrained a specific set of VLANs meaning
that it will "live" on all networks accessible by the tenant. The virtual
server should always have vlansEnabled = True and the vlans list constrained
to the specific vlan or tunnel networks constructed for the tenant.

Analysis:
Convert bigip.assured_networks to a dictionary where the key is
the OpenStack network_id and the value is the network name as it
appears in the BigIP configuration.

Save the names of the vlans/tunnels in the assured_networks.  When
a listener is created refer to the assured_networks map to extract
the vlan name of the virtual server's vip.

Tests:
Traffic/2-armed deployment.