### PR TITLE
changing the status of loadbalancer to ONLINE after creation

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1249,8 +1249,7 @@ class iControlDriver(LBaaSBaseDriver):
         if (provisioning_status == plugin_const.PENDING_CREATE or
                 provisioning_status == plugin_const.PENDING_UPDATE):
             listeners = service['listeners']
-            operating_status = (lb_const.ONLINE if len(listeners)
-                                else lb_const.OFFLINE)
+            operating_status = (lb_const.ONLINE)
             if (self.disconnected_service_polling.enabled and
                     not
                     self.disconnected_service.is_service_connected(service)):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1248,7 +1248,6 @@ class iControlDriver(LBaaSBaseDriver):
 
         if (provisioning_status == plugin_const.PENDING_CREATE or
                 provisioning_status == plugin_const.PENDING_UPDATE):
-            listeners = service['listeners']
             operating_status = (lb_const.ONLINE)
             if (self.disconnected_service_polling.enabled and
                     not

--- a/test/functional/neutronless/l2adjacent/test_disconnected_service_creation.py
+++ b/test/functional/neutronless/l2adjacent/test_disconnected_service_creation.py
@@ -192,7 +192,7 @@ def test_featureoff_withsegid_lb(setup_l2adjacent_test, bigip):
                        'ce69e293-56e7-43b8-b51c-01b91d66af20_0')
     ]
     assert rpc.update_loadbalancer_status.call_args_list == [
-        call(u'50c5d54a-5a9e-4a80-9e74-8400a461a077', 'ACTIVE', 'OFFLINE')
+        call(u'50c5d54a-5a9e-4a80-9e74-8400a461a077', 'ACTIVE', 'ONLINE')
     ]
 
 
@@ -217,7 +217,7 @@ def test_withsegid_lb(setup_l2adjacent_test, bigip):
                        'ce69e293-56e7-43b8-b51c-01b91d66af20_0')
     ]
     assert rpc.update_loadbalancer_status.call_args_list == [
-        call(u'50c5d54a-5a9e-4a80-9e74-8400a461a077', 'ACTIVE', 'OFFLINE')
+        call(u'50c5d54a-5a9e-4a80-9e74-8400a461a077', 'ACTIVE', 'ONLINE')
     ]
 
 


### PR DESCRIPTION
@mattgreene @pjbreaux 

#### What issues does this address?
Fixes #284


#### What's this change do?
It will change the status of loadbalancer to ONLINE after creation.

#### Where should the reviewer start?
icontrol_driver.py file


