### PR TITLE
Route domain id allocation failure.

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
@@ -226,8 +226,8 @@ class NetworkHelper(object):
             else:
                 raise LookupError(
                     "The list of route domain ids is out of order")
-        else:
-            return lowest_available_index
+
+        return lowest_available_index
 
     @log_helpers.log_method_call
     def create_route_domain(self, bigip, partition=const.DEFAULT_PARTITION,


### PR DESCRIPTION
@mattgreene 
#### What issues does this address?
Fixes #299 

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?

Issues:
Fixes #299

Problem:
When creating a new route domain the agent gets the set of all route
domains on the BigIP, and selects the lowest available route domain id
available.

This allocation fails when there is a hole in the list of existing route
domains b/c the lowest available route domain id is not returned.

Analysis:
Return route domain id at the end of the function.

Tests:
Create a loadbalancer/listener on BIGIP system where a hole in the route domain
id list exists.
Reran Tempest TLS test suite.