### PR TITLE
traffic_group distribution not working for scalen deployments

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1088,6 +1088,7 @@ class iControlDriver(LBaaSBaseDriver):
                       (time() - start_time))
 
             traffic_group = self.service_to_traffic_group(service)
+            service['loadbalancer']['traffic_group'] = traffic_group
 
             LOG.debug("XXXXXXXXXX: traffic group created ")
 


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
Fixes #321 

#### What's this change do?
Add traffic_group to loadbalancer service object.

#### Where should the reviewer start?
common_service_handler

#### Any background context?
The call to create a virtual server does not properly initialize the virtual address with a traffic group.

Issues:
Fixes #321

Problem:
When the agent starts it collects all provisioned traffic groups on the BIG-IP,
removing only the local_only traffic group. When a load_balancer is requested
the traffic_group is intended to be populated from a the collected traffic_group
list with tenant affinity. The traffic_group for the virtual_address is always
/Common/traffic-group-1.

Analysis:
Add the traffic group to the service object when it is discovered in
common_service_handler.

Tests: