### PR TITLE
Fix flake8 errors in test_l7policy_adapter module

### DIFF
--- a/f5_openstack_agent/tests/functional/adapters/test_l7policy_adapter.py
+++ b/f5_openstack_agent/tests/functional/adapters/test_l7policy_adapter.py
@@ -106,7 +106,6 @@ def test_adapter_redirect_to_pool_file_type_beginswith(
                 'actions': [
                     {
                         'forward': True, 'name': 0, 'request': True,
-                        'name': '0',
                         'pool': u'/Project_test/Project_test_pool'
                     }
                 ],
@@ -413,7 +412,7 @@ def test_adapter_redirect_to_pool_file_type_not_beginswith(
                 'actions': [
                     {
                         'forward': True, 'name': 0, 'request': True,
-                        'name': '0', 'pool': u'/Project_test/Project_test_pool'
+                        'pool': u'/Project_test/Project_test_pool'
                     }
                 ],
                 'conditions': [


### PR DESCRIPTION
@swormke 

#### What issues does this address?
Fixes #478 

#### What's this change do?
Fixup for flake8 failures in travis build after merging up tox infra into mitaka. Removed redundant dictionary keys.

#### Where should the reviewer start?

#### Any background context?