### PR TITLE
Agent manager not using correct interface for service rename.

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -539,7 +539,7 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                 LOG.error('active loadbalancer %s is not on BIG-IP...syncing'
                           % lb_id)
 
-                if self.lbdriver.rename_required(service):
+                if self.lbdriver.service_rename_required(service):
                     self.lbdriver.service_object_teardown(service)
                     LOG.error('active loadbalancer %s is configured with '
                               'non-unique names on BIG-IP...rename in '


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
Fixes #427


Fixes: issue-427

Problem:
The agent manager was not updated to use the update icontrol driver
api and fails rename test.

Analysis:
Call service_rename_required()

Test:
Rename full_service