### PR TITLE
Issue #194 Agent filter syntax is not compatible with REST API in ver…

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
@@ -18,6 +18,7 @@ import netaddr
 import os
 import urllib
 
+from f5_openstack_agent.lbaasv2.drivers.bigip.utils import get_filter
 from oslo_log import helpers as log_helpers
 from oslo_log import log as logging
 from requests.exceptions import HTTPError
@@ -164,7 +165,9 @@ class NetworkHelper(object):
         rdc = bigip.tm.net.route_domains
         params = {}
         if partition:
-            params = {'params': {'$filter': 'partition eq %s' % partition}}
+            params = {
+                'params': get_filter(bigip, 'partition', 'eq', partition)
+            }
         route_domains = rdc.get_collection(requests_params=params)
         for rd in route_domains:
             if rd.id == id:
@@ -222,7 +225,9 @@ class NetworkHelper(object):
         rdc = bigip.tm.net.route_domains
         params = {}
         if partition:
-            params = {'params': {'$filter': 'partition eq %s' % partition}}
+            params = {
+                'params': get_filter(bigip, 'partition', 'eq', partition)
+            }
         route_domains = rdc.get_collection(requests_params=params)
         rd_ids_list = []
         for rd in route_domains:
@@ -234,7 +239,9 @@ class NetworkHelper(object):
         rdc = bigip.tm.net.route_domains
         params = {}
         if partition:
-            params = {'params': {'$filter': 'partition eq %s' % partition}}
+            params = {
+                'params': get_filter(bigip, 'partition', 'eq', partition)
+            }
         route_domains = rdc.get_collection(requests_params=params)
         rd_names_list = []
         for rd in route_domains:
@@ -412,7 +419,7 @@ class NetworkHelper(object):
             return []
         mac_addresses = []
         ac = bigip.tm.net.arps
-        params = {'params': {'$filter': 'partition eq %s' % partition}}
+        params = {'params': get_filter(bigip, 'partition', 'eq', partition)}
         try:
             arps = ac.get_collection(requests_params=params)
         except HTTPError as err:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 
 from enum import Enum
+from f5_openstack_agent.lbaasv2.drivers.bigip.utils import get_filter
 
 from oslo_log import log as logging
 
@@ -157,7 +158,9 @@ class BigIPResourceHelper(object):
 
         if collection:
             if partition:
-                params = {'params': {'$filter': 'partition eq %s' % partition}}
+                params = {
+                    'params': get_filter(bigip, 'partition', 'eq', partition)
+                }
                 resources = collection.get_collection(requests_params=params)
             else:
                 resources = collection.get_collection()

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
@@ -25,6 +25,7 @@ from f5_openstack_agent.lbaasv2.drivers.bigip.resource_helper \
     import BigIPResourceHelper
 from f5_openstack_agent.lbaasv2.drivers.bigip.resource_helper \
     import ResourceType
+from f5_openstack_agent.lbaasv2.drivers.bigip.utils import get_filter
 from requests import HTTPError
 
 LOG = logging.getLogger(__name__)
@@ -333,7 +334,7 @@ class BigipSelfIpManager(object):
             if not vlan_name.startswith('/'):
                 vlan_name = "/%s/%s" % (partition, vlan_name)
 
-        params = {'params': {'$filter': 'partition eq %s' % partition}}
+        params = {'params': get_filter(bigip, 'partition', 'eq', partition)}
         try:
             selfips_list = [selfip for selfip in
                             bigip.tm.net.selfips.get_collection(

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_utils.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_utils.py
@@ -1,0 +1,81 @@
+# coding=utf-8
+# Copyright 2014-2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import f5_openstack_agent.lbaasv2.drivers.bigip.utils as utils
+import mock
+
+
+class TestUtils(object):
+    def test_strip_domain_address_no_mask(self):
+        addr = utils.strip_domain_address("192.168.1.1%20")
+        assert addr == '192.168.1.1'
+
+    def test_strip_domain_address_mask(self):
+        domain = utils.strip_domain_address('192.168.1.1%20/24')
+        assert domain == "192.168.1.1/24"
+
+    def test_request_index_0(self):
+        request_q = [
+            [1, 2, 3],
+            [2, 4, 6],
+            [3, 6, 9]
+        ]
+        index = utils.request_index(request_q, 1)
+        assert index == 0
+
+    def test_request_index_1(self):
+        request_q = [
+            [1, 2, 3],
+            [2, 4, 6],
+            [3, 6, 9]
+        ]
+        index = utils.request_index(request_q, 2)
+        assert index == 1
+
+    def test_request_index_none(self):
+        request_q = [
+            [1, 2, 3],
+            [2, 4, 6],
+            [3, 6, 9]
+        ]
+        index = utils.request_index(request_q, 99)
+        assert index == len(request_q)
+
+    def test_get_filter_v11_5(self):
+        bigip = mock.MagicMock()
+        bigip.tmos_version = "11.5"
+        f = utils.get_filter(bigip, 'partition', 'eq', 'Common')
+        assert f == '$filter=partition+eq+Common'
+
+    def test_get_filter_v11_5_4(self):
+        bigip = mock.MagicMock()
+        bigip.tmos_version = "11.5.4"
+        f = utils.get_filter(bigip, 'partition', 'eq', 'Common')
+        assert f == '$filter=partition+eq+Common'
+
+    def test_get_filter_v11_6_0(self):
+        bigip = mock.MagicMock()
+        bigip.tmos_version = "11.6.0"
+        f = utils.get_filter(bigip, 'partition', 'eq', 'Common')
+        assert isinstance(f, dict)
+        assert f == {'$filter': 'partition eq Common'}
+
+    def test_get_filter_v12_1_0(self):
+        bigip = mock.MagicMock()
+        bigip.tmos_version = "12.1.0"
+        f = utils.get_filter(bigip, 'partition', 'eq', 'Common')
+        assert isinstance(f, dict)
+        assert f == {'$filter': 'partition eq Common'}


### PR DESCRIPTION
@mattgreene 
Issue #194 Agent filter syntax is not compatible with REST API in version 11.5.x

Issues:
Fixes #194

Problem:
In BIG-IP version 11.5.4 the syntax used in the agent code is not
compatible with the BIG-IP REST API because the $ is encoded to
%24 and the REST server does not decode it back into a $.

This DevCentral article explains the issue and the workaround.
https://devcentral.f5.com/questions/icontrol-rest-filter-processing-not-http-compliant

Analysis:
* Created a get_filter function to get the right syntax based on the version of BIG-IP
* Used that function to construct the requests_params for the filter.

Tests: