### PR TITLE
Issue #195 No obvious way to remove cert_manager support

### DIFF
--- a/etc/neutron/services/f5/f5-openstack-agent.ini
+++ b/etc/neutron/services/f5/f5-openstack-agent.ini
@@ -469,7 +469,7 @@ icontrol_password = admin
 ###############################################################################
 # Certificate Manager
 ###############################################################################
-cert_manager = f5_openstack_agent.lbaasv2.drivers.bigip.barbican_cert.BarbicanCertManager
+# cert_manager = f5_openstack_agent.lbaasv2.drivers.bigip.barbican_cert.BarbicanCertManager
 #
 # Two authentication modes are supported for BarbicanCertManager:
 #   keystone_v2, and keystone_v3

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -209,8 +209,7 @@ OPTS = [  # XXX maybe we should make this a dictionary
     ),
     cfg.StrOpt(
         'cert_manager',
-        default='f5_openstack_agent.lbaasv2.drivers.bigip.barbican_cert.'
-                'BarbicanCertManager',
+        default=None,
         help='Class name of the certificate mangager used for retrieving '
              'certificates and keys.'
     ),


### PR DESCRIPTION
@mattgreene @jgruber 

**This should not be merged until @mattgreene has tested it**
Issues:
Fixes #195

Problem:
If no cert_manager support is desired, there is no way to do this
without causing a ERROR message in the log.

Analysis:
* The default setting for cert_manager was set to the F5 cert manager
  driver instead of None.
* This caused it to always enter the section where it was imported
  and if the user does not have Barbican setup they will get an
  error in the log.

Tests: