### PR TITLE
It is not valid part of the configuration items in the Keystone v2

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -234,7 +234,7 @@ OPTS = [  # XXX maybe we should make this a dictionary
     cfg.StrOpt(
         'os_username',
         default=None,
-        help='OpenStack user name for Keystone authentication..'
+        help='OpenStack user name for Keystone authentication.'
     ),
     cfg.StrOpt(
         'os_user_domain_name',
@@ -261,6 +261,11 @@ OPTS = [  # XXX maybe we should make this a dictionary
         default='clientssl',
         help='Parent profile used when creating client SSL profiles '
         'for listeners with TERMINATED_HTTPS protocols.'
+    ),
+    cfg.StrOpt(
+        'os_tenant_name',
+        default=None,
+        help='OpenStack tenant name for Keystone authentication (v2 only).'
     )
 ]
 


### PR DESCRIPTION
@mattgreene 
#### What issues does this address?
Fixes #296 

#### What's this change do?
Adds os_tenant_name config option default definition.

#### Where should the reviewer start?
icontrol_driver.py

#### Any background context?
This option should have been included once Barbican support was added.

Issues:
Fixes #296

Problem: Config object is missing definition for os_tenant_name.

Analysis: Added string option for os_tenant_name in config options.

Tests: Manual.