### PR TITLE
added static agent ID configuration

### DIFF
--- a/etc/neutron/services/f5/f5-openstack-agent.ini
+++ b/etc/neutron/services/f5/f5-openstack-agent.ini
@@ -46,6 +46,13 @@ periodic_interval = 10
 #
 # service_resync_interval = 500
 #
+###############################################################################
+#  Environment Settings
+###############################################################################
+#
+# Since many TMOS® object names must start with an alpha character
+# the environment_prefix is used to prefix all service objects.
+#
 # Objects created on the BIG-IP® by this agent will have their names prefixed
 # by an environment string. This allows you set this string.  The default is
 # 'Project'.
@@ -56,18 +63,22 @@ periodic_interval = 10
 # and on the the BIG-IP® associated with the old environment will need to be managed
 # manually.
 #
-###############################################################################
-#  Environment Settings
-###############################################################################
-#
-# Since many TMOS® object names must start with an alpha character
-# the environment_prefix is used to prefix all service objects.
-#
 # environment_prefix = 'Project'
 #
 ###############################################################################
 #  Static Agent Configuration Setting
 ###############################################################################
+#
+# Statically set the agent ID used to identify this agent with 
+# Neutron. 
+#
+# The agent ID is used to identify this instance of
+# the agent for scheduling and messaging. If not set, the
+# agent ID will be automatically populated with the host name 
+# of host running the agent appended with a hash of the 
+# environment_prefix and the first iControl endpoint. 
+#
+# agent_id = None
 #
 # Static configuration data to sent back to the plugin. This can be used
 # on the plugin side of neutron to provide agent identification for custom

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -19,7 +19,6 @@ import datetime
 import hashlib
 import logging as std_logging
 import urllib2
-import uuid
 
 from eventlet import greenthread
 from time import time
@@ -297,6 +296,7 @@ class iControlDriver(LBaaSBaseDriver):
         self.conf = conf
         if registerOpts:
             self.conf.register_opts(OPTS)
+        self.initialized = False
         self.hostnames = None
         self.device_type = conf.f5_device_type
         self.plugin_rpc = None  # overrides base, same value
@@ -352,6 +352,7 @@ class iControlDriver(LBaaSBaseDriver):
                  % (len(self.__bigips), self.conf.icontrol_username))
         LOG.info('iControlDriver dynamic agent configurations:%s'
                  % self.agent_configurations)
+        self.initialized = True
 
     def connect_bigips(self):
         self._init_bigips()
@@ -451,21 +452,6 @@ class iControlDriver(LBaaSBaseDriver):
         self.hostnames = self.conf.icontrol_hostname.split(',')
         self.hostnames = [item.strip() for item in self.hostnames]
         self.hostnames = sorted(self.hostnames)
-
-        # Setting an agent_id is the flag to the agent manager
-        # that your plugin has initialized correctly. If you
-        # don't set one, the agent manager will not register
-        # with Neutron as a valid agent.
-        if self.conf.environment_prefix:
-            self.agent_id = str(
-                uuid.uuid5(uuid.NAMESPACE_DNS,
-                           self.conf.environment_prefix +
-                           '.' + self.hostnames[0])
-                )
-        else:
-            self.agent_id = str(
-                uuid.uuid5(uuid.NAMESPACE_DNS, self.hostnames[0])
-            )
 
     def _init_bigips(self):
         # Connect to all BIG-IP®s


### PR DESCRIPTION
@mattgreene 
#### What issues does this address?
Fixes #348
WIP #348
...

#### What's this change do?
Allows the operator to set a static agent_id setting in the agent ini. If set this setting will override the current agent host name + UUID5 hash of the environment_prefix and first iControl endpoint host.

If not set, the behavior is the same as before this feature.

I also removed some unused agent_host logic in the icontrol driver. 

#### Where should the reviewer start?
Build and install LBaaSv2 agent. 

1) Leave agent_id commented out from the agent config and confirm the old agent naming scheme is still working with Neutron. Confirm with neutron agent list.
2) Change the agent_id to a unique fqdn formatted string and restart the agent. Neutron should now see the new agent_id for host scheduling. Confirm with neutron agent list.

#### Any background context?
Customers need this to be able to launch agent processes (in containers or directly on hosts) with process managers, like pacemaker. This feature gives them control over the agent registration.
