### PR TITLE
Agent should run as neutron user instead of root

### DIFF
--- a/f5-openstack-agent-dist/Docker/redhat/7/build-rpms.sh
+++ b/f5-openstack-agent-dist/Docker/redhat/7/build-rpms.sh
@@ -7,6 +7,7 @@ DIST_DIR="${PKG_NAME}-dist"
 RPMBUILD_DIR="rpmbuild"
 OS_VERSION=7
 DEST_DIR="${SRC_DIR}/${DIST_DIR}"
+PRE_INSTALL_SCRIPT=${DIST_DIR}/rpms/scripts/f5-openstack-agent-preinstall.sh
 
 # The version is embedded in the package.
 pushd ${SRC_DIR}
@@ -31,7 +32,7 @@ python setup.py build bdist_rpm --rpm-base rpmbuild
 echo "%_topdir ${buildroot}/rpmbuild" > ~/.rpmmacros
 
 # Create a .spec file to use as the package template.
-python setup.py bdist_rpm --spec-only --dist-dir rpmbuild/SPECS
+python setup.py bdist_rpm --spec-only --dist-dir rpmbuild/SPECS --pre-install ${PRE_INSTALL_SCRIPT}
 echo "%config /etc/neutron/services/f5/f5-openstack-agent.ini" >> rpmbuild/SPECS/f5-openstack-agent.spec
 
 rpmbuild -ba rpmbuild/SPECS/f5-openstack-agent.spec

--- a/f5-openstack-agent-dist/rpms/scripts/f5-openstack-agent-preinstall.sh
+++ b/f5-openstack-agent-dist/rpms/scripts/f5-openstack-agent-preinstall.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/bash -ex
+
+AGENT_LOG="/var/log/neutron/f5-openstack-agent.log"
+if [[ -f ${AGENT_LOG} ]]; then
+	owner="$(stat --format '%U' ${AGENT_LOG})"
+	id neutron >/dev/null 2>&1
+	has_user_neutron=$?
+	if [[ ${owner} == 'root' && ${has_user_neutron} == 0 ]]; then
+		chown neutron:neutron ${AGENT_LOG}
+	fi
+fi

--- a/lib/systemd/system/f5-openstack-agent.service
+++ b/lib/systemd/system/f5-openstack-agent.service
@@ -4,7 +4,7 @@ After=syslog.target network.target
 Requires=network.target
 
 [Service]
-#User=neutron
+User=neutron
 ExecStart=/usr/bin/f5-oslbaasv2-agent --log-file /var/log/neutron/f5-openstack-agent.log --config-file /etc/neutron/neutron.conf --config-file /etc/neutron/services/f5/f5-openstack-agent.ini
 Restart=always
 


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
Fixes #227

#### What's this change do?
Changes the systemd user to Neutron.  Adds a pre-install
script in the rpm to change the user of the logfile if it exists.
This way if the agent was run as root prior to install of the 
rpm, 

#### Where should the reviewer start?

#### Any background context?

Issues:
Fixes #227

Problem:
Service definition for f5-openstack-agent currently run as root. It is correct,
and requested by a customer, to run as user 'neutron'.

Analysis:
Change the service definition to uncomment the user neutron.  Change
the pre-install script to modify the log file ownership if it already
exists.

Tests:
Ran installation tests.