### PR TITLE
Adding environment prefix to rule actions, so we can recreate the poo…

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l7policy_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l7policy_adapter.py
@@ -25,11 +25,12 @@ from f5_openstack_agent.lbaasv2.drivers.bigip.service_adapter \
 class Action(object):
     '''Describes a single action for a rule.'''
 
-    def __init__(self, action, action_name, partition, action_val=None):
+    def __init__(
+            self, action, action_name, partition, env_prefix, action_val=None):
         action_map = {
             'REDIRECT_TO_POOL': {'forward': True,
                                  'pool': self._get_pool_name(
-                                     partition, action_val)},
+                                     partition, env_prefix, action_val)},
             'REDIRECT_TO_URL': {
                 'redirect': True, 'location': action_val, 'httpReply': True},
             'REJECT': {'reset': True, 'forward': True}
@@ -38,10 +39,10 @@ class Action(object):
         self.name = action_name
         self.__dict__.update(action_map[action])
 
-    def _get_pool_name(self, partition, action_value):
+    def _get_pool_name(self, partition, env_prefix, action_value):
         '''Construct pool name from partition and OpenStack pool name.'''
 
-        return '/{0}/{1}'.format(partition, action_value)
+        return '/{0}/{1}{2}'.format(partition, env_prefix, action_value)
 
 
 class Condition(object):
@@ -75,15 +76,16 @@ class Condition(object):
 class Rule(object):
     '''Describes a single rule for a policy.'''
 
-    def __init__(self, policy, service, partition):
+    def __init__(self, policy, service, partition, env_prefix):
         self._set_name(policy)
         self.ordinal = policy['position']
         self.actions = []
         self.conditions = []
-        self._adapt_rule_to_conditions_and_actions(policy, service, partition)
+        self._adapt_rule_to_conditions_and_actions(
+            policy, service, partition, env_prefix)
 
     def _adapt_rule_to_conditions_and_actions(
-            self, policy, service, partition):
+            self, policy, service, partition, env_prefix):
         '''Adapt OpenStack rules into conditions and actions.'''
 
         for idx, os_rule_dict in enumerate(policy['rules']):
@@ -91,7 +93,7 @@ class Rule(object):
             cond = Condition(os_rule, str(idx))
             self.conditions.append(cond.__dict__)
         act_type, act_val = self._get_action_and_value(policy['id'], service)
-        action = Action(act_type, '0', partition, act_val)
+        action = Action(act_type, '0', partition, env_prefix, act_val)
         self.actions.append(action.__dict__)
 
     def _get_l7rule(self, rule_id, service):
@@ -136,7 +138,7 @@ class L7PolicyServiceAdapter(ServiceModelAdapter):
         '''OS Policies are translated into Rules on the device.'''
 
         for policy in self.service['l7policies']:
-            bigip_rule = Rule(policy, self.service, self.folder)
+            bigip_rule = Rule(policy, self.service, self.folder, self.prefix)
             self.policy_dict['rules'].append(bigip_rule.__dict__)
 
     def _adapt_policy(self):


### PR DESCRIPTION
@jlongstaf 

Issues:
Fixes: #425

Problem:
The policy is not deploying properly when containing a rule
action that redirects to a particular pool.

Analysis:
Modified action class to have an environment prefix input parameter.
This is used to link the action redirect to a particular pool.

Tests:
Will run tempest tests against this code