### PR TITLE
Unable to create more than one SNAT member in a pool

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
@@ -168,32 +168,30 @@ class BigipSnatManager(object):
                 "name": snat_info['pool_name'],
                 "partition": snat_info['pool_folder'],
             }
-            model["members"] = ['/' + model["partition"] + '/' +
-                                index_snat_name]
+            snatpool_member = ('/' + model["partition"] + '/' +
+                               index_snat_name)
+            model["members"] = [snatpool_member]
             try:
-                LOG.debug("Creating SNAT pool: %s" % model)
-                self.snatpool_manager.create(bigip, model)
-
-            except HTTPError as err:
-                LOG.error("Create SNAT pool failed %s" % err.message)
-                if err.response.status_code == 409:
-                    try:
-                        snatpool = self.snatpool_manager.load(
-                            bigip,
-                            name=model["name"],
-                            partition=model["partition"]
-                        )
-                        snatpool.members.append(model["members"])
-                        snatpool.update()
-                    except HTTPError as err:
-                        LOG.error("Update SNAT pool failed %s" % err.message)
-                        raise f5_ex.SNATCreationException(
-                            "Failed to update SNAT pool with "
-                            "member %s." % (model["members"])
-                        )
+                if not self.snatpool_manager.exists(
+                        bigip,
+                        name=model['name'],
+                        partition=model['partition']):
+                    LOG.debug("Creating SNAT pool: %s" % model)
+                    self.snatpool_manager.create(bigip, model)
                 else:
-                    raise f5_ex.SNATCreationException(
-                        "Failed to create SNAT pool")
+                    LOG.debug("Updating SNAT pool")
+                    snatpool = self.snatpool_manager.load(
+                        bigip,
+                        name=model["name"],
+                        partition=model["partition"]
+                    )
+                    snatpool.members.append(snatpool_member)
+                    snatpool.update()
+
+            except Exception as err:
+                LOG.error("Create SNAT pool failed %s" % err.message)
+                raise f5_ex.SNATCreationException(
+                    "Failed to create SNAT pool")
 
             if self.l3_binding:
                 self.l3_binding.bind_address(subnet_id=subnet['id'],


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
Fixes #161

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?

Issues:
Fixes #161

Problem:
The snat code creates a translation address and a snat pool to use for
the virtual server. However, if the snat pool already exists the previously
added member is overwritten. So if a user specifies more that one SNAT
address, only the last one created is in the list.

Analysis:
The bug expected a pool creation error to occur in the event that
the pool already existed and the error code is 409.  The resource
manager code interprets a conflict as an update and proceeds.
This fix explicitly checks for the snatpool.  If it exists,
it is loaded and the members are updated with the most resently
created snat translation element.

Tests:
Traffic 2-armed/ and Common network.