### PR TITLE
Listener update with name change fails

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -716,6 +716,7 @@ class iControlDriver(LBaaSBaseDriver):
     def update_listener(self, old_listener, listener, service):
         """Update virtual server"""
         LOG.debug("Updating listener")
+        service['old_listener'] = old_listener
         self._common_service_handler(service)
 
     @serialized('delete_listener')

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
@@ -655,7 +655,7 @@ class NetworkServiceBuilder(object):
         # Delete pool member l2 records
         network = member['network']
         if network:
-            if member['port']:
+            if 'port' in member:
                 if self.l2_service.is_common_network(network):
                     net_folder = 'Common'
                 else:


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
Fixes #247 

#### What's this change do?
Adds ability to rename the virtual server associated with a listener object. Does so
by checking if an update includes a name change, and if it does, deletes existing
virtual and then creates a new one.

#### Where should the reviewer start?
lbaas-builder.py, _assure_listeners_created()

#### Any background context?
Found when running tempest tests.
