### PR TITLE
Functional tests should be ignored in travis build

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands = flake8 ./f5_openstack_agent
 basepython = python2.7
 deps = -rrequirements.unittest.txt
 changedir = f5_openstack_agent
-commands = py.test -svvra --cov {posargs}
+commands = py.test --ignore tests/functional -svvra --cov {posargs}
 
 [testenv:unit-buildbot]
 basepython = python2.7


### PR DESCRIPTION
@swormke 

#### What issues does this address?
Fixes #477

#### What's this change do?
Added --ignore flag in the mitaka branch to ignore these func tests.

#### Where should the reviewer start?

#### Any background context?
Travis build was failing due to unit tests attempting to run functional tests.