### PR TITLE
pin neutron to that branch implied by subject code

### DIFF
--- a/systest/scripts/install_systests.sh
+++ b/systest/scripts/install_systests.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -ex
 
+if [ "$1" == "-h" ] || [[ "$1" == "--help" ]]; then
+    echo "Usage: This script expects to be called from the buildbot interface (systest/Makefile or systest/????.yml).  Appropriate arguments are established in that context."
+fi
 if [ "$1" == "" ]; then
     echo "ERROR: no repo value provided!"
     exit 1
@@ -34,7 +37,7 @@ cd f5-openstack-agent
 pip install --upgrade .
 
 # Install openstack deps (if necessary)
-pip install git+https://github.com/openstack/neutron@9.1.0
+pip install git+https://github.com/openstack/neutron@stable/$branch
 pip install git+https://github.com/openstack/oslo.log.git@stable/$branch
 pip install git+https://github.com/openstack/neutron-lbaas.git@stable/$branch
 

--- a/test/functional/neutronless/conftest.py
+++ b/test/functional/neutronless/conftest.py
@@ -88,6 +88,13 @@ def remove_elements(bigip, uris, vlan=False):
                 # If testing VLAN (with vCMP) the fdb tunnel cannot be deleted
                 # directly. It goes away when the net tunnel is deleted
                 continue
+            elif sc == 400\
+              and 'mgmt/tm/net/tunnels/tunnel/' in selfLink\
+              and 'tunnel-vxlan' in selfLink:
+                for t in bigip.tm.net.fdb.tunnels.get_collection():
+                    if t.name != 'http-tunnel' and t.name != 'socks-tunnel':
+                        t.update(records=[])
+                registry[selfLink].delete()
             else:
                 raise
 

--- a/test/functional/neutronless/conftest.py
+++ b/test/functional/neutronless/conftest.py
@@ -63,9 +63,9 @@ def _get_nolevel_handler(logname):
     rootlogger = logging.getLogger()
     for h in rootlogger.handlers:
         rootlogger.removeHandler(h)
-    rootlogger.setLevel(logging.DEBUG)
+    rootlogger.setLevel(logging.INFO)
     fh = logging.FileHandler(logname)
-    fh.setLevel(logging.DEBUG)
+    fh.setLevel(logging.INFO)
     rootlogger.addHandler(fh)
     return fh
 

--- a/test/functional/neutronless/service_object_rename/conftest.py
+++ b/test/functional/neutronless/service_object_rename/conftest.py
@@ -72,9 +72,9 @@ def _get_nolevel_handler(logname):
     rootlogger = logging.getLogger()
     for h in rootlogger.handlers:
         rootlogger.removeHandler(h)
-    rootlogger.setLevel(logging.DEBUG)
+    rootlogger.setLevel(logging.INFO)
     fh = logging.FileHandler(logname)
-    fh.setLevel(logging.DEBUG)
+    fh.setLevel(logging.INFO)
     rootlogger.addHandler(fh)
     return fh
 

--- a/test/functional/neutronless/service_object_rename/test_service_object_rename.py
+++ b/test/functional/neutronless/service_object_rename/test_service_object_rename.py
@@ -22,7 +22,7 @@ from conftest import setup_neutronless_test
 requests.packages.urllib3.disable_warnings()
 
 LOG = logging.getLogger(__name__)
-LOG.setLevel(logging.DEBUG)
+LOG.setLevel(logging.INFO)
 
 # Get the Oslo Config File
 curdir = os.path.dirname(os.path.realpath(__file__))


### PR DESCRIPTION
@mattgreene 
#### What issues does this address?
Pinning the correct version of neutron is critical to regression stability...  this is particularly the case because back-compatibility is not guaranteed. 

Fixes #450 