### PR TITLE
Fixes #324 - unicode characters in install commands

### DIFF
--- a/docs/topic_install-f5-agent.rst
+++ b/docs/topic_install-f5-agent.rst
@@ -30,7 +30,7 @@ The ``f5-openstack-agent`` package can be installed using ``dpkg`` tools.
 .. code-block:: bash
 
     $ curl -L -O https://github.com/F5Networks/f5-common-python/releases/download/v1.2.0/python-f5–sdk_1.2.0–1_1404_all.deb
-    $ curl –L –O https://github.com/F5Networks/f5-icontrol-rest-python/releases/download/v1.0.9/python-f5-icontrol-rest_1.0.9-1_1404_all.deb
+    $ curl -L -O https://github.com/F5Networks/f5-icontrol-rest-python/releases/download/v1.0.9/python-f5-icontrol-rest_1.0.9-1_1404_all.deb
     $ sudo dpkg –i python-f5-icontrol-rest_1.0.9-1_1404_all.deb
     $ sudo dpkg –i python-f5–sdk_1.2.0–1_1404_all.deb
 
@@ -51,8 +51,8 @@ The ``f5-openstack-agent`` package can be installed using ``rpm`` tools.
 
 .. code-block:: bash
 
-    $ curl –L –O https://github.com/F5Networks/f5-common-python/releases/download/v1.2.0/f5-sdk-1.2.0-1.el7.noarch.rpm
-    $ curl –L –O https://github.com/F5Networks/f5-icontrol-rest-python/releases/download/v1.0.9/f5-icontrol-rest-1.0.9-1.el7.noarch.rpm
+    $ curl -L -O https://github.com/F5Networks/f5-common-python/releases/download/v1.2.0/f5-sdk-1.2.0-1.el7.noarch.rpm
+    $ curl -L -O https://github.com/F5Networks/f5-icontrol-rest-python/releases/download/v1.0.9/f5-icontrol-rest-1.0.9-1.el7.noarch.rpm
     $ sudo rpm –ivh f5-icontrol-rest-1.0.9-1.el7.noarch.rpm f5-sdk-1.2.0-1.el7.noarch.rpm
 
 
@@ -60,7 +60,7 @@ The ``f5-openstack-agent`` package can be installed using ``rpm`` tools.
 
 .. code-block:: bash
 
-    $ curl –L –O https://github.com/F5Networks/f5-openstack-agent/releases/download/v8.0.8/f5-openstack-agent-8.0.8-1.el7.noarch.rpm
+    $ curl -L -O https://github.com/F5Networks/f5-openstack-agent/releases/download/v8.0.8/f5-openstack-agent-8.0.8-1.el7.noarch.rpm
     $ sudo rpm –ivh f5-openstack-agent-8.0.8-1.el7.noarch.rpm
 
 


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
Fixes #324 

#### What's this change do?
Fixes the issue that prevents users from downloading packages via `curl`.

#### Where should the reviewer start?
See changes inline below; test new strings. I have tested these locally and confirmed that they work.

#### Any background context?

