### PR TITLE
Agent ini file still says HA ScaleN is not supported

### DIFF
--- a/etc/neutron/services/f5/f5-openstack-agent.ini
+++ b/etc/neutron/services/f5/f5-openstack-agent.ini
@@ -86,8 +86,8 @@ periodic_interval = 10
 # Device can be required to be: 
 #
 # standalone - single device no HA
-# pair - active/standby two device HA(Not supported)
-# scalen - active device cluster(Not supported)
+# pair - active/standby two device HA
+# scalen - active device cluster
 # 
 # If the device is external, the devices must be onboarded for the 
 # appropriate HA mode or else the driver will not provision devices


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
Fixes #190 
Fixes #237 

#### What's this change do?
Removes obsolete 'Not supported' text

#### Where should the reviewer start?
f5-openstack-agent.ini

#### Any background context?
