### PR TITLE
Add support for loadbalancer stats

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -835,10 +835,14 @@ class iControlDriver(LBaaSBaseDriver):
             pool_stats = self.lbaas_builder.get_pool_stats(service, stats)
 
             # convert to bytes
-            lb_stats['bytes_in'] = pool_stats['serverside.bitsIn']/8
-            lb_stats['bytes_out'] = pool_stats['serverside.bitsOut']/8
-            lb_stats['active_connections'] = pool_stats['serverside.curConns']
-            lb_stats['total_connections'] = pool_stats['serverside.totConns']
+            lb_stats[lb_const.STATS_IN_BYTES] = \
+                pool_stats['serverside.bitsIn']/8
+            lb_stats[lb_const.STATS_OUT_BYTES] = \
+                pool_stats['serverside.bitsOut']/8
+            lb_stats[lb_const.STATS_ACTIVE_CONNECTIONS] = \
+                pool_stats['serverside.curConns']
+            lb_stats[lb_const.STATS_TOTAL_CONNECTIONS] = \
+                pool_stats['serverside.totConns']
 
         except Exception as e:
             LOG.error("Error getting pool stats: %s", e.message)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -54,9 +54,7 @@ from f5_openstack_agent.lbaasv2.drivers.bigip.system_helper import \
     SystemHelper
 from f5_openstack_agent.lbaasv2.drivers.bigip.tenants import \
     BigipTenantManager
-from f5_openstack_agent.lbaasv2.drivers.bigip.utils import OBJ_PREFIX
 from f5_openstack_agent.lbaasv2.drivers.bigip.utils import serialized
-from f5_openstack_agent.lbaasv2.drivers.bigip.utils import strip_domain_address
 
 LOG = logging.getLogger(__name__)
 
@@ -826,105 +824,27 @@ class iControlDriver(LBaaSBaseDriver):
 
     @is_connected
     def get_stats(self, service):
-        """Get service stats"""
-        # use pool stats because the pool_id is the
-        # the service definition...
-        stats = {}
-        stats[lb_const.STATS_IN_BYTES] = 0
-        stats[lb_const.STATS_OUT_BYTES] = 0
-        stats[lb_const.STATS_ACTIVE_CONNECTIONS] = 0
-        stats[lb_const.STATS_TOTAL_CONNECTIONS] = 0
-        # add a members stats return dictionary
-        members = {}
-        for hostbigip in self.get_all_bigips():
-            # It appears that stats are collected for pools in a pending delete
-            # state which means that if those messages are queued (or delayed)
-            # it can result in the process of a stats request after the pool
-            # and tenant are long gone. Check if the tenant exists.
-            if not service['pool'] or not hostbigip.system.folder_exists(
-                    OBJ_PREFIX + service['pool']['tenant_id']):
-                return None
-            pool = service['pool']
-            pool_stats = hostbigip.pool.get_statistics(
-                name=pool['id'],
-                folder=pool['tenant_id'],
-                config_mode=self.conf.icontrol_config_mode)
-            if 'STATISTIC_SERVER_SIDE_BYTES_IN' in pool_stats:
-                stats[lb_const.STATS_IN_BYTES] += \
-                    pool_stats['STATISTIC_SERVER_SIDE_BYTES_IN']
-                stats[lb_const.STATS_OUT_BYTES] += \
-                    pool_stats['STATISTIC_SERVER_SIDE_BYTES_OUT']
-                stats[lb_const.STATS_ACTIVE_CONNECTIONS] += \
-                    pool_stats['STATISTIC_SERVER_SIDE_CURRENT_CONNECTIONS']
-                stats[lb_const.STATS_TOTAL_CONNECTIONS] += \
-                    pool_stats['STATISTIC_SERVER_SIDE_TOTAL_CONNECTIONS']
-                # are there members to update status
-                if 'members' in service:
-                    # only query BIG-IP® pool members if they
-                    # not in a state indicating provisioning or error
-                    # provisioning the pool member
-                    some_members_require_status_update = False
-                    update_if_status = [plugin_const.ACTIVE,
-                                        plugin_const.DOWN,
-                                        plugin_const.INACTIVE]
-                    if plugin_const.ACTIVE not in update_if_status:
-                        update_if_status.append(plugin_const.ACTIVE)
+        lb_stats = {}
+        stats = ['serverside.bitsIn',
+                 'serverside.bitsOut',
+                 'serverside.curConns',
+                 'serverside.totConns']
 
-                    for member in service['members']:
-                        if member['status'] in update_if_status:
-                            some_members_require_status_update = True
-                    # are we have members who are in a
-                    # state to update there status
-                    if some_members_require_status_update:
-                        # query pool members on each BIG-IP
-                        monitor_states = \
-                            hostbigip.pool.get_members_monitor_status(
-                                name=pool['id'],
-                                folder=pool['tenant_id'],
-                                config_mode=self.conf.icontrol_config_mode
-                            )
-                        for member in service['members']:
-                            if member['status'] in update_if_status:
-                                # create the entry for this
-                                # member in the return status
-                                # dictionary set to ACTIVE
-                                if not member['id'] in members:
-                                    members[member['id']] = \
-                                        {'status': plugin_const.INACTIVE}
-                                # check if it down or up by monitor
-                                # and update the status
-                                for state in monitor_states:
-                                    # matched the pool member
-                                    # by address and port number
-                                    if member['address'] == \
-                                            strip_domain_address(
-                                            state['addr']) and \
-                                            int(member['protocol_port']) == \
-                                            int(state['port']):
-                                        # if the monitor says member is up
-                                        if state['state'] == \
-                                                'MONITOR_STATUS_UP' or \
-                                           state['state'] == \
-                                                'MONITOR_STATUS_UNCHECKED':
-                                            # set ACTIVE as long as the
-                                            # status was not set to 'DOWN'
-                                            # on another BIG-IP
-                                            if members[
-                                                member['id']]['status'] != \
-                                                    'DOWN':
-                                                if member['admin_state_up']:
-                                                    members[member['id']][
-                                                        'status'] = \
-                                                        plugin_const.ACTIVE
-                                                else:
-                                                    members[member['id']][
-                                                        'status'] = \
-                                                        plugin_const.INACTIVE
-                                        else:
-                                            members[member['id']]['status'] = \
-                                                plugin_const.DOWN
-        stats['members'] = members
-        return stats
+        try:
+            # sum pool stats for all BIG-IPs
+            pool_stats = self.lbaas_builder.get_pool_stats(service, stats)
+
+            # convert to bytes
+            lb_stats['bytes_in'] = pool_stats['serverside.bitsIn']/8
+            lb_stats['bytes_out'] = pool_stats['serverside.bitsOut']/8
+            lb_stats['active_connections'] = pool_stats['serverside.curConns']
+            lb_stats['total_connections'] = pool_stats['serverside.totConns']
+
+        except Exception as e:
+            LOG.error("Error getting pool stats: %s", e.message)
+
+        finally:
+            return lb_stats
 
     @serialized('remove_orphans')
     def remove_orphans(self, all_loadbalancers):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py
@@ -57,7 +57,7 @@ class LBaaSBaseDriver(object):
         raise NotImplementedError()
 
     def get_stats(self, service):
-        """Get Stats for a Pool Service """
+        """Get Stats for a loadbalancer Service """
         raise NotImplementedError()
 
     def exists(self, service):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
@@ -104,6 +104,19 @@ class LBaaSv2PluginRPC(object):
         )
 
     @log_helpers.log_method_call
+    def update_loadbalancer_stats(self,
+                                  lb_id,
+                                  stats):
+        """Update the database with loadbalancer stats."""
+        return self._cast(
+            self.context,
+            self._make_msg('update_loadbalancer_stats',
+                           loadbalancer_id=lb_id,
+                           stats=stats),
+            topic=self.topic
+        )
+
+    @log_helpers.log_method_call
     def loadbalancer_destroyed(self, loadbalancer_id):
         """Delete the loadbalancer from the database."""
         return self._cast(

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
@@ -185,3 +185,38 @@ class PoolServiceBuilder(object):
         else:
             hm = self.http_mon_helper
         return hm
+
+    def get_stats(self, service, bigips, stats):
+        """Return stat values for a single pool.
+
+        Stats to collect are defined as an array of strings in input stats.
+        Values are summed across one or more BIG-IPs defined in input bigips.
+
+        :param service: Has pool name/partition
+        :param bigips: One or more BIG-IPs to get pool stats from.
+        :param stats: Array of strings that define which stats to collect.
+        :return: A dict with key/value pairs for each stat defined in
+        input stats.
+        """
+        collected_stats = {}
+        pool = self.service_adapter.get_pool(service)
+        part = pool["partition"]
+        for bigip in bigips:
+            try:
+                # get pool, then its stats
+                p = self.pool_helper.load(bigip,
+                                          name=pool["name"],
+                                          partition=part)
+                pool_stats = p.stats.load()
+
+                # add stats defined in input stats array
+                for stat in stats:
+                    if stat in pool_stats.entries:
+                        collected_stats[stat] = \
+                            pool_stats.entries[stat]['value']
+
+            except Exception as e:
+                # log error but continue on
+                LOG.error("Error getting pool stats: %s", e.message)
+
+        return collected_stats

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
@@ -199,21 +199,18 @@ class PoolServiceBuilder(object):
         input stats.
         """
         collected_stats = {}
+        for stat in stats:
+            collected_stats[stat] = 0
+
         pool = self.service_adapter.get_pool(service)
         part = pool["partition"]
         for bigip in bigips:
             try:
-                # get pool, then its stats
-                p = self.pool_helper.load(bigip,
-                                          name=pool["name"],
-                                          partition=part)
-                pool_stats = p.stats.load()
-
-                # add stats defined in input stats array
+                pool_stats = self.pool_helper.get_stats(
+                    bigip, name=pool["name"], partition=part)
                 for stat in stats:
-                    if stat in pool_stats.entries:
-                        collected_stats[stat] = \
-                            pool_stats.entries[stat]['value']
+                    if stat in pool_stats:
+                        collected_stats[stat] += pool_stats[stat]
 
             except Exception as e:
                 # log error but continue on

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
@@ -207,7 +207,7 @@ class PoolServiceBuilder(object):
         for bigip in bigips:
             try:
                 pool_stats = self.pool_helper.get_stats(
-                    bigip, name=pool["name"], partition=part)
+                    bigip, name=pool["name"], partition=part, stats=stats)
                 for stat in stats:
                     if stat in pool_stats:
                         collected_stats[stat] += pool_stats[stat]

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
@@ -246,3 +246,26 @@ class BigIPResourceHelper(object):
                       "resource %s", self.resource_type)
             raise KeyError("No collection available for %s" %
                            (self.resource_type))
+
+    def get_stats(self, bigip,  name=None, partition=None, stats=None):
+        """Returns stats
+
+        :param bigip: BIG-IP to get stats
+        :param name: name of resource object
+        :param partition: partition where to get resource
+        :param stats: Array of strings that define stats to collect.
+        :return:
+        """
+        collected_stats = {}
+
+        # get resource, then its stats
+        resource = self.load(bigip, name=name, partition=partition)
+        resource_stats = resource.stats.load()
+
+        # add stats defined in input stats array
+        for stat in stats:
+            if stat in resource_stats.entries:
+                collected_stats[stat] = \
+                    resource_stats.entries[stat]['value']
+
+        return collected_stats

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
@@ -247,25 +247,32 @@ class BigIPResourceHelper(object):
             raise KeyError("No collection available for %s" %
                            (self.resource_type))
 
-    def get_stats(self, bigip,  name=None, partition=None, stats=None):
-        """Returns stats
+    def get_stats(self, bigip,  name=None, partition=None, stats=[]):
+        """Returns dictionary of stats.
 
-        :param bigip: BIG-IP to get stats
-        :param name: name of resource object
-        :param partition: partition where to get resource
+        Use by calling with an array of stats to get from resource. Return
+        value will be a dict with key/value pairs. The stat key will only
+        be included in the return dict if the resource includes that stat.
+
+        :param bigip: BIG-IP to get stats from.
+        :param name: name of resource object.
+        :param partition: partition where to get resource.
         :param stats: Array of strings that define stats to collect.
-        :return:
+        :return: dictionary with key/value pairs where key is string
+        defined in input array, if present in resource stats, and value
+        as the value of resource stats 'value' key.
         """
         collected_stats = {}
 
         # get resource, then its stats
-        resource = self.load(bigip, name=name, partition=partition)
-        resource_stats = resource.stats.load()
+        if self.exists(bigip, name=name, partition=partition):
+            resource = self.load(bigip, name=name, partition=partition)
+            resource_stats = resource.stats.load()
 
-        # add stats defined in input stats array
-        for stat in stats:
-            if stat in resource_stats.entries:
-                collected_stats[stat] = \
-                    resource_stats.entries[stat]['value']
+            # add stats defined in input stats array
+            for stat in stats:
+                if stat in resource_stats.entries:
+                    collected_stats[stat] = \
+                        resource_stats.entries[stat]['value']
 
         return collected_stats

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setuptools.setup(
             'f5-oslbaasv2-agent = f5_openstack_agent.lbaasv2.drivers.bigip.agent:main'
         ]
     },
-    install_requires=['f5-sdk==1.2.0']
+    install_requires=['f5-sdk==1.3.0']
 )
 

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setuptools.setup(
             'f5-oslbaasv2-agent = f5_openstack_agent.lbaasv2.drivers.bigip.agent:main'
         ]
     },
-    install_requires=['f5-sdk==1.3.0']
+    install_requires=['f5-sdk==1.3.1']
 )
 


### PR DESCRIPTION
@richbrowne, @mattgreene 
#### What issues does this address?
WIP #40

#### What's this change do?
Implements support for lbaas-loadbalancer-stats command.

#### Where should the reviewer start?
Start with agent_manager, collect_stats(), then icontrol_driver get_stats()

#### Any background context?
NOTE: See original v1 implementation of get_stats in icontrol_driver. The v1 code has additional work to update member status. I didn't implement this as it is independent of loadbalancer stats. If we still want this, it should be added under a separate issue.
