### PR TITLE
Add stats and capacity score calculation

### DIFF
--- a/etc/neutron/services/f5/f5-openstack-agent.ini
+++ b/etc/neutron/services/f5/f5-openstack-agent.ini
@@ -65,6 +65,47 @@ periodic_interval = 10
 #
 # environment_prefix = 'Project'
 #
+# An additional function of differentiated environments is the ability
+# for the agent to collect capacity data and return that to the scheduler
+# through configuration data. The agent will return one configuration
+# item called  environment_capacity_score. The score is the highest capacity
+# recorded on several collected statistics specified in the capacity_policy
+# setting. The capacity_policy is a dictionary where the key is the
+# metric name and the value is the max allowed value for that metric.
+# The score is determined simply by dividing the metric collected by
+# the max for that metric specified in the capacity_policy.
+#
+# When multiple environemnt_group_number designated group of agents are
+# available, and a service is created where the services' tenant is not
+# associated with a group, the scheduler will try to assign the service
+# to the group with the last recorded lowest environment_capacity_score.
+# If the services' tenant was associated with an agent where the
+# environment_group_number for all agents in the group are above capacity,
+# the new service will be associated with another group where capacity
+# is under the limit.
+#
+# WARNING - If you set the capacity_policy with a differentiated
+# environment, and all agents in all groups are at capacity, services
+# will no long be provisioned, but return errors.
+#
+# The following metrics are implemented by the icontrol_driver.iControlDriver:
+#
+# throughput - total throughput in bps of the TMOS devices
+# inbound_throughput - throughput in bps inbound to TMOS devices
+# outbound_throughput - throughput in bps outbound from TMOS devices
+# active_connections - number of concurrent active actions on a TMOS device
+# tenant_count - number of tenants associated with a TMOS device
+# node_count - number of nodes provisioned on a TMOS device
+# route_domain_count - number of route domains on a TMOS device
+# vlan_count - number of VLANs on a TMOS device
+# tunnel_count - number of GRE and VxLAN overlay tunnels on a TMOS device
+# ssltps - the current measured SSL TPS count on a TMOS device
+# clientssl_profile_count - the number of clientside SSL profiles defined
+#
+# You can specify one or multiple metrics.
+#
+# capacity_policy = throughput:1000000000, active_connections: 250000, route_domain_count: 512, tunnel_count: 2048
+#
 ###############################################################################
 #  Static Agent Configuration Setting
 ###############################################################################

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
@@ -764,3 +764,25 @@ class NetworkHelper(object):
         if decorator_index > 0:
             ip_address = ip_address[:decorator_index]
         return ip_address
+
+    def get_route_domain_count(self, bigip, partition=''):
+        """Return number of route domains, exluding route domain 0"""
+        route_domain_ids = self.get_route_domain_ids(
+            bigip, partition=partition)
+        if 0 in route_domain_ids:
+            route_domain_ids.remove(0)
+        return len(route_domain_ids)
+
+    def get_tunnel_count(self, bigip, partition='/'):
+        """Return sum of VXLAN and GRE tunnels"""
+        all_tunnels = bigip.tm.net.tunnels.tunnels.get_collection(
+            partition=partition)
+
+        tunnels = [item for item in all_tunnels if
+                   item.profile.find('vxlan') > 0 or
+                   item.profile.find('gre') > 0]
+        return len(tunnels)
+
+    def get_vlan_count(self, bigip, partition='/'):
+        """Return number of VLANs"""
+        return len(bigip.tm.net.vlans.get_collection(partition=partition))

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/ssl_profile.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/ssl_profile.py
@@ -77,3 +77,9 @@ class SSLProfileHelper(object):
         except Exception as err:
             LOG.error("Error creating SSL profile: %s" % err.message)
             raise SSLProfileError(err.message)
+
+    @staticmethod
+    def get_client_ssl_profile_count(bigip):
+        return len(
+            bigip.tm.ltm.profile.client_ssls.get_collection(
+                partition='Common'))

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/stat_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/stat_helper.py
@@ -25,7 +25,7 @@ LOG = logging.getLogger(__name__)
 
 class StatHelper(object):
     def get_global_statistics(self, bigip):
-        allstats = bigip.tm.sys.performance.all_stats.load()
+        allstats = bigip.tm.sys.performances.all_stats.load().__dict__
         if 'apiRawValues' in allstats:
             sr = {'Sys::Performance System': {
                 'System CPU Usage': {

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/system_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/system_helper.py
@@ -181,3 +181,10 @@ class SystemHelper(object):
             LOG.error(
                 ('Request to purge exempt folder %s ignored.' %
                  folder))
+
+    def get_tenant_folder_count(self, bigip):
+        folders = bigip.tm.sys.folders.get_collection()
+        # ignore '/' and 'Common'
+        tenants = [item for item in folders if item.name != '/' and
+                   item.name != 'Common']
+        return len(tenants)

--- a/test/test_stats.py
+++ b/test/test_stats.py
@@ -1,0 +1,123 @@
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+from pytest import symbols as symbol_data
+import requests
+requests.packages.urllib3.disable_warnings()
+
+from f5.bigip import ManagementRoot
+from f5_openstack_agent.lbaasv2.drivers.bigip import network_helper
+from f5_openstack_agent.lbaasv2.drivers.bigip import ssl_profile
+from f5_openstack_agent.lbaasv2.drivers.bigip import stat_helper
+from f5_openstack_agent.lbaasv2.drivers.bigip import system_helper
+
+class TestStats:
+    """
+    Test global stats used for calculating capacity score.
+
+    Test assumes a BIG-IP with single load balancer in an under cloud
+    environment using vxlan tunnels.
+    """
+    @pytest.fixture(scope="session")
+    def bigip(self):
+        return ManagementRoot(symbol_data.bigip_ip, 'admin', 'admin')
+
+    @pytest.fixture(scope="session")
+    def network_helper(self):
+        return network_helper.NetworkHelper()
+
+    @pytest.fixture(scope="session")
+    def stats_helper(self):
+        return stat_helper.StatHelper()
+
+    @pytest.fixture(scope="session")
+    def system_helper(self):
+        return system_helper.SystemHelper()
+
+    def test_get_global_statistics(self, bigip, stats_helper):
+        stats = stats_helper.get_global_statistics(bigip)
+        assert stats
+
+    def test_get_composite_score(self, bigip, stats_helper):
+        score = stats_helper.get_composite_score(bigip)
+        assert score > 0
+        print "Composite Score: " + str(score)
+
+    def test_get_mem_health_score(self, bigip, stats_helper):
+        score = stats_helper.get_mem_health_score(bigip)
+        assert score > 0
+        print "Memory Health Score: " + str(score)
+
+    def test_get_cpu_health_score(self, bigip, stats_helper):
+        score = stats_helper.get_cpu_health_score(bigip)
+        assert score > 0
+        print "CPU Health Score: " + str(score)
+
+    def test_get_active_connection_count(self, bigip, stats_helper):
+        score = stats_helper.get_active_connection_count(bigip)
+        assert score >= 0
+        print "Active Connection Count: " + str(score)
+
+    def test_get_active_SSL_TPS(self, bigip, stats_helper):
+        score = stats_helper.get_active_SSL_TPS(bigip)
+        assert score >= 0
+        print "Active SSL TPS: " + str(score)
+
+    def test_get_inbound_throughput(self, bigip, stats_helper):
+        score = stats_helper.get_inbound_throughput(bigip)
+        assert score > 0
+        print "Inbound Throughtput: " + str(score)
+
+    def test_get_outbound_throughput(self, bigip, stats_helper):
+        score = stats_helper.get_outbound_throughput(bigip)
+        assert score > 0
+        print "Outbound Throughtput: " + str(score)
+
+    def test_get_throughput(self, bigip, stats_helper):
+        score = stats_helper.get_throughput(bigip)
+        assert score >= 0
+        print "Throughput: " + str(score)
+
+    def test_get_node_count(self, bigip):
+        count = len(bigip.tm.ltm.nodes.get_collection())
+        assert count == 1
+        print "Node Count: " + str(count)
+
+    def test_get_clientssl_profile_count(self, bigip):
+        count = ssl_profile.SSLProfileHelper.get_client_ssl_profile_count(bigip)
+        assert count > 0
+        print "SSL Profile Count: " + str(count)
+
+    def test_get_tenant_count(self, bigip, system_helper):
+        count = system_helper.get_tenant_folder_count(bigip)
+        assert count == 1
+        print "Tenant Count: " + str(count)
+
+    def test_get_tunnel_count(self, bigip, network_helper):
+        count = network_helper.get_tunnel_count(bigip)
+        assert count == 1
+        print "Tunnel Count: " + str(count)
+
+
+    def test_get_vlan_count(self, bigip, network_helper):
+        count = network_helper.get_vlan_count(bigip)
+        assert count == 2
+        print "VLAN Count: " + str(count)
+
+    def test_get_route_domain_count(self, bigip, network_helper):
+        count = network_helper.get_route_domain_count(bigip)
+        assert count == 1
+        print "Route Domain Count: " + str(count)


### PR DESCRIPTION
@richbrowne 

#### What issues does this address?
Need capacity score calculation to support multi-agent scheduling.

Fixes #177 

#### What's this change do?
Adds functions to get stats needed for capacity score function; adds generate capacity function; adds capacity score section to agent ini file; adds tests of stats functions.

#### Where should the reviewer start?
Start with generate_capacity_score() in icontrol_driver.py

#### Any background context?
Supporting same functionality as in LBaaS v1.

Issues:
Fixes #177

Problem: Need capacity score caclulations for BIG=IPs in order
to support multi-agent scheduling.

Analysis: Added mutliple stat functions and generate_capacity_score()
function

Tests: test_stats.py