### PR TITLE
In global routed mode agent_manager fails to start.

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -371,7 +371,8 @@ class iControlDriver(LBaaSBaseDriver):
         self.connect_bigips()
 
         # After we have a connection to the BIG-IPs, initialize vCMP
-        self.network_builder.initialize_vcmp()
+        if self.network_builder:
+            self.network_builder.initialize_vcmp()
 
         self.agent_configurations['network_segment_physical_network'] = \
             self.disconnected_service_polling.get_physical_network()


### PR DESCRIPTION
@pjbreaux @jlongstaf 
#### What issues does this address?
Fixes #356 

#### What's this change do?
Guards vcmp initialization with a check on the existence of network_builder.

#### Where should the reviewer start?
icontrol_driver code.

#### Any background context?

Issues:
Fixes #356

Problem:
vCMP initialization is performed when the network_builder is non-
existent.  The vCMP initialization should only be performed for
under-cloud deployments.

Analysis:
Check that the network builder exists before using it to initialize
vCMP.

Tests:
Undercloud startup.