### PR TITLE
vlans fields in JSON when creating VirtualServer behave differently b…

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -348,6 +348,7 @@ class ServiceModelAdapter(object):
             vip['vlans'].append(
                 bigip.assured_networks[network_id])
             vip['vlansEnabled'] = True
+            vip.pop('vlansDisabled', None)
 
     def _add_bigip_items(self, listener, vip):
         # following are needed to complete a create()
@@ -393,7 +394,7 @@ class ServiceModelAdapter(object):
                 vip['sourceAddressTranslation']['type'] = 'automap'
 
         # default values for pinning the VS to a specific VLAN set
-        vip['vlansEnabled'] = False
+        vip['vlansDisabled'] = True
         vip['vlans'] = []
 
     def _map_member(self, loadbalancer, lbaas_member):


### PR DESCRIPTION
@zancas 

Code fix identified by @swormke, tested and being submitted by me.

Issues:
Fixes #201

Problem:
In BIG-IP version 11.5.4 the REST server accepts vlansEnabled = False, but returns vlansEnabled = True in the response.

Analysis:
The solution that works for all releases of BIG-IP is to set vlansDisabled = True.

Tests:
Traffic test on 11.5.4 overcloud deployment (which is the only toplogy that fails for this reason).  Undercloud deployment is not susceptible to this problem.