### PR TITLE
Generate md5 checksums for release artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: true
 env:
   global:
     - DIST_REPO="f5-openstack-agent-dist"
+    - PKG_VERSION=$(python -c "import f5_openstack_agent; print f5_openstack_agent.__version__")
+    - PKG_RELEASE=$(python ${DIST_REPO}/scripts/get-version-release.py --release)
+    - PKG_RELEASE_EL7=${DIST_REPO}/rpms/build/f5-openstack-agent-${PKG_VERSION}-${PKG_RELEASE}.el7.noarch.rpm
+    - PKG_RELEASE_1404=${DIST_REPO}/deb_dist/python-f5-openstack-agent_${PKG_VERSION}-${PKG_RELEASE}_1404_all.deb
 services:
 - docker
 language: python
@@ -24,18 +28,19 @@ script:
     - sudo chown -R travis:travis ${DIST_REPO}/rpms/build
     - sudo chown -R travis:travis ${DIST_REPO}/deb_dist/*.deb
 after_success:
+  - md5sum ${PKG_RELEASE_EL7} > ${PKG_RELEASE_EL7}.md5 && md5sum --check ${PKG_RELEASE_EL7}.md5
+  - md5sum ${PKG_RELEASE_1404} > ${PKG_RELEASE_1404}.md5 && md5sum --check ${PKG_RELEASE_1404}.md5
   - f5-openstack-agent-dist/scripts/test_install.sh "redhat" "7"
   - f5-openstack-agent-dist/scripts/test_install.sh "ubuntu" "14.04"
-before_deploy:
-  PKG_VERSION=$(python -c "import f5_openstack_agent; print f5_openstack_agent.__version__")
-  PKG_RELEASE=$(python ${DIST_REPO}/scripts/get-version-release.py --release)
 deploy:
   - provider: releases
     api_key:
       secure: lTash9wrbwY5rsdl+ZfhYZ+Iqt2EdvZNqrq6FlLT6L4Wc4/RYCDLFwY2qrDb/n1XI3g/XhOCTyYMCu9URrw0HAY45HcAgOcEABNcAGfs/aBk5uB+l/V/42QKB+oAR9RR9qves5PJGBpJcBym9oswcxblBo8L6Z2o/yFzyGo3tHKVopTZoIw+hPqt5eAClPz8FX0ZIUZqH1iUiqMj1JJWvO9DRWECcjt4pr5HuY3u32qocQP4DUY1WQwI/R6iye5VPTAbWnsIBChJcJF1HAbsVa5IhQHhSo03RCJwZay/NF0btc9dKvIyrwqhQIUZX/RcDPvbs7TP02zg9O27HBAts2ivVRoBulN9dsHGiWGXMMQjavZGsdZ/TddKQxUvWoUKv+nHQyWGbyrE4smDHrex29NR/WgB/kHSAkNyUU1rZs8ALaoab5LY3Z0WmrFlHFs4HDb4YG+//0ODVppRe+Z8uFFnSsN4fjG9Xok+Tl+Gb9XM6/LNu+C+5DCG2VfPCnp2UGzmmo9Hm6ODhWauCR9DfJk1dUTVYb871I3ina0rwm2NQ04bKv0UHGZ2FWpq/KGx+jvXW8F54cWIluU/ze2MrJF/z9uKyTluEbDNBEr9/LaZoG22MBzHZB4xK0cEy+CSwGdOredCDCyEM7dsLlnE8ruiujbCAMvdjsHH4bu4MjU=
     file:
-      - ${DIST_REPO}/rpms/build/f5-openstack-agent-${PKG_VERSION}-${PKG_RELEASE}.el7.noarch.rpm
-      - ${DIST_REPO}/deb_dist/python-f5-openstack-agent_${PKG_VERSION}-${PKG_RELEASE}_1404_all.deb
+      - ${PKG_RELEASE_EL7}
+      - ${PKG_RELEASE_EL7}.md5
+      - ${PKG_RELEASE_1404}
+      - ${PKG_RELEASE_1404}.md5
     skip_cleanup: true
     overwrite: true
     on:


### PR DESCRIPTION
@jlongstaf 

Issues:
Fixes #334

Problem: Need to add md5 checksum to binary files for consistency with F5 downloads.

Analysis: Update travis scheme to generate md5sum files and attach to the github release page adjacent to the rpm and deb binary files.

Tests: Confirmed generation of md5 files via test build in fork.