### PR TITLE
If cert manager is not loaded agent should show as down

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/barbican_cert.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/barbican_cert.py
@@ -73,7 +73,7 @@ class BarbicanCertManager(cert_manager.CertManagerBase):
         max_attempts = 5
         sleep_time = 5
         n_attempts = 0
-        while n_attempts < max_attempts:
+        while n_attempts <= max_attempts:
             n_attempts += 1
             try:
                 if self.auth_version == "v3":

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -219,11 +219,6 @@ OPTS = [  # XXX maybe we should make this a dictionary
         help='Keystone authentication version (v2 or v3) for Barbican client.'
     ),
     cfg.StrOpt(
-        'barbican_endpoint',
-        default='http://BARBICAN_IP:9311',
-        help='Barbican endpoint to use when no authentication is specified.'
-    ),
-    cfg.StrOpt(
         'os_project_id',
         default='service',
         help='OpenStack project ID.'
@@ -406,13 +401,14 @@ class iControlDriver(LBaaSBaseDriver):
             try:
                 self.cert_manager = importutils.import_object(
                     self.conf.cert_manager, self.conf)
-            except ImportError:
-                self.cert_manager = None
-                LOG.error('Failed to import CertManager: %s'
-                          % self.conf.cert_manager)
-
-        if not self.cert_manager:
-            LOG.debug('No CertManager is configured.')
+            except ImportError as import_err:
+                LOG.error('Failed to import CertManager: %s.' %
+                          import_err.message)
+                raise
+            except Exception as err:
+                LOG.error('Failed to initialize CertManager. %s' % err.message)
+                # re-raise as ImportError to cause agent exit
+                raise ImportError(err.message)
 
         self.service_adapter = ServiceModelAdapter(self.conf)
         self.tenant_manager = BigipTenantManager(self.conf, self)


### PR DESCRIPTION
@richbrowne @mattgreene 
#### What issues does this address?
Fixes #211 

#### What's this change do?
Adds additional checks for Python library import errors, as well as adding a retry loop in case Keystone or Barbican are in the process of starting. Modified icontrol driver raise exception in case of errors so that agent will exit.

#### Where should the reviewer start?
Start with barbican_client.py then review icontrol_drvier.py

#### Any background context?
SAP requested retry loop as their services run in containers and may not be immediately available when agent starts.

Issues:
Fixes #211

Problem: Agent continues running if it fails to load barbican
client code.

Analysis: Added checks for import errors of Python libraries and
retry loop to ensure that client can talk with Barbican. Also,
added raising exception if error detected when initializing
barbican client code so that agent will not contiue.

Tests: Manual.