### PR TITLE
L7Policy Adapter does not excise rule with a PENDING_DELETE status

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l7policy_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l7policy_adapter.py
@@ -90,8 +90,9 @@ class Rule(object):
 
         for idx, os_rule_dict in enumerate(policy['rules']):
             os_rule = self._get_l7rule(os_rule_dict['id'], service)
-            cond = Condition(os_rule, str(idx))
-            self.conditions.append(cond.__dict__)
+            if os_rule['provisioning_status'] != 'PENDING_DELETE':
+                cond = Condition(os_rule, str(idx))
+                self.conditions.append(cond.__dict__)
         act_type, act_val = self._get_action_and_value(policy['id'], service)
         action = Action(act_type, '0', partition, env_prefix, act_val)
         self.actions.append(action.__dict__)

--- a/f5_openstack_agent/tests/functional/adapters/policy_rules.json
+++ b/f5_openstack_agent/tests/functional/adapters/policy_rules.json
@@ -526,5 +526,41 @@
                         "value": "test_header"
                     }
                 ]
+        },
+    "redirect_to_url_not_header_remove_rule":
+        {
+            "l7policies": 
+                [
+                    {
+                        "action": "REDIRECT_TO_URL",
+                        "admin_state_up": true,
+                        "description": "",
+                        "id": "5113fb9d-054f-4494-976d-84bfeb14c42a",
+                        "listener_id": "95a59425-d144-4710-ae0c-3750763df0c1",
+                        "name": "",
+                        "position": 1,
+                        "provisioning_status": "ACTIVE",
+                        "redirect_pool_id": null,
+                        "redirect_url": "http://www.example.com",
+                        "rules": [{"id": "f7e45215-d254-455d-b6be-737ed4393eaa"}],
+                        "tenant_id": "test"
+                    }
+                ],
+         "l7rules":
+                [
+                    {
+                        "admin_state_up": true,
+                        "compare_type": "ENDS_WITH",
+                        "id": "f7e45215-d254-455d-b6be-737ed4393eaa",
+                        "invert": true,
+                        "key": "X-HEADER",
+                        "policies": [{"id": "5113fb9d-054f-4494-976d-84bfeb14c42a"}],
+                        "policy_id": "5113fb9d-054f-4494-976d-84bfeb14c42a",
+                        "provisioning_status": "PENDING_DELETE",
+                        "tenant_id": "test",
+                        "type": "HEADER",
+                        "value": "test_header"
+                    }
+                ]
         }
 }

--- a/f5_openstack_agent/tests/functional/adapters/test_l7policy_adapter.py
+++ b/f5_openstack_agent/tests/functional/adapters/test_l7policy_adapter.py
@@ -53,7 +53,7 @@ def partition_setup(request, bigip):
 def policy_setup(request, bigip, partition_setup):
     pool = bigip.tm.ltm.pools.pool
     pol = bigip.tm.ltm.policys.policy
-    pool_kwargs = {'name': 'test_pool', 'partition': 'Project_test'}
+    pool_kwargs = {'name': 'Project_test_pool', 'partition': 'Project_test'}
     pol_kwargs = {'name': 'wrapper_policy', 'partition': 'Project_test'}
 
     def teardown():
@@ -107,7 +107,7 @@ def test_adapter_redirect_to_pool_file_type_beginswith(
                     {
                         'forward': True, 'name': 0, 'request': True,
                         'name': '0',
-                        'pool': u'/Project_test/test_pool'
+                        'pool': u'/Project_test/Project_test_pool'
                     }
                 ],
                 'conditions': [
@@ -197,7 +197,7 @@ def test_adapter_redirect_to_pool_hostname_equal_to(
                 'actions': [
                     {
                         'request': True, 'name': '0', 'forward': True,
-                        'pool': '/Project_test/test_pool'
+                        'pool': '/Project_test/Project_test_pool'
                     }
                 ],
                 'conditions': [
@@ -229,7 +229,7 @@ def test_adapter_redirect_to_pool_many_rules(
                 "actions": [{
                     "forward": True,
                     "name": "0",
-                    "pool": "/Project_test/test_pool",
+                    "pool": "/Project_test/Project_test_pool",
                     "request": True
                 }],
                 "conditions": [{
@@ -279,7 +279,7 @@ def test_adapter_many_policies_rules(
                 "actions": [{
                     "forward": True,
                     "name": "0",
-                    "pool": "/Project_test/test_pool",
+                    "pool": "/Project_test/Project_test_pool",
                     "request": True
                 }],
                 "conditions": [{
@@ -355,7 +355,7 @@ def test_adapter_redirect_to_pool_hostname_not_equal_to(
                 'actions': [
                     {
                         'request': True, 'name': '0', 'forward': True,
-                        'pool': '/Project_test/test_pool'
+                        'pool': '/Project_test/Project_test_pool'
                     }
                 ],
                 'conditions': [
@@ -413,7 +413,7 @@ def test_adapter_redirect_to_pool_file_type_not_beginswith(
                 'actions': [
                     {
                         'forward': True, 'name': 0, 'request': True,
-                        'name': '0', 'pool': u'/Project_test/test_pool'
+                        'name': '0', 'pool': u'/Project_test/Project_test_pool'
                     }
                 ],
                 'conditions': [
@@ -484,6 +484,30 @@ def test_adapter_redirect_to_url_header_not_ends_with(
                         'tmName': 'X-HEADER', 'not': True
                     }
                 ],
+                'name': u'redirect_to_url_1', 'ordinal': 1
+            }
+        ],
+        'strategy': 'first-match'
+    }
+    bigip.tm.ltm.policys.policy.create(**pol)
+
+
+def test_adapter_remove_rule(bigip, fake_conf, policy_setup):
+    adapter = l7policy_adapter.L7PolicyServiceAdapter(fake_conf)
+    pol = adapter.translate(
+        POL_CONFIGS['redirect_to_url_not_header_remove_rule'])
+    assert pol == {
+        'name': 'wrapper_policy', 'partition': u'Project_test', 'legacy': True,
+        'requires': ['http'], 'controls': ['forwarding'],
+        'rules': [
+            {
+                'actions': [
+                    {
+                        'request': True, 'name': '0', 'httpReply': True,
+                        'redirect': True, 'location': 'http://www.example.com'
+                    }
+                ],
+                'conditions': [],
                 'name': u'redirect_to_url_1', 'ordinal': 1
             }
         ],


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
Fixes #430 

#### What's this change do?
When adapting a policy and rules, the l7policy adapter should expect to  see a rule in a PENDING_DELETE operating status. This would mean to ignore that rule when it does the translation for deployment on the device.

#### Where should the reviewer start?
Start at the code change, then look at the test.

#### Any background context?
@szakeri found this issue when running her tempest api tests. Thanks!
