### PR TITLE
Remove f5_sync_mode option

### DIFF
--- a/etc/neutron/services/f5/f5-openstack-agent.ini
+++ b/etc/neutron/services/f5/f5-openstack-agent.ini
@@ -94,15 +94,6 @@ periodic_interval = 10
 #
 f5_ha_type = standalone
 #
-#
-# Sync mode
-#
-# autosync - syncable policies configured on one device then
-#            synced to the group
-# replication - each device configured separately
-# 
-f5_sync_mode = replication
-#
 ###############################################################################
 #  L2 Segmentation Mode Settings
 ###############################################################################

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
@@ -566,24 +566,14 @@ class NetworkServiceBuilder(object):
                 self._assure_delete_nets_shared(bigip, service,
                                                 subnet_hints))
 
-        # avoids race condition:
-        # deletion of shared ip objects must sync before we
-        # remove the selfips or vlans from the peer bigips.
-        self.driver.sync_if_clustered()
-
         # Delete non shared config objects
         for bigip in self.driver.get_all_bigips():
             LOG.debug('    post_service_networking: calling '
                       '    _assure_delete_networks del nets ns for bigip %s'
                       % bigip.device_name)
-            if self.conf.f5_sync_mode == 'replication':
-                subnet_hints = all_subnet_hints[bigip.device_name]
-            else:
-                # If in autosync mode, then the IP operations were performed
-                # on just the primary big-ip, and so that is where the subnet
-                # hints are stored. So, just use those hints for every bigip.
-                device_name = self.driver.get_bigip().device_name
-                subnet_hints = all_subnet_hints[device_name]
+
+            subnet_hints = all_subnet_hints[bigip.device_name]
+
             deleted_names = deleted_names.union(
                 self._assure_delete_nets_nonshared(
                     bigip, service, subnet_hints)


### PR DESCRIPTION
@mattgreene 
#### What issues does this address?
Fixes #169

#### What's this change do?
Removes f5_sync_mode option from agent ini and makes replication mode the only supported sync mode (i.e., auto_sync is NOT supported).

#### Where should the reviewer start?
f5-openstack-agent.ini, icontrol_driver.py

#### Any background context?
LBaaS v1 supported two modes: replication and auto_sync. Because auto_sync does not work well (causing a flood of traffic between BIG-IPs in a cluster), and because our recommendation is to only use replication, we are removing auto_sync support.

Issues:
Fixes #169

Problem: Need to remove support for auto_sync option.

Analysis: Remove auto_sync option from .ini file, and modified
code to use only replication mode logic.

Tests: Manual, test_solution.py