### PR TITLE
files for stand alone test 

### DIFF
--- a/devtools/common_service_handler_env.template.json
+++ b/devtools/common_service_handler_env.template.json
@@ -1,0 +1,18 @@
+{
+  "bigip_ip":                                     "<BIGIP_IP>",
+  "bigip_username":                               "admin",
+  "bigip_password":                               "admin",
+  "icontrol_hostname":                            "<BIGIP_IP>",
+  "icontrol_username":                            "admin",
+  "icontrol_password":                            "admin",
+  "f5_device_type":                               "external",
+  "f5_ha_type":                                   "standalone",
+  "f5_global_routed_mode":                        true,
+  "f5_sync_mode":                                 "replication",
+  "environment_prefix":                           "TEST",
+  "vlan_binding_driver":                          null,
+  "l3_binding_driver":                            null,
+  "cert_manager":                                 null,
+  "debug":                                        false,
+  "f5_parent_ssl_profile":                        null
+}

--- a/requirements.sa-test.txt
+++ b/requirements.sa-test.txt
@@ -1,0 +1,29 @@
+#
+# requirements for standalone agent tests
+#
+#
+
+cryptography
+hacking
+mock==1.3.0
+pytest
+pytest-cov
+paramiko
+decorator
+responses
+
+# F5 Agent from this directory
+.
+
+#F5
+git+https://github.com/F5Networks/pytest-symbols.git
+git+https://github.com/F5Networks/f5-common-python.git
+
+git+https://github.com/F5Networks/f5-openstack-test#liberty
+git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git#liberty
+
+#openstack
+oslo.log
+git+https://github.com/openstack/oslo.log.git#stable/liberty
+git+https://github.com/openstack/neutron#stable/liberty
+git+https://github.com/openstack/neutron-lbaas.git#stable/liberty


### PR DESCRIPTION
@zancas 
#### What issues does this address?
Fixes #238 

#### What's this change do?
Adds a requirements and config template file for stand alone tests.

#### Where should the reviewer start?
The two new files.

#### Any background context?
os_tests script will create a virtual env using the new requirements file. Then using the template file and the ip of a bigip will create a symbols file for py.test.
