### PR TITLE
Add support for shared and detached pools

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -195,10 +195,13 @@ class LBaaSBuilder(object):
         bigips = self.driver.get_config_bigips()
 
         for member in members:
+            pool = self.get_pool_by_id(service, member["pool_id"])
             svc = {"loadbalancer": loadbalancer,
                    "member": member,
-                   "pool": self.get_pool_by_id(service, member["pool_id"])}
-            if member['provisioning_status'] == plugin_const.PENDING_DELETE:
+                   "pool": pool}
+            # delete member if pool is being deleted
+            if member['provisioning_status'] == plugin_const.PENDING_DELETE or\
+                    pool['provisioning_status'] == plugin_const.PENDING_DELETE:
                 try:
                     self.pool_builder.delete_member(svc, bigips)
                 except Exception as err:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
@@ -202,12 +202,13 @@ class ListenerServiceBuilder(object):
         :param bigips: Array of BigIP class instances to update.
         """
         vip = self.service_adapter.get_virtual_name(service)
-        vip["pool"] = name
-        for bigip in bigips:
-            v = bigip.tm.ltm.virtuals.virtual
-            if v.exists(name=vip["name"], partition=vip["partition"]):
-                obj = v.load(name=vip["name"], partition=vip["partition"])
-                obj.modify(**vip)
+        if vip:
+            vip["pool"] = name
+            for bigip in bigips:
+                v = bigip.tm.ltm.virtuals.virtual
+                if v.exists(name=vip["name"], partition=vip["partition"]):
+                    obj = v.load(name=vip["name"], partition=vip["partition"])
+                    obj.modify(**vip)
 
     def update_session_persistence(self, service, bigips):
         """Update session persistence for virtual server.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -85,9 +85,12 @@ class ServiceModelAdapter(object):
         return vip
 
     def get_virtual_name(self, service):
-        listener = service["listener"]
-        loadbalancer = service["loadbalancer"]
-        return self._init_virtual_name(loadbalancer, listener)
+        vs_name = None
+        if "listener" in service:
+            listener = service["listener"]
+            loadbalancer = service["loadbalancer"]
+            vs_name = self._init_virtual_name(loadbalancer, listener)
+        return vs_name
 
     def _init_virtual_name(self, loadbalancer, listener):
         if "name" not in listener or not listener["name"]:


### PR DESCRIPTION
@pjbreaux 
#### What issues does this address?
Fixes #407

#### What's this change do?
Adds support for detached and shared pools

#### Where should the reviewer start?
lbaas_builder.py

#### Any background context?
Current code assumes service object always defines a single listener for a pool, but
can have 0 or more.

Issues:
Fixes #407

Problem: Agent assumes pools are always associated to one pool.
Mitaka introduces concept of detached and shared pools.

Analysis: Updated agent to not assume associated listner, and to
handle multiple listeners for pool operations (e.g., update default
pool attribute on VS).

Tests: Developed Tempest test in driver code. See  test_pool.py
in f5-openstack-lbaasv2-driver/f5lbaasdriver/test/tempest/tests/api