### PR TITLE
Update of TLS listener fails

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -103,25 +103,17 @@ class LBaaSBuilder(object):
                    "networks": networks}
             if listener['provisioning_status'] == plugin_const.PENDING_UPDATE:
                 if 'old_listener' in service:
-                    # Check if the update includes a name change.
-                    # If it is a name change, delete existing VS and proceed
-                    # with creating VS using new name.
+                    # Delete existing VS and proceed with creating a new VS
+                    # to ensure that name changes, SSL profile changes,
+                    # etc. are handled correctly.
                     old_svc = {"loadbalancer": loadbalancer,
                                "listener": service["old_listener"]}
-                    old_vip = self.service_adapter.get_virtual_name(old_svc)
-                    new_vip = self.service_adapter.get_virtual_name(svc)
-                    if old_vip['name'] != new_vip['name']:
-                        # rename by deleting and creating vs
-                        LOG.debug("Rename vs from %s to %s",
-                                  (old_vip['name'], new_vip['name']))
-                        try:
-                            self.listener_builder.delete_listener(
-                                old_svc, bigips)
-                        except Exception as err:
-                            listener['provisioning_status'] = \
-                                plugin_const.ERROR
-                            raise f5_ex.VirtualServerDeleteException(
-                                err.message)
+                    try:
+                        self.listener_builder.delete_listener(old_svc, bigips)
+                    except Exception as err:
+                        listener['provisioning_status'] = plugin_const.ERROR
+                        raise f5_ex.VirtualServerDeleteException(err.message)
+
             if listener['provisioning_status'] != plugin_const.PENDING_DELETE:
                 try:
                     # create_listener() will do an update if VS exists


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
Fixes #372

#### What's this change do?
Deletes and re-creates virtual server associated with listener when updating a listener.

#### Where should the reviewer start?
lbaas_builder.py

#### Any background context?

Issues:
Fixes #372

Problem: Updating a TLS listener fails because of BIG-IP error.

Analysis: Update normally relies on simply updating (PATCH) a
virtual server with changed attributes. For TLS though, the SSL
profile attributes need to be modified as well. To fix, modified
udpate to delete existing virtual server and create a new.
In this way, the SSL profiles are removed and added correctly.

Tests: tempest test suite.