### PR TITLE
traffic_group distribution not working for scalen deployments

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+import urllib
+
 from oslo_log import log as logging
 
 from f5_openstack_agent.lbaasv2.drivers.bigip.disconnected_service import \
@@ -90,6 +92,8 @@ class ListenerServiceBuilder(object):
             ip_address = service['loadbalancer']['vip_address']
             if str(ip_address).endswith('%0'):
                 ip_address = ip_address[:-2]
+            else:
+                ip_address = urllib.quote(ip_address)
 
             for bigip in bigips:
                 virtual_address = \

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -99,13 +99,11 @@ class ServiceModelAdapter(object):
                 "partition": self.get_folder_name(loadbalancer['tenant_id'])}
 
     def get_traffic_group(self, service):
-        tg = None
+        tg = "traffic-group-local-only"
         loadbalancer = service["loadbalancer"]
 
         if "traffic_group" in loadbalancer:
-            listener = service["listener"]
-            tg = self._init_virtual_name(loadbalancer, listener)
-            tg["traffic_group"] = loadbalancer["traffic_group"]
+            tg = loadbalancer["traffic_group"]
 
         return tg
 


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
Fixes #338 

#### What's this change do?
URL encode virtual address name when route domain included; set traffic group name.

#### Where should the reviewer start?
listener_service.py

#### Any background context?

Issues:
Fixes #338

Problem: Setting traffic group on virutal address fails.

Analysis: Two issues: virtual address names with route domains need
to be urlencoded; traffic group name not correctly retrieved from
service object. Added urlencoding of virtual addres name and set
traffic group name correctly.

Tests: tempest