### PR TITLE
Update install instructions for mitaka

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ Overview
     :maxdepth: 1
 
     release_notes
-    ref_agent-config-file
+
 
 Quick Start
 -----------

--- a/docs/topic_install-f5-agent.rst
+++ b/docs/topic_install-f5-agent.rst
@@ -10,7 +10,7 @@ Install the F5 OpenStack Agent
 
     .. code-block:: text
 
-        $ sudo pip install git+https://github.com/F5Networks/f5-openstack-agent@liberty
+        $ sudo pip install git+https://github.com/F5Networks/f5-openstack-agent@mitaka
 
 .. topic:: To install the ``f5-openstack-agent`` release package for v |version|:
 
@@ -20,7 +20,7 @@ Install the F5 OpenStack Agent
 
     .. code-block:: text
 
-        $ sudo pip install git+https://github.com/F5Networks/f5-openstack-agent@v8.0.3
+        $ sudo pip install git+https://github.com/F5Networks/f5-openstack-agent@v9.0.1
 
 
 Need to Upgrade?

--- a/docs/topic_install-f5-agent.rst
+++ b/docs/topic_install-f5-agent.rst
@@ -1,20 +1,20 @@
-Install the F5® OpenStack Agent
--------------------------------
+Install the F5 OpenStack Agent
+------------------------------
 
 .. note::
 
     - You must have both ``pip`` and ``git`` installed on your machine in order to use these commands.
     - It may be necessary to use ``sudo``, depending on your environment.
 
-.. topic:: To install the ``f5-openstack-agent`` package:
+.. topic:: To install the ``f5-openstack-agent`` package from the |openstack| branch:
 
     .. code-block:: text
 
-        $ sudo pip install git+https://github.com/F5Networks/f5-openstack-agent
+        $ sudo pip install git+https://github.com/F5Networks/f5-openstack-agent@liberty
 
-.. important::
+.. topic:: To install the ``f5-openstack-agent`` release package for v |version|:
 
-    The command above will install the package from the default branch in GitHub (liberty). You can install specific releases by adding ``@<release_tag>`` to the end of the install command.
+    You can install specific releases by adding ``@<release_tag>`` to the end of the install command.
 
     For example:
 
@@ -26,4 +26,4 @@ Install the F5® OpenStack Agent
 Need to Upgrade?
 ````````````````
 
-Please see the :ref:`upgrade instructions <lbaasv2driver:Upgrading the F5® LBaaSv2 Plugin>`.
+Please see the :ref:`upgrade instructions <lbaasv2driver:Upgrading the F5 LBaaSv2 Components>`.


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
Fixes #173 

#### What's this change do?
Removes the reference to liberty being the default branch. 
Provides specific instructions to install from mitaka branch or release tag.
Fixes a few issues (bad link to upgrade instructions, remove link to agent config file)


#### Where should the reviewer start?
Ok to just view changes below, they're minimal.


#### Any background context?

