### PR TITLE
Unable to delete pools with shared nodes (IP addresses)

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
@@ -15,6 +15,7 @@
 #
 
 from oslo_log import log as logging
+from requests import HTTPError
 import urllib
 
 from f5_openstack_agent.lbaasv2.drivers.bigip.resource_helper import \
@@ -157,10 +158,18 @@ class PoolServiceBuilder(object):
                            partition=part)
 
                 m.delete()
-                node = self.service_adapter.get_member_node(service)
-                self.node_helper.delete(bigip,
-                                        name=urllib.quote(node["name"]),
-                                        partition=node["partition"])
+                try:
+                    node = self.service_adapter.get_member_node(service)
+                    self.node_helper.delete(bigip,
+                                            name=urllib.quote(node["name"]),
+                                            partition=node["partition"])
+                except HTTPError as err:
+                    # Possilbe error if node is shared with another member.
+                    # If so, ignore the error.
+                    if err.response.status_code == 400:
+                        LOG.debug(err.message)
+                    else:
+                        raise
 
     def update_member(self, service, bigips):
         # TODO(jl) handle state -- SDK enforces at least state=None


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
Fixes #469 

#### What's this change do?
Adds exception handling when deleting a member node. 

#### Where should the reviewer start?
pool_service.py

#### Any background context?
Original code does handle use case where a node is shared between members.

Issues:
Fixes #469

Problem: BIG-IP returns an error when deleting a node
that is shared between two or more members.

Analysis: Added exception handling to look for 400 status code
and ignore, assuming that node is shared.

Tests: