### PR TITLE
traffic_group distribution not working for scalen deployments

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
@@ -87,8 +87,16 @@ class ListenerServiceBuilder(object):
         # of BIG-IP® defaults.
         traffic_group = self.service_adapter.get_traffic_group(service)
         if traffic_group:
+            ip_address = service['loadbalancer']['vip_address']
+            if str(ip_address).endswith('%0'):
+                ip_address = ip_address[:-2]
+
             for bigip in bigips:
-                self.vs_helper.update(bigip, traffic_group)
+                virtual_address = \
+                    bigip.tm.ltm.virtual_address_s.virtual_address
+                obj = virtual_address.load(name=ip_address,
+                                           partition=vip['partition'])
+                obj.modify(trafficGroup=traffic_group)
 
     def get_listener(self, service, bigip):
         """Retrieve BIG-IP® virtual from a single BIG-IP® system.


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
Fixes #321 

#### What's this change do?
Modifies listener service to set the traffic group on virtual address object instead of virtual server.

#### Where should the reviewer start?
listener_service.py

#### Any background context?
Part of fix for traffic group distribution and scalen deployments.

Issues:
Fixes #321

Problem: Listener service incorrectly sets the traffic group
on a virtual server object, and should set it on the virtual
address object.

Analysis: Modified create virtual server function to set the traffic
group on the virtual address, not virtual server.

Tests: tempest test suite