### PR TITLE
Deleting a loadbalancer removes all elements in a tenant partition

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tenants.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tenants.py
@@ -122,11 +122,7 @@ class BigipTenantManager(object):
             LOG.error(
                 "Folder deletion exception for tenant partition %s occurred."
                 % tenant_id)
-            try:
-                self.system_helper.purge_folder_contents(bigip, partition)
-                self.system_helper.delete_folder(bigip, partition)
-            except Exception as err:
-                LOG.exception("%s" % err.message)
-                raise f5ex.SystemDeleteException(
-                    "Failed to destroy folder %s manual cleanup might be "
-                    "required." % partition)
+            LOG.exception("%s" % err.message)
+            raise f5ex.SystemDeleteException(
+                "Failed to destroy folder %s manual cleanup might be "
+                "required." % partition)


### PR DESCRIPTION
@jlongstaf @mattgreene 
#### What issues does this address?
Fixes #228

#### What's this change do?
It removes the logic to delete everything in a tenant partition when a loadbalancer goes away.
The expected fix should be implemented as a part of the multiagent story

#### Where should the reviewer start?
tenant.py

#### Any background context?

Issues:
Fixes #228

Problem:
Create two loadbalancers in the same tenant. Delete one of the loadbalancers.
The tenant folder and remaining loadbalancer are removed from the BIG-IP.

Analysis:
The tenant cleanup call expects to be called when the folder is ready to
be removed; however, it is called whenever a loadbalancer is removed.  If there
are remaining objects in the folder, they will be destroyed too.  The
tenant cleanup should not remove everything in the folder.

Tests: