### PR TITLE
L7Policy adapter needs to have the logic to fully translate OpenStack policies and rule

### DIFF
--- a/f5-openstack-agent-dist/deb_dist/stdeb.cfg
+++ b/f5-openstack-agent-dist/deb_dist/stdeb.cfg
@@ -1,3 +1,3 @@
 [DEFAULT]
 Depends:
-	python-f5-sdk (=1.5.0-1)
+	python-f5-sdk (=2.1.0-1)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l7policy_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l7policy_service.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-from neutron.plugins.common import constants as plugin_const
 from oslo_log import log as logging
 
 from f5_openstack_agent.lbaasv2.drivers.bigip.exceptions import \
@@ -174,8 +173,7 @@ class L7PolicyService(object):
         listener = lbaas_service.get_listener(l7policy['listener_id'])
         for policy_id in listener['l7_policies']:
             policy = lbaas_service.get_l7policy(policy_id['id'])
-            if policy and policy['provisioning_status'] != \
-                    plugin_const.PENDING_DELETE:
+            if policy:
                 os_policies['l7policies'].append(policy)
                 for rule in policy['rules']:
                     l7rule = lbaas_service.get_l7rule(rule['id'])

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_rpm]
-requires =  f5-sdk == 1.5.0
+requires =  f5-sdk == 2.1.0

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setuptools.setup(
             'f5-oslbaasv2-agent = f5_openstack_agent.lbaasv2.drivers.bigip.agent:main'
         ]
     },
-    install_requires=['f5-sdk==2.0.2']
+    install_requires=['f5-sdk==2.1.0']
 )
 


### PR DESCRIPTION
@jlongstaf 

#### What issues does this address?
Fixes #452 

#### What's this change do?
Modified the policy adapter to take mostly full control of translation.
It is now aware of policies that are being deleted and rules that are
being deleted. It is smart enough to know when the wrapper policy should
be deleted completely.

#### Where should the reviewer start?
Start at the policy adapter changes.

#### Any background context?
The l7policy adapter does not pay attention to policy provisioning
status nor does it do much by way of guessing what the work should be
for the BIG-IP. We need to make it a little more intelligent by having
it inspect provisioning status of the policies and rules and it will
inform the caller about the work that needs to be done. It will either
produce a JSON object for the caller to deploy onto the BIG-IP or it
will raise an exception, and if the exception is of a certain, the
caller will know that we can delete the wrapper policy on the device.
All other exceptions will be treated as errors.