### PR TITLE
set local_ip default to None on all connected BIG-IPs

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
@@ -79,6 +79,8 @@ class NetworkServiceBuilder(object):
 
         for bigip in self.driver.get_all_bigips():
 
+            bigip.local_ip = None
+
             if not vtep_folder or vtep_folder.lower() == 'none':
                 vtep_folder = 'Common'
 


### PR DESCRIPTION
@mattgreene 
#### What issues does this address?

Fixes #368 
WIP #368
...
#### What's this change do?

Default the local_ip attribute on all BIG-IPs to None. Today there are code branches which reference the local_ip attribute ( icontrol_driver.iControlDriver.tunnel_sync() ) without it being defined. This raises AttributeError on each period sync.
#### Where should the reviewer start?

Create an LBaaSv2 implementation with tenant network types as VLAN and with no VTEP settings set in the agent config. Watch the errors the logs in period tasks.

Add this assignment and watch the log errors go away.
#### Any background context?
