### PR TITLE
Feature.bug bundler

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include etc/neutron/services/f5/f5-openstack-agent.ini
 include etc/init.d/*
+include bin/*
 recursive-include lib *.service

--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,30 @@ We use the hacking module for our style checks (installed as part of step 1 in t
 
     $ flake8 ./
 
+Troubleshooting
+===============
+
+When the f5-openstack-agent is installed, the *debug_bundler.pyr* script will be installed to */usr/bin/f5/*. This script can be run from the command line directly. It will search in the specified directories to bundle log files and configuration files for use in debugging an issue with the f5-openstack-agent. In addition to the above files, it also dumps a complete listing of the ``pip lists`` output.
+
+**WARNING**
+
+The files added to this bundle may contain VERY SENSITIVE INFORMATION such as encryption keys, passwords, and usernames. Do not upload this bundle, or any information within, to a public forum unless you have scrubbed sensitive information thoroughly. When in doubt, don't upload it at all.
+
+Below you can see the basic usage, using the default command-line arguments:
+
+::
+
+    $ python /usr/bin/f5/debug_bundler.py /home/myuser/debug_bundle_output/
+
+A tarred, compressed, file will be created in the directory specified. It will contain all logs and configuration files the script found. Note that the script offers a best-effort search of the directories given, and if it cannot find the log files it is looking for in those directories, it will print a message and continue running.
+
+The default log location is set to `/var/log/neutron` and the default configuration file location is in `/etc/neutron`. These locations can be overriden via the command-line invocation shown below:
+
+::
+
+    $ python /usr/bin/f5/debug_bundler.py --log-dir=/var/log/mylogs --config-dir /etc/myconfigs/ ~/
+
+If any issue is found with the debug_bundler script, please file an issue on GitHub.
 
 Copyright
 *********

--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ We use the hacking module for our style checks (installed as part of step 1 in t
 Troubleshooting
 ===============
 
-When the f5-openstack-agent is installed, the *debug_bundler.pyr* script will be installed to */usr/bin/f5/*. This script can be run from the command line directly. It will search in the specified directories to bundle log files and configuration files for use in debugging an issue with the f5-openstack-agent. In addition to the above files, it also dumps a complete listing of the ``pip lists`` output.
+When the f5-openstack-agent is installed, the *debug_bundler.py* script will be installed to */usr/bin/f5/*. This script can be run from the command line directly. It will search in the specified directories to bundle log files and configuration files for use in debugging an issue with the f5-openstack-agent. In addition to the above files, it also dumps a complete listing of the ``pip lists`` output.
 
 **WARNING**
 

--- a/bin/debug_bundler.py
+++ b/bin/debug_bundler.py
@@ -41,8 +41,14 @@ import argparse
 from argparse import RawTextHelpFormatter
 import fnmatch
 import os
-import pip
 import tarfile
+
+
+try:
+    import pip
+    PIP_INSTALLED = True
+except ImportError:
+    PIP_INSTALLED = False
 
 
 class DebugBundle(object):
@@ -145,7 +151,8 @@ class DebugBundle(object):
                 self._tar_config_files(tar)
             if not self.no_log_files:
                 self._tar_log_files(tar)
-            self._save_pip_list(tar)
+            if PIP_INSTALLED:
+                self._save_pip_list(tar)
 
 
 if __name__ == "__main__":

--- a/bin/debug_bundler.py
+++ b/bin/debug_bundler.py
@@ -1,0 +1,189 @@
+# coding=utf-8
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+'''Bundle important log and configuration information for debug purposes.
+
+This module creates a compressed, tarred, bundle of log and configuration
+information relating to the f5-openstack-agent for the purpose of debugging
+an issue.
+
+WARNING: Some of the logs and config files gathered into this bundle contain
+VERY sensitive information, such as, keys, usernames, and possibly passwords.
+DO NOT upload this bundle to a publicly accessible location unless you have
+scrubbed/snipped/cropped the bundle and its contents thoroughly.
+
+This tool will create a bundle with the following information:
+
+    * A 'pip list' of installed packages
+    * Logs from /var/log/neutron (server.log and f5-openstack-agent.log)
+    * Config files from /etc/neutron (neutron.conf, neutron_lbaas.conf)
+    * Config files from /etc/neutron/services/f5 (f5-openstack-agent.ini)
+
+NOTE: This tool must be run where the agent is installed and currently must
+be run on the OpenStack Network Node (where neutron is installed).
+'''
+
+
+import argparse
+from argparse import RawTextHelpFormatter
+import fnmatch
+import os
+import pip
+import tarfile
+
+
+class DebugBundle(object):
+
+    def __init__(self, command_args):
+        self.config_dir = command_args.config_dir
+        self.log_dir = command_args.log_dir
+        self.tar_dest = command_args.tar_dest
+        self.no_config_files = command_args.no_config_files
+        self.no_log_files = command_args.no_log_files
+
+    def _save_pip_list(self, tar):
+        '''Dump a pip list, containing packages and versions.
+
+        :param dest: unicode -- directory of dumped pip list
+        :param tar: tarfile object -- tar where pip list dump will be added
+        '''
+
+        pkgs = pip.get_installed_distributions()
+        sorted_pkgs = sorted(pkgs, key=lambda pkg: pkg._key)
+        sorted_pkg_names = [str(pkg) for pkg in sorted_pkgs]
+        pip_list_file = os.path.join(self.tar_dest, 'pip_list.txt')
+        with open(pip_list_file, 'w') as pip_file:
+            pip_file.write('\n'.join(sorted_pkg_names))
+        self._add_file_to_tar(self.tar_dest, 'pip_list.txt', tar)
+        os.remove(pip_list_file)
+        return sorted_pkgs
+
+    def _tar_config_files(self, tar):
+        '''Add config files specified to tarfile
+
+        :param tar: tarfile object -- tar where config files will be added
+        '''
+
+        lbaas_config_dir = os.path.join(self.config_dir, 'services', 'f5')
+        config_files = [
+            (self.config_dir, 'neutron.conf'),
+            (self.config_dir, 'neutron_lbaas.conf'),
+            (lbaas_config_dir, 'f5-openstack-agent.ini')
+        ]
+        for cfg_dir, cfg_file in config_files:
+            self._add_file_to_tar(cfg_dir, cfg_file, tar)
+
+    def _tar_log_files(self, tar):
+        '''Add log files specified to tarfile
+
+        :param tar: tarfile object -- tar where log files will be added
+        '''
+
+        log_files = [
+            (self.log_dir, 'server.log'),
+            (self.log_dir, 'f5-openstack-agent.log')
+        ]
+        for log_dir, log_file in log_files:
+            if os.path.exists(log_dir):
+                self._add_file_to_tar(log_dir, log_file, tar)
+                self._tar_archived_log_files(log_dir, log_file, tar)
+            else:
+                msg = 'The following log directory does not exist: {}.\n\n' \
+                    'Skipping...'.format(log_dir)
+                print(msg)
+
+    def _tar_archived_log_files(self, log_dir, log_file, tar):
+        '''Add archived log files to tarfile
+
+        :param log_dir: unicode -- directory where log resides
+        :param log_file: unicode -- filename of log
+        :param tar: tarfile object -- tar where log files will be added
+        '''
+
+        for log in os.listdir(log_dir):
+            if fnmatch.fnmatch(log, log_file + '.[0-9].gz'):
+                self._add_file_to_tar(log_dir, log, tar)
+
+    def _add_file_to_tar(self, log_dir, log_file, tar):
+        '''Add a specific file to the tarfile
+
+        :param file_dir: unicode -- directory where file resides
+        :param file_name: unicode -- name of file to add to tarfile
+        :param tar: tarfile object -- tar where a specific file will be added
+        '''
+
+        log_path = os.path.join(log_dir, log_file)
+        if os.path.exists(log_path):
+            tar.add(log_path, arcname=log_file)
+        else:
+            msg = 'File to add to tarfile does not exist: {}.\n\n' \
+                'Skipping...'.format(log_path)
+            print(msg)
+
+    def produce_bundle(self):
+        '''Create a tarred, gzipped bundle of files useful for debugging
+
+        :param args: argparse args -- argument given by user
+        '''
+
+        bundle = os.path.join(self.tar_dest, 'debug_bundle.tar.gz')
+        with tarfile.open(bundle, 'w:gz') as tar:
+            if not self.no_config_files:
+                self._tar_config_files(tar)
+            if not self.no_log_files:
+                self._tar_log_files(tar)
+            self._save_pip_list(tar)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='Bundle important info for debugging purposes. The files '
+        'bundled here will be tarred and compressed, but not encrypted in '
+        'any way. This will be done best effort, meaning files that are not '
+        'found are simply logged to stdout and the script keeps going.\n\n'
+        '**WARNING**: do not publish the contents of the bundle in any public '
+        'location, as it may contain very sensitive information such as, '
+        'encryption keys, passwords, and usernames.',
+        formatter_class=RawTextHelpFormatter
+    )
+    parser.add_argument(
+        '--no-config-files',
+        action='store_true',
+        help='Include this option if you would not like configuration '
+        'files included in your bundle (they will by default).'
+    )
+    parser.add_argument(
+        '--no-log-files',
+        action='store_true',
+        help='Include this option if you would not like log files included '
+        'in your bundle (they will by default).'
+    )
+    parser.add_argument(
+        'tar_dest', help='Directory of bundle produced by this script.'
+    )
+    parser.add_argument(
+        '--log-dir',
+        default='/var/log/neutron/',
+        help='Set log directory location. Defaults to /var/log/neutron'
+    )
+    parser.add_argument(
+        '--config-dir',
+        default='/etc/neutron/',
+        help='Set config directory location. Defaults to /etc/neutron'
+    )
+    args = parser.parse_args()
+    bundle = DebugBundle(args)
+    bundle.produce_bundle()

--- a/f5_openstack_agent/utils/debug_bundler.py
+++ b/f5_openstack_agent/utils/debug_bundler.py
@@ -1,0 +1,157 @@
+# coding=utf-8
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import argparse
+import fnmatch
+import os
+import pip
+import tarfile
+
+
+class TarAdditionNonExtant(Exception):
+    pass
+
+
+class DebugBundle(object):
+
+    def __init__(self, command_args):
+        self.config_dir = command_args.config_dir
+        self.log_dir = command_args.log_dir
+        self.tar_dest = command_args.tar_dest
+        self.no_config_files = command_args.no_config_files
+        self.no_log_files = command_args.no_log_files
+
+    def _save_pip_list(self, tar):
+        '''Dump a pip list, containing packages and versions.
+
+        :param dest: unicode -- directory of dumped pip list
+        :param tar: tarfile object -- tar where pip list dump will be added
+        '''
+
+        pkgs = pip.get_installed_distributions()
+        sorted_pkgs = sorted(pkgs, key=lambda pkg: pkg._key)
+        sorted_pkg_names = [str(pkg) for pkg in sorted_pkgs]
+        pip_list_file = os.path.join(self.tar_dest, 'pip_list.txt')
+        with open(pip_list_file, 'w') as pip_file:
+            pip_file.write('\n'.join(sorted_pkg_names))
+        self._add_file_to_tar(self.tar_dest, 'pip_list.txt', tar)
+        os.remove(pip_list_file)
+        return sorted_pkgs
+
+    def _tar_config_files(self, tar):
+        '''Add config files specified to tarfile
+
+        :param tar: tarfile object -- tar where config files will be added
+        '''
+
+        lbaas_config_dir = os.path.join(self.config_dir, 'services', 'f5')
+        config_files = [
+            (self.config_dir, 'neutron.conf'),
+            (self.config_dir, 'neutron_lbaas.conf'),
+            (lbaas_config_dir, 'f5-openstack-agent.ini')
+        ]
+        for cfg_dir, cfg_file in config_files:
+            self._add_file_to_tar(cfg_dir, cfg_file, tar)
+
+    def _tar_log_files(self, tar):
+        '''Add log files specified to tarfile
+
+        :param tar: tarfile object -- tar where log files will be added
+        '''
+
+        log_files = [
+            (self.log_dir, 'server.log'),
+            (self.log_dir, 'f5-openstack-agent.log')
+        ]
+        for log_dir, log_file in log_files:
+            self._add_file_to_tar(log_dir, log_file, tar)
+            self._tar_archived_log_files(log_dir, log_file, tar)
+
+    def _tar_archived_log_files(self, log_dir, log_file, tar):
+        '''Add archived log files to tarfile
+
+        :param log_dir: unicode -- directory where log resides
+        :param log_file: unicode -- filename of log
+        :param tar: tarfile object -- tar where log files will be added
+        '''
+
+        for log in os.listdir(log_dir):
+            if fnmatch.fnmatch(log, log_file + '.[0-9].gz'):
+                self._add_file_to_tar(log_dir, log, tar)
+
+    def _add_file_to_tar(self, log_dir, log_file, tar):
+        '''Add a specific file to the tarfile
+
+        :param file_dir: unicode -- directory where file resides
+        :param file_name: unicode -- name of file to add to tarfile
+        :param tar: tarfile object -- tar where a specific file will be added
+        :raises: TarAdditionNonExtant
+        '''
+
+        log_path = os.path.join(log_dir, log_file)
+        if os.path.exists(log_path):
+            tar.add(log_path, arcname=log_file)
+        else:
+            msg = 'File to add to tarfile does not exist: {}'.format(log_path)
+            raise TarAdditionNonExtant(msg)
+
+    def produce_bundle(self):
+        '''Create a tarred, gzipped bundle of files useful for debugging
+
+        :param args: argparse args -- argument given by user
+        '''
+
+        bundle = os.path.join(self.tar_dest, 'debug_bundle.tar.gz')
+        with tarfile.open(bundle, 'w:gz') as tar:
+            if not self.no_config_files:
+                self._tar_config_files(tar)
+            if not self.no_log_files:
+                self._tar_log_files(tar)
+            self._save_pip_list(tar)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description='Bundle important info for troubleshooting purposes.'
+    )
+    parser.add_argument(
+        '--no-config-files',
+        action='store_true',
+        help='Include this option if you would not like configuration '
+        'files included in your bundle (they will by default).'
+    )
+    parser.add_argument(
+        '--no-log-files',
+        action='store_true',
+        help='Include this option if you would not like log files included '
+        'in your bundle (they will by default).'
+    )
+    parser.add_argument(
+        'tar_dest', help='Directory of bundle produced by this script.'
+    )
+    parser.add_argument(
+        '--log-dir',
+        default='/var/log/neutron/',
+        help='Override default log directory location.'
+    )
+    parser.add_argument(
+        '--config-dir',
+        default='/etc/neutron/',
+        help='Override default config directory location.'
+    )
+    args = parser.parse_args()
+    bundle = DebugBundle(args)
+    bundle.produce_bundle(args)

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ setuptools.setup(
     author_email="f5_openstack_agent@f5.com",
     data_files=[('/etc/neutron/services/f5', ['etc/neutron/services/f5/f5-openstack-agent.ini']),
                 ('/etc/init.d', ['etc/init.d/f5-oslbaasv2-agent']),
-                ('/usr/lib/systemd/system', ['lib/systemd/system/f5-openstack-agent.service'])],
+                ('/usr/lib/systemd/system', ['lib/systemd/system/f5-openstack-agent.service']),
+                ('/usr/bin/f5', ['bin/debug_bundler.py'])],
     packages=setuptools.find_packages(exclude=['*.test', '*.test.*', 'test*', 'test']),
     classifiers=[
         'Environment :: OpenStack',

--- a/test/functional/bin/test_debug_bundler.py
+++ b/test/functional/bin/test_debug_bundler.py
@@ -1,0 +1,200 @@
+# coding=utf-8
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import os
+import pytest
+import shutil
+import subprocess
+import tarfile
+
+
+SCRIPT_PATH = os.path.dirname(__file__)
+TAR_FILE_LIST = [
+    'neutron.conf', 'neutron_lbaas.conf', 'f5-openstack-agent.ini',
+    'server.log', 'f5-openstack-agent.log', 'pip_list.txt',
+    'server.log.1.gz', 'server.log.5.gz', 'f5-openstack-agent.log.1.gz'
+]
+BUNDLE_SCRIPT_PATH = '/usr/bin/f5/debug_bundler.py'
+
+
+def create_empty_file(file_path):
+    with open(file_path, 'w'):
+        pass
+
+
+@pytest.fixture
+def setup_bundle_logfiles(request):
+    log_path = os.path.join(SCRIPT_PATH, 'logs')
+    os.makedirs(log_path)
+    create_empty_file(os.path.join(log_path, 'server.log'))
+    create_empty_file(os.path.join(log_path, 'server.log.1.gz'))
+    create_empty_file(os.path.join(log_path, 'server.log.5.gz'))
+    create_empty_file(os.path.join(log_path, 'f5-openstack-agent.log'))
+    create_empty_file(os.path.join(log_path, 'f5-openstack-agent.log.1.gz'))
+
+    def teardown():
+        shutil.rmtree(log_path)
+
+    request.addfinalizer(teardown)
+    return log_path
+
+
+@pytest.fixture
+def setup_bundle_cfgfiles(request):
+    cfg_path = os.path.join(SCRIPT_PATH, 'cfgs')
+    os.makedirs(cfg_path)
+    lbaas_cfg = os.path.join(cfg_path, 'services', 'f5')
+    os.makedirs(lbaas_cfg)
+    create_empty_file(os.path.join(cfg_path, 'neutron.conf'))
+    create_empty_file(os.path.join(cfg_path, 'neutron_lbaas.conf'))
+    create_empty_file(os.path.join(lbaas_cfg, 'f5-openstack-agent.ini'))
+
+    def teardown():
+        shutil.rmtree(cfg_path)
+
+    request.addfinalizer(teardown)
+    return cfg_path
+
+
+@pytest.fixture
+def setup_bundle_test(request, setup_bundle_cfgfiles, setup_bundle_logfiles):
+    tar_dest = os.path.join(SCRIPT_PATH, 'output')
+    os.makedirs(tar_dest)
+
+    def teardown():
+        shutil.rmtree(tar_dest)
+
+    request.addfinalizer(teardown)
+    margs_dict = {
+        'tar_dest': tar_dest,
+        'log_dir': setup_bundle_logfiles,
+        'config_dir': setup_bundle_cfgfiles
+    }
+    return margs_dict
+
+
+def test_produce_bundle(setup_bundle_test):
+    margs = setup_bundle_test
+    subprocess.call(
+        [
+            'python',
+            BUNDLE_SCRIPT_PATH,
+            '--log-dir', margs['log_dir'],
+            '--config-dir', margs['config_dir'],
+            margs['tar_dest']
+        ]
+    )
+    tar_file = os.path.join(margs['tar_dest'], 'debug_bundle.tar.gz')
+    assert os.path.exists(tar_file) is True
+    assert tarfile.is_tarfile(tar_file) is True
+    with tarfile.open(tar_file, 'r:gz') as tar:
+        assert sorted(tar.getnames()) == sorted(TAR_FILE_LIST)
+
+
+def test_produce_bundle_no_cfgs(setup_bundle_test):
+    margs = setup_bundle_test
+    subprocess.call(
+        [
+            'python',
+            BUNDLE_SCRIPT_PATH,
+            '--log-dir', margs['log_dir'],
+            '--config-dir', margs['config_dir'],
+            '--no-config-files',
+            margs['tar_dest']
+        ]
+    )
+
+    tar_file = os.path.join(margs['tar_dest'], 'debug_bundle.tar.gz')
+    assert os.path.exists(tar_file) is True
+    assert tarfile.is_tarfile(tar_file) is True
+    with tarfile.open(tar_file, 'r:gz') as tar:
+        assert sorted(tar.getnames()) == \
+            sorted(
+                [
+                    'f5-openstack-agent.log', 'f5-openstack-agent.log.1.gz',
+                    'pip_list.txt', 'server.log', 'server.log.1.gz',
+                    'server.log.5.gz'
+                ]
+            )
+
+
+def test_produce_bundle_no_logs(setup_bundle_test):
+    margs = setup_bundle_test
+    subprocess.call(
+        [
+            'python',
+            BUNDLE_SCRIPT_PATH,
+            '--log-dir', margs['log_dir'],
+            '--config-dir', margs['config_dir'],
+            '--no-log-files',
+            margs['tar_dest']
+        ]
+    )
+    tar_file = os.path.join(margs['tar_dest'], 'debug_bundle.tar.gz')
+    assert os.path.exists(tar_file) is True
+    assert tarfile.is_tarfile(tar_file) is True
+    with tarfile.open(tar_file, 'r:gz') as tar:
+        assert sorted(tar.getnames()) == \
+            sorted(
+                [
+                    'f5-openstack-agent.ini', 'pip_list.txt',
+                    'neutron.conf', 'neutron_lbaas.conf'
+                ]
+            )
+
+
+def test_produce_bundle_file_not_found(setup_bundle_test):
+    margs = setup_bundle_test
+    os.remove(os.path.join(margs['log_dir'], 'server.log'))
+    output = subprocess.check_output(
+        [
+            'python',
+            BUNDLE_SCRIPT_PATH,
+            '--log-dir', margs['log_dir'],
+            '--config-dir', margs['config_dir'],
+            margs['tar_dest']
+        ]
+    )
+    print(output)
+    assert 'File to add to tarfile does not exist:' in output
+    assert 'server.log' in output
+
+
+def test_produce_bundle_subprocess(setup_bundle_test):
+    margs = setup_bundle_test
+    subprocess.call(
+        [
+            'python',
+            BUNDLE_SCRIPT_PATH,
+            '--log-dir', margs['log_dir'],
+            '--config-dir', margs['config_dir'],
+            margs['tar_dest']
+        ]
+    )
+    tar_file = os.path.join(margs['tar_dest'], 'debug_bundle.tar.gz')
+    assert os.path.exists(margs['tar_dest']) is True
+    with tarfile.open(tar_file, 'r:gz') as tar:
+        assert sorted(tar.getnames()) == sorted(TAR_FILE_LIST)
+        tar.extract('pip_list.txt', margs['tar_dest'])
+        with open(
+                os.path.join(margs['tar_dest'], 'pip_list.txt'), 'r'
+        ) as pip_file:
+            assert os.stat(
+                os.path.join(margs['tar_dest'], 'pip_list.txt')
+            ).st_size > 0
+            # One more check for good measure
+            assert len(pip_file.read()) > 0

--- a/test/functional/utils/test_debug_bundler.py
+++ b/test/functional/utils/test_debug_bundler.py
@@ -1,0 +1,153 @@
+# coding=utf-8
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5_openstack_agent.utils.debug_bundler import DebugBundle
+from f5_openstack_agent.utils.debug_bundler import TarAdditionNonExtant
+
+import os
+import pytest
+import shutil
+import subprocess
+import tarfile
+
+
+SCRIPT_PATH = os.path.dirname(__file__)
+TAR_FILE_LIST = [
+    'neutron.conf', 'neutron_lbaas.conf', 'f5-openstack-agent.ini',
+    'server.log', 'f5-openstack-agent.log', 'pip_list.txt',
+    'server.log.1.gz', 'server.log.5.gz', 'f5-openstack-agent.log.1.gz'
+]
+
+
+class MockArgs(object):
+    def __init__(self, tar_dest, log_dir, cfg_dir, no_cfg, no_log):
+        self.tar_dest = tar_dest
+        self.log_dir = log_dir
+        self.config_dir = cfg_dir
+        self.no_config_files = no_cfg
+        self.no_log_files = no_log
+
+
+def create_empty_file(file_path):
+    with open(file_path, 'w'):
+        pass
+
+
+@pytest.fixture
+def setup_bundle_logfiles(request):
+    log_path = os.path.join(SCRIPT_PATH, 'logs')
+    os.makedirs(log_path)
+    create_empty_file(os.path.join(log_path, 'server.log'))
+    create_empty_file(os.path.join(log_path, 'server.log.1.gz'))
+    create_empty_file(os.path.join(log_path, 'server.log.5.gz'))
+    create_empty_file(os.path.join(log_path, 'f5-openstack-agent.log'))
+    create_empty_file(os.path.join(log_path, 'f5-openstack-agent.log.1.gz'))
+
+    def teardown():
+        shutil.rmtree(log_path)
+
+    request.addfinalizer(teardown)
+    return log_path
+
+
+@pytest.fixture
+def setup_bundle_cfgfiles(request):
+    cfg_path = os.path.join(SCRIPT_PATH, 'cfgs')
+    os.makedirs(cfg_path)
+    lbaas_cfg = os.path.join(cfg_path, 'services', 'f5')
+    os.makedirs(lbaas_cfg)
+    create_empty_file(os.path.join(cfg_path, 'neutron.conf'))
+    create_empty_file(os.path.join(cfg_path, 'neutron_lbaas.conf'))
+    create_empty_file(os.path.join(lbaas_cfg, 'f5-openstack-agent.ini'))
+
+    def teardown():
+        shutil.rmtree(cfg_path)
+
+    request.addfinalizer(teardown)
+    return cfg_path
+
+
+@pytest.fixture
+def setup_bundle_test(request, setup_bundle_cfgfiles, setup_bundle_logfiles):
+    out_path = os.path.join(SCRIPT_PATH, 'output')
+    os.makedirs(out_path)
+
+    def teardown():
+        shutil.rmtree(out_path)
+
+    request.addfinalizer(teardown)
+    margs = MockArgs(
+        out_path, setup_bundle_logfiles, setup_bundle_cfgfiles, False, False
+    )
+    return margs, out_path
+
+
+def test_produce_bundle(setup_bundle_test):
+    margs, out_path = setup_bundle_test
+    bundle = DebugBundle(margs)
+    bundle.produce_bundle()
+    tar_file = os.path.join(out_path, 'debug_bundle.tar.gz')
+    assert os.path.exists(tar_file) is True
+    assert tarfile.is_tarfile(tar_file) is True
+    with tarfile.open(tar_file, 'r:gz') as tar:
+        assert sorted(tar.getnames()) == sorted(TAR_FILE_LIST)
+
+
+def test_produce_bundle_no_cfgs(setup_bundle_test):
+    margs, out_path = setup_bundle_test
+    margs.no_config_files = True
+    bundle = DebugBundle(margs)
+    bundle.produce_bundle()
+    tar_file = os.path.join(out_path, 'debug_bundle.tar.gz')
+    assert os.path.exists(tar_file) is True
+    assert tarfile.is_tarfile(tar_file) is True
+    with tarfile.open(tar_file, 'r:gz') as tar:
+        assert sorted(tar.getnames()) == \
+            sorted(
+                [
+                    'f5-openstack-agent.log', 'f5-openstack-agent.log.1.gz',
+                    'pip_list.txt', 'server.log', 'server.log.1.gz',
+                    'server.log.5.gz'
+                ]
+            )
+
+
+def test_produce_bundle_no_logs(setup_bundle_test):
+    margs, out_path = setup_bundle_test
+    margs.no_log_files = True
+    bundle = DebugBundle(margs)
+    bundle.produce_bundle()
+    tar_file = os.path.join(out_path, 'debug_bundle.tar.gz')
+    assert os.path.exists(tar_file) is True
+    assert tarfile.is_tarfile(tar_file) is True
+    with tarfile.open(tar_file, 'r:gz') as tar:
+        assert sorted(tar.getnames()) == \
+            sorted(
+                [
+                    'f5-openstack-agent.ini', 'pip_list.txt',
+                    'neutron.conf', 'neutron_lbaas.conf'
+                ]
+            )
+
+
+def test_produce_add_nonextant_file(setup_bundle_test):
+    margs, out_path = setup_bundle_test
+    os.remove(os.path.join(margs.log_dir, 'server.log'))
+    bundle = DebugBundle(margs)
+    with pytest.raises(TarAdditionNonExtant) as ex:
+        bundle.produce_bundle()
+    assert 'File to add to tarfile does not exist:' in ex.value.message
+    assert 'server.log' in ex.value.message


### PR DESCRIPTION
@jlongstaf 

#### What issues does this address?
Fixes #241 

#### What's this change do?
Implements a tool to bundle together interesting logs and config files for debugging purposes. The tools is installed into /usr/bin/f5 on the system where the f5-openstack-agent is installed.

#### Where should the reviewer start?
Start at the README.rst changes, then look at the tests for this tool in test/functional/bin

#### Any background context?
This tool will be useful for debugging issues with the agent or the BIG-IP device. We can bundle the common set of logs and config files into a compressed tarfile and have it ready for review if a test fails.
