### PR TITLE
Listener creation service objects trigger l2 network operations in th…

### DIFF
--- a/devtools/Dockerfiles/test_base
+++ b/devtools/Dockerfiles/test_base
@@ -34,4 +34,3 @@ COPY ./f5-openstack-lbaasv2-driver/ /root/devenv/f5-openstack-lbaasv2-driver/
 RUN pip install /root/devenv/f5-openstack-lbaasv2-driver
 COPY ./f5-openstack-test/ /root/devenv/f5-openstack-test/
 RUN pip install /root/devenv/f5-openstack-test
-COPY /root_ssh/ /root/.ssh

--- a/devtools/HOWTO_run_dockertests.txt
+++ b/devtools/HOWTO_run_dockertests.txt
@@ -1,28 +1,38 @@
 My test setup works like this:
 
-    make a devenv directory on a system that can run docker
+    # make a devenv directory on a system that can run docker
+    mkdir devenv
 
     cd devenv
 
     git clone git@github.com:openstack/oslo.log.git
 
-    git@github.com:F5Networks/pytest-symbols.git
+    git clone git@github.com:F5Networks/pytest-symbols.git
 
-    git@github.com:F5Networks/f5-openstack-lbaasv2-driver.git
+    git clone git@github.com:F5Networks/f5-openstack-lbaasv2-driver.git
 
-    git@github.com:F5Networks/f5-openstack-test
+    git clone git@github.com:F5Networks/f5-openstack-test
 
-    git@github.com:F5Networks/f5-openstack-agent.git
+    git clone git@github.com:F5Networks/f5-openstack-agent.git
 
-    git@github.com:F5Networks/f5-common-python.git
+    git clone git@github.com:F5Networks/f5-common-python.git
 
-    run docker build -t test_base -f f5-openstack-agent/devtools/Dockerfiles/test_base .
+    docker build -t test_base -f f5-openstack-agent/devtools/Dockerfiles/test_base .
 
-    edit f5-openstack-agent/devtools/common_service_handler_env.json to have the address of your test device
+    # replace DEVICE_IP with the actual address of your test device
+    export DEVICE_IP=<address>
+    files=`grep -Rl DEVICE_IP --include=*.json *`
+    for f in $files; do
+        sed -i ".bak" "s/DEVICE_IP/$DEVICE_IP/g" $f
+    done
 
-    edit or remove the VOLUME directive from f5-openstack-agent/test/functional/neutronless/CD/Dockerfile to suit your purposes
+    edit or remove the VOLUME directive from f5-openstack-agent/test/functional/neutronless/*/Dockerfile to suit your purposes
 
-    edit the last line of f5-openstack-agent/test/functional/neutronless/CD/Dockerfile to customize how the tests will run (e.g. add ::test_loadbalancer_CD to the end of the line to run only that test)
+    edit the last line of f5-openstack-agent/test/functional/neutronless/*/Dockerfile to customize how the tests will run (e.g. add ::test_loadbalancer_CD to the end of the line to run only that test)
+
+    # example to run l2adjacent tests
+    export IMAGE_TAG=l2adjacent`date "+%s"` && \
+    docker build -t $IMAGE_TAG -f f5-openstack-agent/test/functional/neutronless/l2adjacent/Dockerfile .
 
     To change code in any of the related codebases... e.g. f5-common-python, simply change the code on the filesystem, and rerun the tests! The COPY directives in the Dockerfile ensure that local changes are added to the container image...
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/disconnected_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/disconnected_service.py
@@ -50,7 +50,8 @@ class DisconnectedServicePolling(object):
     def remove_obsolete_service_address(self, bigips, virtual,
                                         starting_dest, ending_dest):
         for bigip in bigips:
-            if starting_dest[bigip] != ending_dest[bigip]:
+            if (starting_dest[bigip] != ending_dest[bigip] and
+                    starting_dest[bigip]):
                 vac = bigip.tm.ltm.virtual_address_s
                 dest = basename(starting_dest[bigip])
                 nh = self.driver.disconnected_service.network_helper
@@ -81,8 +82,8 @@ class DisconnectedServicePolling(object):
                     continue
                 service = d.plugin_rpc.get_service_by_loadbalancer_id(id)
 
-                if (plugin_const.ACTIVE !=
-                        service['loadbalancer']['provisioning_status']):
+                if (service['loadbalancer']['provisioning_status'].upper() !=
+                        plugin_const.ACTIVE):
                     continue
 
                 if not d.disconnected_service.is_service_connected(service):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/disconnected_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/disconnected_service.py
@@ -18,6 +18,7 @@ from f5_openstack_agent.lbaasv2.drivers.bigip.network_helper import \
     NetworkHelper
 from neutron.plugins.common import constants as plugin_const
 from neutron_lbaas.services.loadbalancer import constants as lb_const
+from os.path import basename
 from oslo_log import helpers as log_helpers
 from oslo_log import log as logging
 from oslo_utils import timeutils
@@ -31,10 +32,34 @@ class DisconnectedServicePolling(object):
         self.enabled = (True if self.get_physical_network() else False)
         if self.enabled:
             greenthread.spawn(self.polling_thread)
-        self.start_time = {}
+        self.timer = {}
 
     def get_physical_network(self):
         return self.driver.conf.f5_network_segment_physical_network
+
+    def get_service_virtual_address(self, bigips, virtual):
+        va_table = {}
+        for bigip in bigips:
+            vsf = bigip.tm.ltm.virtuals.virtual
+            vs = vsf.load(
+                name=virtual['name'], partition=virtual['partition'])
+            destination = getattr(vs, 'destination', None)
+            va_table[bigip] = destination
+        return va_table
+
+    def remove_obsolete_service_address(self, bigips, virtual,
+                                        starting_dest, ending_dest):
+        for bigip in bigips:
+            if starting_dest[bigip] != ending_dest[bigip]:
+                vac = bigip.tm.ltm.virtual_address_s
+                dest = basename(starting_dest[bigip])
+                nh = self.driver.disconnected_service.network_helper
+                (vip_addr, vip_port) = nh.split_addr_port(dest)
+                if vac.virtual_address.exists(
+                        name=vip_addr, partition=virtual['partition']):
+                    va = vac.virtual_address.load(
+                        name=vip_addr, partition=virtual['partition'])
+                    va.delete()
 
     def scan(self):
         """Periodically scan for disconnected virtual servers.
@@ -51,43 +76,74 @@ class DisconnectedServicePolling(object):
             loadbalancer_ids = d.plugin_rpc.get_all_loadbalancers()
             for lb in loadbalancer_ids:
                 id = lb['lb_id']
+                if (id in self.timer and self.timer[id]['expired']):
+                    # LB is in error state, no need to check further
+                    continue
                 service = d.plugin_rpc.get_service_by_loadbalancer_id(id)
-                listeners = service.get('listeners', None)
-                service.pop('listeners', None)
-                provisioning_status = \
-                    service['loadbalancer']['provisioning_status']
+
+                if (plugin_const.ACTIVE !=
+                        service['loadbalancer']['provisioning_status']):
+                    continue
+
                 if not d.disconnected_service.is_service_connected(service):
-                    if id in self.start_time:
-                        if timeutils.is_older_than(
-                                self.start_time[id],
+                    if id in self.timer:
+                        if not timeutils.is_older_than(
+                                self.timer[id]['start'],
                                 d.conf.f5_network_segment_gross_timeout):
-                            LOG.error(
-                                "TIMEOUT: failed to connect loadbalancer %s "
-                                "to a real network after %d seconds" %
-                                (id, d.conf.f5_network_segment_gross_timeout))
-                            if (provisioning_status !=
-                                    plugin_const.PENDING_DELETE):
-                                d.plugin_rpc.update_loadbalancer_status(id)
-                    else:
-                        self.start_time[id] = timeutils.utcnow()
+                            continue
+                        self.timer[id]['expired'] = True
+                        LOG.error(
+                            "TIMEOUT: failed to connect loadbalancer %s "
+                            "to a real network after %d seconds" %
+                            (id, d.conf.f5_network_segment_gross_timeout))
                         d.plugin_rpc.update_loadbalancer_status(
-                            id, provisioning_status, lb_const.OFFLINE)
+                            id, plugin_const.ERROR, lb_const.OFFLINE)
+                        for listener in service['listeners']:
+                            if (listener['provisioning_status'] !=
+                                    plugin_const.PENDING_DELETE):
+                                d.plugin_rpc.update_listener_status(
+                                    listener['id'], plugin_const.ERROR,
+                                    lb_const.OFFLINE)
+                    else:
+                        self.timer[id] = {
+                            'start': timeutils.utcnow(),
+                            'expired': False
+                        }
+                        d.plugin_rpc.update_loadbalancer_status(
+                            id, plugin_const.ACTIVE, lb_const.OFFLINE)
                     continue
                 # service is connected in neutron, move all listeners for this
                 # loadbalancer onto a real network
-                for listener in listeners:
-                    service['listener'] = listener
-                    virtual = d.service_adapter.get_virtual_name(service)
+                for listener in service['listeners']:
+                    if (listener['provisioning_status'] ==
+                            plugin_const.PENDING_DELETE):
+                        continue
+                    test_service = {
+                        'listener': listener,
+                        'loadbalancer': service['loadbalancer']
+                    }
+                    virtual = d.service_adapter.get_virtual_name(test_service)
                     bigips = d.get_all_bigips()
                     if not d.disconnected_service.is_virtual_connected(
                             virtual, bigips):
                         LOG.debug("connecting %s to a real network" %
                                   virtual['name'])
-                        d.lbaas_builder.listener_builder.update_listener(
-                            service, bigips)
-                d.plugin_rpc.update_loadbalancer_status(
-                    id, provisioning_status, lb_const.ONLINE)
-                self.start_time.pop(id, None)
+                        service['loadbalancer']['provisioning_status'] = \
+                            plugin_const.PENDING_UPDATE
+                        # Save existing list of virtual addresses in case
+                        # a new one is created in the next step.  We need to
+                        # remove obsolete entries
+                        starting_dest = self.get_service_virtual_address(
+                            bigips, virtual)
+                        # if any virtual is not connected update the entire
+                        # service, but only once since the handler will run
+                        # through all listeners
+                        d._common_service_handler(service)
+                        ending_dest = self.get_service_virtual_address(
+                            bigips, virtual)
+                        self.remove_obsolete_service_address(
+                            bigips, virtual, starting_dest, ending_dest)
+                        break
 
     def polling_thread(self):
         while True:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1031,6 +1031,8 @@ class iControlDriver(LBaaSBaseDriver):
 
             LOG.debug("XXXXXXXXXX: traffic group created ")
 
+            # This loop will only run once.  Using while as a control-flow
+            # mechanism to flatten out the code by allowing breaks.
             while (self.network_builder):
                 if not self.disconnected_service.is_service_connected(service):
                     if self.disconnected_service_polling.enabled:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -104,6 +104,8 @@ class LBaaSBuilder(object):
             if listener['provisioning_status'] != plugin_const.PENDING_DELETE:
                 try:
                     self.listener_builder.create_listener(svc, bigips)
+                    listener['operating_status'] = \
+                        svc['listener']['operating_status']
                 except Exception as err:
                     listener['provisioning_status'] = plugin_const.ERROR
                     raise f5_ex.VirtualServerCreationException(err.message)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
@@ -20,6 +20,7 @@ from f5_openstack_agent.lbaasv2.drivers.bigip.disconnected_service import \
     DisconnectedService
 from f5_openstack_agent.lbaasv2.drivers.bigip import resource_helper
 from f5_openstack_agent.lbaasv2.drivers.bigip import ssl_profile
+from neutron_lbaas.services.loadbalancer import constants as lb_const
 
 LOG = logging.getLogger(__name__)
 
@@ -58,14 +59,21 @@ class ListenerServiceBuilder(object):
             tls['name'] = vip['name']
             tls['partition'] = vip['partition']
 
-        # start the virtual server on a disconnected network if the neutron
-        # network does not yet exist
+        service['listener']['operating_status'] = lb_const.ONLINE
+        # Hierarchical Port Binding mode adjustments
         if not self.disconnected_service.is_service_connected(service):
+            # start the virtual server on a disconnected network if the neutron
+            # network does not yet exist
             network_name = DisconnectedService.network_name
             vip['vlansEnabled'] = True
+            vip.pop('vlansDisabled', None)
             vip['vlans'] = [
                 '/%s/%s' % (vip['partition'], network_name)
             ]
+            # strip out references to network pieces that don't yet exist
+            vip.pop('sourceAddressTranslation', None)
+            # the listener is offline until we have a real network
+            service['listener']['operating_status'] = lb_const.OFFLINE
 
         network_id = service['loadbalancer']['network_id']
         for bigip in bigips:

--- a/test/functional/neutronless/l2adjacent/Dockerfile
+++ b/test/functional/neutronless/l2adjacent/Dockerfile
@@ -22,4 +22,5 @@ RUN pip install --upgrade /root/devenv/f5-openstack-agent
 COPY ./f5-common-python/ /root/devenv/f5-common-python/
 RUN pip install --upgrade /root/devenv/f5-common-python/
 WORKDIR /root/devenv/f5-openstack-agent/test/functional/neutronless/l2adjacent
-RUN py.test -v --symbols /root/devenv/f5-openstack-agent/test/functional/neutronless/l2adjacent/conf_symbols.json -v /root/devenv/f5-openstack-agent/test/functional/neutronless/l2adjacent/
+RUN py.test -v --symbols conf_symbols.json ./
+

--- a/test/test_disconnected.py
+++ b/test/test_disconnected.py
@@ -18,12 +18,12 @@ import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 from f5.bigip import BigIP
-from f5_openstack_agent.lbaasv2.drivers.bigip.resource_helper \
-    import BigIPResourceHelper
 from f5_openstack_agent.lbaasv2.drivers.bigip.disconnected_service import \
     DisconnectedService
 from f5_openstack_agent.lbaasv2.drivers.bigip.listener_service import \
     ListenerServiceBuilder
+from f5_openstack_agent.lbaasv2.drivers.bigip.resource_helper \
+    import BigIPResourceHelper
 from f5_openstack_agent.lbaasv2.drivers.bigip.resource_helper \
     import ResourceType
 from f5_openstack_agent.lbaasv2.drivers.bigip.service_adapter import \


### PR DESCRIPTION
@richbrowne @pjbreaux 

#### What issues does this address?
Fixes #242 

Problem:
DS feature attempts to construct all networking object with an empty seg-id, leading to code fault parsing the tunnel/VLAN name (must be a string).

Analysis:
This commit addresses issues for all tests in the new test_disconnected_service_creation suite.
1. Feature code
- update scanning logic to clean up state transitions
- explicitly update status for loadbalancer and all attached listeners
- make status updates consistent between feature enabled and disabled (LB starts in offline state and becomes online once a listener is attached)
- add virtual-address clean up since swinging from disconnected to real network leaves an obsolate VA object
- add ERROR message when feature is disabled and seg-id missing from service defintion as hint to operator

2. Test code
- update docker files and instructions to work on multiple platforms
- new method to force clean up during test setup to remove stale objects from previous test
- clone service objects to provide clean starting env without cross-test pollution
- updated tests to bake in final accepted URIs
- updated tests to reflect actual log text for various events
- corrected logic in a few tests to model proper feature usage

Tests:
All tests in test_disconnected_service_creation suite pass.