### PR TITLE
Add support for code coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+source = 
+    */lbaasv2/*
+
+[paths]
+source =
+    f5_openstack_agent/
+    /usr/lib/python2.7/site-packages/f5_openstack_agent/
+    /root/devenv/f5-openstack-agent/f5_openstack_agent/

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,7 @@
 f5-openstack-agent
 ##################
 
-|Build Status| |slack badge|
+|Build Status| |slack badge| |coveralls badge|
 
 Introduction
 ************
@@ -151,9 +151,13 @@ Contributor License Agreement
 Individuals or business entities who contribute to this project must have completed and submitted the `F5® Contributor License Agreement <http://f5-openstack-docs.readthedocs.org/en/latest/cla_landing.html#cla-landing>`_ to Openstack\_CLA@f5.com prior to their code submission being included in this project.
 
 
-.. |Build Status| image:: https://travis-ci.org/F5Networks/f5-openstack-agent.svg?branch=master
-   :target: https://travis-ci.org/F5Networks/f5-openstack-agent
+.. |Build Status| image:: https://travis-ci.org/F5Networks/f5-openstack-agent.svg?branch=liberty
+   :target: https://travis-ci.org/F5Networks/f5-openstack-agent?branch=liberty
 
 .. |slack badge| image:: https://f5-openstack-slack.herokuapp.com/badge.svg
     :target: https://f5-openstack-slack.herokuapp.com/
     :alt: Slack
+
+.. |coveralls badge| image:: https://coveralls.io/repos/github/F5Networks/f5-openstack-agent/badge.svg?branch=liberty
+    :target: https://coveralls.io/github/F5Networks/f5-openstack-agent?branch=liberty
+    :alt: Coveralls

--- a/f5_openstack_agent/.coveragerc
+++ b/f5_openstack_agent/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+include =
+    lbaasv2/*
+
+data_file = .coverage.f5-openstack-agent.unit

--- a/requirements.test.txt
+++ b/requirements.test.txt
@@ -11,4 +11,7 @@ git+ssh://git@github.com/F5Networks/f5-openstack-test.git
 
 mock==1.3.0
 pytest==2.9.1
+pytest-cov==2.3.1
 responses
+coverage==4.2
+python-coveralls==2.7.0

--- a/test/.coveragerc
+++ b/test/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+include =
+    */f5-openstack-agent/*
+
+data_file = .coverage.f5-openstack-agent.test

--- a/test/functional/neutronless/CD/.coveragerc
+++ b/test/functional/neutronless/CD/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+include =
+    */f5-openstack-agent/*
+
+data_file = .coverage.f5-openstack-agent.CD

--- a/test/functional/neutronless/l2adjacent/.coveragerc
+++ b/test/functional/neutronless/l2adjacent/.coveragerc
@@ -1,0 +1,5 @@
+[run]
+include =
+    */f5-openstack-agent/*
+
+data_file = .coverage.f5-openstack-agent.l2adjacent


### PR DESCRIPTION
@pjbreaux 

Issues:
Fixes #294

Problem: Team goal to measure and track code coverage for f5-openstack-agent.

Analysis: Create .coveragerc files in multiple locations to match how and where we execute tests.
Each file is slightly different to produce non-overlapping coverage data files and accommodate variations in where the agent code resides for measurement.

Tests:
Execute unit, neutronless, lbv2-driver test_solution and neutron-lbass tempest api tests.  Combined results manually and uploaded to coveralls.io