### PR TITLE
Health monitor update (lbaas-healthmonitor-update) fails

### DIFF
--- a/f5-openstack-agent-dist/deb_dist/stdeb.cfg
+++ b/f5-openstack-agent-dist/deb_dist/stdeb.cfg
@@ -1,3 +1,3 @@
 [DEFAULT]
 Depends:
-	python-f5-sdk (=1.1.0-1)
+	python-f5-sdk (=1.2.0-1)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/cluster_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/cluster_manager.py
@@ -36,12 +36,12 @@ class ClusterManager(object):
     def disable_auto_sync(self, device_group_name, bigip, partition='Common'):
         dg = bigip.tm.cm.device_groups.device_group.load(
             name=device_group_name, partition=partition)
-        dg.update(autoSync='disabled')
+        dg.modify(autoSync='disabled')
 
     def enable_auto_sync(self, device_group_name, bigip, partition='Common'):
         dg = bigip.tm.cm.device_groups.device_group.load(
             name=device_group_name, partition=partition)
-        dg.update(autoSync='enabled')
+        dg.modify(autoSync='enabled')
 
     def get_sync_status(self, bigip):
         sync_status = bigip.tm.cm.sync_status

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
@@ -176,7 +176,7 @@ class ListenerServiceBuilder(object):
             v = bigip.tm.ltm.virtuals.virtual
             if v.exists(name=vip["name"], partition=vip["partition"]):
                 obj = v.load(name=vip["name"], partition=vip["partition"])
-                obj.update(**vip)
+                obj.modify(**vip)
 
     def update_session_persistence(self, service, bigips):
         """Update session persistence for virtual server.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
@@ -227,7 +227,9 @@ class ListenerServiceBuilder(object):
                 return
 
         # not found -- add profile (assumes Common partition)
-        p.profiles.create(name=profile_name, context=context)
+        p.profiles.create(name=profile_name,
+                          partition='Common',
+                          context=context)
         LOG.debug("Created profile %s" % profile_name)
 
     def _add_cookie_persist_rule(self, vip, persistence, bigip):
@@ -360,7 +362,7 @@ class ListenerServiceBuilder(object):
             # see if profile exists
             for profile in profiles:
                 if profile.name == profile_name:
-                    pr = p.profiles.load(name=profile_name)
+                    pr = p.profiles.load(name=profile_name, partition='Common')
                     pr.delete()
                     LOG.debug("Deleted profile %s" % profile.name)
                     return

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
@@ -313,7 +313,7 @@ class NetworkHelper(object):
 
         existing_vlans.append(name)
         rd.vlans = existing_vlans
-        rd.update()
+        rd.modify()
         return True
 
     @log_helpers.log_method_call
@@ -330,7 +330,7 @@ class NetworkHelper(object):
             return False
         existing_vlans.append(name)
         rd.vlans = existing_vlans
-        rd.update()
+        rd.modify()
         return True
 
     @log_helpers.log_method_call
@@ -522,7 +522,7 @@ class NetworkHelper(object):
             tunnel = bigip.tm.net.fdb.tunnels.tunnel
             if tunnel.exists(name=tunnel_name, partition=partition):
                 obj = tunnel.load(name=tunnel_name, partition=partition)
-                obj.update(records=records)
+                obj.modify(records=records)
                 if const.FDB_POPULATE_STATIC_ARP:
                     # arp_ip_address is typcially member address.
                     if arp_ip_address:
@@ -581,7 +581,7 @@ class NetworkHelper(object):
             tunnel = bigip.tm.net.fdb.tunnels.tunnel
             if tunnel.exists(name=tunnel_name, partition=partition):
                 obj = tunnel.load(name=tunnel_name, partition=partition)
-                obj.update(records=records)
+                obj.modify(records=records)
         except HTTPError as err:
             LOG.error("Error updating tunnel %s. "
                       "Repsponse status code: %s. Response "
@@ -626,7 +626,7 @@ class NetworkHelper(object):
             # default to 11.6.0, so we expect it to work in 12 and greater.
             if tunnel.exists(name=tunnel_name, partition=folder):
                 obj = tunnel.load(name=tunnel_name, partition=folder)
-                obj.update(records=new_records)
+                obj.modify(records=new_records)
 
     @log_helpers.log_method_call
     def delete_fdb_entries(self, bigip, tunnel_name=None, fdb_entries=None):
@@ -655,7 +655,7 @@ class NetworkHelper(object):
             # default to 11.6.0, so we expect it to work in 12 and greater.
             if tunnel.exists(name=tunnel_name, partition=folder):
                 obj = tunnel.load(name=tunnel_name, partition=folder)
-                obj.update(records=new_records)
+                obj.modify(records=new_records)
 
             if const.FDB_POPULATE_STATIC_ARP:
                 for mac in arps_to_delete:
@@ -703,7 +703,7 @@ class NetworkHelper(object):
         try:
             t = bigip.tm.net.fdb.tunnels.tunnel
             obj = t.load(name=tunnel_name, partition=partition)
-            obj.update(records=None)
+            obj.modify(records=None)
         except HTTPError as err:
             LOG.error("Error deleting all fdb entries %s. "
                       "Repsponse status code: %s. Response "
@@ -731,7 +731,7 @@ class NetworkHelper(object):
                             partition=partition
                         )
 
-                    obj.update(records=[])
+                    obj.modify(records=[])
         except HTTPError as err:
             LOG.error("Error updating tunnel %s. "
                       "Repsponse status code: %s. Response "

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
@@ -172,7 +172,7 @@ class PoolServiceBuilder(object):
             if m.exists(name=urllib.quote(member["name"]), partition=part):
                 m = m.load(name=urllib.quote(member["name"]),
                            partition=part)
-                m.update(**member)
+                m.modify(**member)
 
     def _get_monitor_helper(self, service):
         monitor_type = self.service_adapter.get_monitor_type(service)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
@@ -135,7 +135,7 @@ class BigIPResourceHelper(object):
         if "partition" in model:
             partition = model["partition"]
         resource = self.load(bigip, name=model["name"], partition=partition)
-        resource.update(**model)
+        resource.modify(**model)
 
         return resource
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
@@ -237,7 +237,7 @@ class BigipSelfIpManager(object):
         try:
             obj = virtual_address.load(
                 name='0.0.0.0', partition=network_folder)
-            obj.update(trafficGroup=traffic_group)
+            obj.modify(trafficGroup=traffic_group)
         except Exception as err:
             LOG.exception(err)
             raise f5_ex.VirtualServerCreationException(

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
@@ -186,7 +186,7 @@ class BigipSnatManager(object):
                         partition=model["partition"]
                     )
                     snatpool.members.append(snatpool_member)
-                    snatpool.update()
+                    snatpool.modify()
 
             except Exception as err:
                 LOG.error("Create SNAT pool failed %s" % err.message)
@@ -297,7 +297,7 @@ class BigipSnatManager(object):
                 else:
                     LOG.debug('Snat pool is not empty - update snatpool')
                     try:
-                        snatpool.update()
+                        snatpool.modify()
                     except HTTPError as err:
                         LOG.error("Update SNAT pool failed %s" % err.message)
             except HTTPError as err:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/ssl_profile.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/ssl_profile.py
@@ -70,6 +70,7 @@ class SSLProfileHelper(object):
                       'cert': '/Common/' + certfilename,
                       'key': '/Common/' + keyfilename}]
             ssl_client_profile.create(name=name,
+                                      partition='Common',
                                       certKeyChain=chain,
                                       sniDefault=sni_default,
                                       defaultsFrom=parent_profile)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/system_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/system_helper.py
@@ -101,7 +101,7 @@ class SystemHelper(object):
         else:
             val = 'disable'
         db = bigip.tm.sys.dbs.db.load(name='iptunnel.configsync')
-        db.update(value=val)
+        db.modify(value=val)
 
     def get_provision_extramb(self, bigip):
         db = bigip.tm.sys.dbs.db.load(name='provision.extramb')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_rpm]
-requires =  f5-sdk == 1.1.0
+requires =  f5-sdk == 1.2.0

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setuptools.setup(
             'f5-oslbaasv2-agent = f5_openstack_agent.lbaasv2.drivers.bigip.agent:main'
         ]
     },
-    install_requires=['f5-sdk==1.1.0']
+    install_requires=['f5-sdk==1.2.0']
 )
 


### PR DESCRIPTION
@richbrowne @mattgreene 

#### What issues does this address?
Fixes #262 

#### What's this change do?
Replaces use of f5-sdk update() method with new modify() method. Changes dependency of f5-sdk to version 1.2.0.

#### Where should the reviewer start?
resource_helper.py

#### Any background context?
The SDK update() method does a PUT of all attributes of an object. If a caller first loads an object (i.e., REST GET) and tries to update an object with a subset of attributes (e.g., just change one attribute) all object attributes are sent in update() (REST PUT). This can cause a failure if one or more attributes are effectively read-only. The SDK now supports a modify() method which will only send those attributes explicitly passed in the call.

Issues:
Fixes #262

Problem: Updating health monitor generates an SDK exception.

Analysis: The f5-sdk sends the destination attribute, a read-only field,
causing an error. f5-sdk dev team added a new method, modify, which
only sends attributes explictly passed as method parameters, instead
of all attributes defined for an object. Changed use of f5-sdk update()
method to use new f5-sdk modify() method.

Tests: tempest apiv2 test suite