### PR TITLE
Adding post-build step to test package install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,8 @@ deploy:
     api_key:
       secure: lTash9wrbwY5rsdl+ZfhYZ+Iqt2EdvZNqrq6FlLT6L4Wc4/RYCDLFwY2qrDb/n1XI3g/XhOCTyYMCu9URrw0HAY45HcAgOcEABNcAGfs/aBk5uB+l/V/42QKB+oAR9RR9qves5PJGBpJcBym9oswcxblBo8L6Z2o/yFzyGo3tHKVopTZoIw+hPqt5eAClPz8FX0ZIUZqH1iUiqMj1JJWvO9DRWECcjt4pr5HuY3u32qocQP4DUY1WQwI/R6iye5VPTAbWnsIBChJcJF1HAbsVa5IhQHhSo03RCJwZay/NF0btc9dKvIyrwqhQIUZX/RcDPvbs7TP02zg9O27HBAts2ivVRoBulN9dsHGiWGXMMQjavZGsdZ/TddKQxUvWoUKv+nHQyWGbyrE4smDHrex29NR/WgB/kHSAkNyUU1rZs8ALaoab5LY3Z0WmrFlHFs4HDb4YG+//0ODVppRe+Z8uFFnSsN4fjG9Xok+Tl+Gb9XM6/LNu+C+5DCG2VfPCnp2UGzmmo9Hm6ODhWauCR9DfJk1dUTVYb871I3ina0rwm2NQ04bKv0UHGZ2FWpq/KGx+jvXW8F54cWIluU/ze2MrJF/z9uKyTluEbDNBEr9/LaZoG22MBzHZB4xK0cEy+CSwGdOredCDCyEM7dsLlnE8ruiujbCAMvdjsHH4bu4MjU=
     file:
-      ${DIST_REPO}/rpms/build/f5-openstack-agent-${PKG_VERSION}-${PKG_RELEASE}.el7.noarch.rpm
-      ${DIST_REPO}/deb_dist/python-f5-openstack-agent_${PKG_VERSION}-${PKG_RELEASE}_1404_all.deb
+      - ${DIST_REPO}/rpms/build/f5-openstack-agent-${PKG_VERSION}-${PKG_RELEASE}.el7.noarch.rpm
+      - ${DIST_REPO}/deb_dist/python-f5-openstack-agent_${PKG_VERSION}-${PKG_RELEASE}_1404_all.deb
     skip_cleanup: true
     overwrite: true
     on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ script:
     - f5-openstack-agent-dist/scripts/package_agent.sh "ubuntu" "14.04"
     - sudo chown -R travis:travis ${DIST_REPO}/rpms/build
     - sudo chown -R travis:travis ${DIST_REPO}/deb_dist/*.deb
+after_success:
+  - f5-openstack-agent-dist/scripts/test_install.sh "redhat" "7"
 before_deploy:
   PKG_VERSION=$(python -c "import f5_openstack_agent; print f5_openstack_agent.__version__")
   PKG_RELEASE=$(python ${DIST_REPO}/scripts/get_version_release.py --release)

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
     - sudo chown -R travis:travis ${DIST_REPO}/deb_dist/*.deb
 after_success:
   - f5-openstack-agent-dist/scripts/test_install.sh "redhat" "7"
+  - f5-openstack-agent-dist/scripts/test_install.sh "ubuntu" "14.04"
 before_deploy:
   PKG_VERSION=$(python -c "import f5_openstack_agent; print f5_openstack_agent.__version__")
   PKG_RELEASE=$(python ${DIST_REPO}/scripts/get_version_release.py --release)

--- a/f5-openstack-agent-dist/Docker/redhat/install_test/Dockerfile.centos6
+++ b/f5-openstack-agent-dist/Docker/redhat/install_test/Dockerfile.centos6
@@ -1,0 +1,6 @@
+FROM centos:6
+
+RUN yum update -y && yum install rpm-build make python-setuptools python-requests -y
+
+COPY ./install_pkg.sh /
+

--- a/f5-openstack-agent-dist/Docker/redhat/install_test/Dockerfile.centos7
+++ b/f5-openstack-agent-dist/Docker/redhat/install_test/Dockerfile.centos7
@@ -1,0 +1,5 @@
+FROM centos:7
+
+RUN yum update -y && yum install git python-requests -y
+
+COPY ./fetch_and_install_deps.py /

--- a/f5-openstack-agent-dist/Docker/redhat/install_test/fetch_and_install_deps.py
+++ b/f5-openstack-agent-dist/Docker/redhat/install_test/fetch_and_install_deps.py
@@ -1,0 +1,148 @@
+#!/usr/bin/python
+
+import os
+import re
+import subprocess
+import sys
+
+f5_sdk_pattern = re.compile("^f5-sdk\s*=\s*(\d+\.\d+\.\d+)$")
+f5_icontrol_rest_pattern = re.compile(
+    "^f5-icontrol-rest\s*=\s*(\d+\.\d+\.\d+)$")
+
+
+def usage():
+    print "fetch_dependencies.py working_dir"
+
+def runCommand(cmd):
+    output = ""
+    print " -- %s" % (cmd)
+    try:
+        p = subprocess.Popen(cmd.split(),
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        (output) = p.communicate()[0]
+    except OSError, e:
+        print >>sys.stderr, "Execution failed: ",e
+
+    return (output, p.returncode)
+
+def fetch_agent_dependencies(dist_dir, version, release):
+    agent_pkg = "f5-openstack-agent-%s-%s.el7.noarch.rpm" % (version, release)
+
+    # Copy agent package to /tmp
+    cpCmd = "cp %s/rpms/build/%s /tmp" % (dist_dir, agent_pkg)
+    print "Copying agent package to /tmp install directory"
+    (output, status) = runCommand(cpCmd)
+    if status != 0:
+        print "Failed to copy f5-openstack-agent package"
+    else:
+        print "Success"
+
+    # Get the sdk requirement.
+    requiresCmd = "rpm -qRp %s/rpms/build/%s" % (dist_dir, agent_pkg)
+    print "Getting dependencies for %s." % (agent_pkg)
+    (output, status) = runCommand(requiresCmd)
+
+    if status != 0:
+        print "Can't get package dependencies for %s" % (agent_pkg)
+        return 1
+    else:
+        print "Success"
+    
+    for line in output.split('\n'):
+        m = f5_sdk_pattern.match(line)
+        if m:
+            f5_sdk_version = m.group(1)
+            break
+
+    if not f5_sdk_version:
+        print "Can't find f5-sdk dependency for %s" % (agent_pkg)
+        return 1
+
+    # Fetch the sdk package
+    github_sdk_url = (
+        "https://github.com/F5Networks/f5-common-python/releases/download/v%s" % (
+            f5_sdk_version)
+    )
+    f5_sdk_pkg = "f5-sdk-%s-1.el7.noarch.rpm" % (f5_sdk_version)
+    curlCmd = (
+        "curl -L -o /tmp/%s %s/f5-sdk-%s-1.el7.noarch.rpm" % (
+            f5_sdk_pkg, github_sdk_url, f5_sdk_version) )
+
+    print "Fetching f5-sdk package from github"
+    (output, status) = runCommand(curlCmd)
+
+    # Get the icontrol rest dependency
+    requiresCmd = "rpm -qRp /tmp/%s" % (f5_sdk_pkg)
+    print "Getting dependencies for %s." % (f5_sdk_pkg)
+    (output, status) = runCommand(requiresCmd)
+    if status != 0:
+        print "Failed to to get requirements for %s." % (f5_sdk_pkg)
+        return 1
+    else:
+        print "Success"
+
+    for line in output.split('\n'):
+        m = f5_icontrol_rest_pattern.match(line)
+        if m:
+            f5_icr_version = m.group(1)
+            break
+    if not f5_sdk_version:
+        print "Can't find f5-sdk dependency for %s" % (f5_sdk_pkg)
+        return 1
+
+    # Fectch the icontrol rest package
+    github_icr_url = (
+        "https://github.com/F5Networks/f5-icontrol-rest/releases/download/v%s" % (
+            f5_icr_version)
+    )
+    f5_icr_pkg = "f5-icontrol-rest-%s-1.el7.noarch.rpm" % (f5_icr_version)
+    curlCmd = (
+        "curl -L -o /tmp/%s %s/%s" % (
+            f5_icr_pkg, github_icr_url, f5_icr_pkg) )
+
+    print "Fetching f5-icontrol-reset package from github"
+    (output, status) = runCommand(curlCmd)
+
+    if status != 0:
+        print "Failed to to fetch f5-icontrol-rest package."
+        return 1
+    else:
+        print "Success"
+
+def install_agent_pkgs(repo):
+    installCmd = "rpm -ivh /tmp/*.rpm"
+    (output, status) = runCommand(installCmd)
+    if status != 0:
+        print "Agent install failed"
+        sys.exit(1)
+    
+
+def main(args):
+    if len(args) != 2:
+        usage()
+        sys.exit(1)
+
+    working_dir = os.path.normpath(args[1])
+    try:
+        os.chdir("/var/wdir")
+    except OSError, e:
+        print >>sys.stderr, "Can't change to directory %s (%s)" %  (working_dir, e)
+
+    dist_dir = os.path.join(working_dir, "f5-openstack-agent-dist")
+    version_tool = os.path.join(dist_dir, "scripts/get-version-release.py")
+
+    cmd = "%s --version --release" % (version_tool)
+    (output, status) = runCommand(cmd)
+    if status == 0:
+        (version, release) = output.rstrip().split()
+
+    # Get all files for the f5-openstack agent.
+    fetch_agent_dependencies(dist_dir, version, release)
+
+    # Instal from the tmp directory.
+    install_agent_pkgs("/tmp")
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/f5-openstack-agent-dist/Docker/ubuntu/install_test/Dockerfile.trusty
+++ b/f5-openstack-agent-dist/Docker/ubuntu/install_test/Dockerfile.trusty
@@ -1,0 +1,10 @@
+# Dockerfile
+FROM ubuntu:trusty
+
+RUN apt-get update -y && apt-get install software-properties-common -y
+RUN apt-add-repository cloud-archive:liberty
+RUN apt-get update -y && apt-get dist-upgrade -y --force-yes
+RUN apt-get install python-requests git curl -y --force-yes
+
+COPY ./fetch_and_install_deps.py /
+

--- a/f5-openstack-agent-dist/Docker/ubuntu/install_test/fetch_and_install_deps.py
+++ b/f5-openstack-agent-dist/Docker/ubuntu/install_test/fetch_and_install_deps.py
@@ -1,0 +1,155 @@
+#!/usr/bin/python
+
+import os
+import re
+import subprocess
+import sys
+
+f5_sdk_version_pattern = re.compile("^\s*Depends:\s+(?:.*)python-f5-sdk\s+\(=\s*(.*)\)(?:.*)$")
+f5_icr_version_pattern = re.compile("^\s*Depends:\s+(?:.*)python-f5-icontrol-rest\s+\(=\s*(.*)\)(?:.*)$")
+
+def usage():
+    print "fetch_dependencies.py working_dir"
+
+def runCommand(cmd):
+    output = ""
+    print " -- %s" % (cmd)
+    try:
+        p = subprocess.Popen(cmd.split(),
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        (output) = p.communicate()[0]
+    except OSError, e:
+        print >>sys.stderr, "Execution failed: ",e
+
+    return (output, p.returncode)
+
+def fetch_agent_dependencies(dist_dir, version, release):
+    agent_pkg = "python-f5-openstack-agent_%s-%s_1404_all.deb" % (version, release)
+
+    # Copy agent package to /tmp
+    cpCmd = "cp %s/deb_dist/%s /tmp" % (dist_dir, agent_pkg)
+    print "Copying agent package to /tmp install directory"
+    (output, status) = runCommand(cpCmd)
+    if status != 0:
+        print "Failed to copy python-f5-openstack-agent package"
+    else:
+        print "Success"
+
+    # Get the sdk requirement.
+    requiresCmd = "dpkg -I %s/deb_dist/%s" % (dist_dir, agent_pkg)
+    print "Getting dependencies for %s." % (agent_pkg)
+    (output, status) = runCommand(requiresCmd)
+
+    if status != 0:
+        print "Can't get package dependencies for %s" % (agent_pkg)
+        return 1
+    else:
+        print "Success"
+    
+    for line in output.split('\n'):
+        m = f5_sdk_version_pattern.match(line)
+        if m:
+            f5_sdk_version = m.group(1).strip(' ')
+            break
+
+    if not f5_sdk_version:
+        print "Can't find f5-sdk dependency for %s" % (agent_pkg)
+        return 1
+
+    (f5_sdk_version, f5_sdk_release) = f5_sdk_version.split('-')
+
+    # Fetch the sdk package
+    github_sdk_url = (
+        "https://github.com/F5Networks/f5-common-python/releases/download/v%s" % (
+            f5_sdk_version)
+    )
+    f5_sdk_pkg = "python-f5-sdk_%s-1_1404_all.deb" % (f5_sdk_version)
+    curlCmd = (
+        "curl -L -o /tmp/%s %s/%s" % (
+            f5_sdk_pkg, github_sdk_url, f5_sdk_pkg) )
+
+    print "Fetching f5-sdk package from github"
+    (output, status) = runCommand(curlCmd)
+
+    # Get the icontrol rest dependency
+    requiresCmd = "dpkg -I /tmp/%s" % (f5_sdk_pkg)
+    print "Getting dependencies for %s." % (f5_sdk_pkg)
+    (output, status) = runCommand(requiresCmd)
+    if status != 0:
+        print "Failed to to get requirements for %s." % (f5_sdk_pkg)
+        return 1
+    else:
+        print "Success"
+
+    for line in output.split('\n'):
+        m = f5_icr_version_pattern.match(line)
+        if m:
+            f5_icr_version = m.group(1)
+            break
+    if not f5_icr_version:
+        print "Can't find f5-sdk dependency for %s" % (f5_sdk_pkg)
+        return 1
+    print f5_icr_version
+    (f5_icr_version, f5_icr_release) = f5_icr_version.split('-')
+
+    # Fectch the icontrol rest package
+    github_icr_url = (
+        "https://github.com/F5Networks/f5-icontrol-rest/releases/download/v%s" % (
+            f5_icr_version)
+    )
+    f5_icr_pkg = "python-f5-icontrol-rest_%s-1_1404_all.deb" % (f5_icr_version)
+    curlCmd = (
+        "curl -L -o /tmp/%s %s/%s" % (
+            f5_icr_pkg, github_icr_url, f5_icr_pkg) )
+
+    print "Fetching f5-icontrol-reset package from github"
+    (output, status) = runCommand(curlCmd)
+
+    if status != 0:
+        print "Failed to to fetch f5-icontrol-rest package."
+        return 1
+    else:
+        print "Success"
+
+    return [f5_icr_pkg, f5_sdk_pkg, agent_pkg]
+
+def install_agent_pkgs(repo, pkg_list):
+    for pkg in pkg_list:
+        installCmd = "dpkg -i /tmp/%s" % (pkg)
+        print "Installing: %s" % (pkg)
+        (output, status) = runCommand(installCmd)
+    if status != 0:
+        print "Agent install failed"
+        sys.exit(1)
+    else:
+        print "Success"
+
+def main(args):
+    if len(args) != 2:
+        usage()
+        sys.exit(1)
+
+    working_dir = os.path.normpath(args[1])
+    try:
+        os.chdir("/var/wdir")
+    except OSError, e:
+        print >>sys.stderr, "Can't change to directory %s (%s)" %  (working_dir, e)
+
+    dist_dir = os.path.join(working_dir, "f5-openstack-agent-dist")
+    version_tool = os.path.join(dist_dir, "scripts/get-version-release.py")
+
+    cmd = "%s --version --release" % (version_tool)
+    (output, status) = runCommand(cmd)
+    if status == 0:
+        (version, release) = output.rstrip().split()
+
+    # Get all files for the f5-openstack agent.
+    packages = fetch_agent_dependencies(dist_dir, version, release)
+
+    # Instal from the tmp directory.
+    install_agent_pkgs("/tmp", packages)
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/f5-openstack-agent-dist/deb_dist/stdeb.cfg
+++ b/f5-openstack-agent-dist/deb_dist/stdeb.cfg
@@ -1,3 +1,3 @@
 [DEFAULT]
 Depends:
-	python-f5-sdk (=1.0.2-1)
+	python-f5-sdk (=1.1.0-1)

--- a/f5-openstack-agent-dist/scripts/test_install.sh
+++ b/f5-openstack-agent-dist/scripts/test_install.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -ex
+
+OS_TYPE=$1
+OS_VERSION=$2
+PKG_NAME="f5-openstack-agent"
+DIST_DIR="${PKG_NAME}-dist"
+
+BUILD_CONTAINER="${OS_TYPE}${OS_VERSION}-${PKG_NAME}-pkg-tester"
+WORKING_DIR="/var/wdir"
+
+if [[ ${OS_TYPE} == "redhat" ]]; then
+	CONTAINER_TYPE="centos"
+elif [[ ${OS_TYPE} == "ubuntu" ]]; then
+	CONTAINER_TYPE="ubuntu"
+else
+	echo "Unsupported target OS (${OS_TYPE})"
+	exit 1
+fi
+
+DOCKER_DIR="${DIST_DIR}/Docker/${OS_TYPE}/install_test"
+DOCKER_FILE="${DOCKER_DIR}/Dockerfile.${CONTAINER_TYPE}${OS_VERSION}"
+
+docker build -t ${BUILD_CONTAINER} -f ${DOCKER_FILE} ${DOCKER_DIR}
+docker run --privileged --rm -v $(pwd):${WORKING_DIR} ${BUILD_CONTAINER} /usr/bin/python \
+	   /fetch_and_install_deps.py ${WORKING_DIR}
+
+exit 0

--- a/f5-openstack-agent-dist/scripts/test_install.sh
+++ b/f5-openstack-agent-dist/scripts/test_install.sh
@@ -9,16 +9,21 @@ BUILD_CONTAINER="${OS_TYPE}${OS_VERSION}-${PKG_NAME}-pkg-tester"
 WORKING_DIR="/var/wdir"
 
 if [[ ${OS_TYPE} == "redhat" ]]; then
-	CONTAINER_TYPE="centos"
+	CONTAINER_TYPE="centos${OS_VERSION}"
 elif [[ ${OS_TYPE} == "ubuntu" ]]; then
-	CONTAINER_TYPE="ubuntu"
+	if [[ ${OS_VERSION} == "14.04" ]]; then
+		CONTAINER_TYPE="trusty"
+	else
+		echo "Only Trusty release currently supported"
+		exit 1
+	fi
 else
 	echo "Unsupported target OS (${OS_TYPE})"
 	exit 1
 fi
 
 DOCKER_DIR="${DIST_DIR}/Docker/${OS_TYPE}/install_test"
-DOCKER_FILE="${DOCKER_DIR}/Dockerfile.${CONTAINER_TYPE}${OS_VERSION}"
+DOCKER_FILE="${DOCKER_DIR}/Dockerfile.${CONTAINER_TYPE}"
 
 docker build -t ${BUILD_CONTAINER} -f ${DOCKER_FILE} ${DOCKER_DIR}
 docker run --privileged --rm -v $(pwd):${WORKING_DIR} ${BUILD_CONTAINER} /usr/bin/python \

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_rpm]
-requires =  f5-sdk == 1.0.2 
+requires =  f5-sdk == 1.1.0

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setuptools.setup(
             'f5-oslbaasv2-agent = f5_openstack_agent.lbaasv2.drivers.bigip.agent:main'
         ]
     },
-    install_requires=['f5-sdk==1.0.2']
+    install_requires=['f5-sdk==1.1.0']
 )
 


### PR DESCRIPTION
@mattgreene 
#### What issues does this address?
This issue address a Jira story to build package install tests into the Travis
build.

#### What's this change do?
After the RPMS and debs are successfully built, travis launches containers to test the
installation of the f5-openstack-agent package and its dependencies: f5-icontrol-rest-python
and f5-common-python.

#### Where should the reviewer start?
Start with the test_install script in f5-openstack-agent-dist/scripts.
