### PR TITLE
update tests with docs/flake8 to prep for nightly

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,8 @@
+''' Test utilities for creation and deletion of pools via the sdk.
+
+This fixture should be promoted to a more general library.  Probably
+f5_os_test.
+'''
 # Copyright 2015-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,6 +61,7 @@ def NAT(bigip):
 
 
 def _delete_pools_members(bigip, pool_records):
+    '''Get the members for the pool --> delete pool --> delete members'''
     for pr in pool_records:
         if bigip.ltm.pools.pool.exists(partition=pr.partition, name=pr.name):
             pool_inst = bigip.ltm.pools.pool.load(partition=pr.partition,
@@ -68,6 +74,7 @@ def _delete_pools_members(bigip, pool_records):
 
 @pytest.fixture
 def pool_factory():
+    '''Given pool record objects, set up and teardown tests for that pool.'''
     def _setup_boilerplate(bigip, request, pool_records):
         _delete_pools_members(bigip, pool_records)
         pool_registry = {}

--- a/test/test_cert.py
+++ b/test/test_cert.py
@@ -1,3 +1,8 @@
+'''
+test_requirements = {'devices':         [],
+                     'openstack_infra': [barbican, keystone]}
+
+'''
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test_cluster.py
+++ b/test/test_cluster.py
@@ -1,3 +1,8 @@
+'''
+test_requirements = {'devices':         [],
+                     'openstack_infra': []}
+
+'''
 # Copyright 2015-2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test_create_tls_container.py
+++ b/test/test_create_tls_container.py
@@ -1,3 +1,8 @@
+'''
+test_requirements = {'devices':         [],
+                     'openstack_infra': []}
+
+'''
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test_disconnected.py
+++ b/test/test_disconnected.py
@@ -1,3 +1,8 @@
+'''
+test_requirements = {'devices':         [],
+                     'openstack_infra': []}
+
+'''
 # Copyright 2106 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test_listener.py
+++ b/test/test_listener.py
@@ -1,3 +1,8 @@
+'''
+test_requirements = {'devices':         [],
+                     'openstack_infra': []}
+
+'''
 # Copyright 2015-2106 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test_network.py
+++ b/test/test_network.py
@@ -1,3 +1,8 @@
+'''
+test_requirements = {'devices':         [],
+                     'openstack_infra': []}
+
+'''
 # Copyright 2015-2106 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test_pool.py
+++ b/test/test_pool.py
@@ -1,3 +1,8 @@
+'''
+test_requirements = {'devices':         [VE],
+                     'openstack_infra': [Neutron or Neutronless]}
+
+'''
 # Copyright 2015-2106 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test_ssl_profile.py
+++ b/test/test_ssl_profile.py
@@ -1,3 +1,8 @@
+'''
+test_requirements = {'devices':         [VE],
+                     'openstack_infra': []}
+
+'''
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/test/test_stats.py
+++ b/test/test_stats.py
@@ -1,3 +1,8 @@
+'''
+test_requirements = {'devices':         [UNDERCLOUD],
+                     'openstack_infra': []}
+
+'''
 # Copyright 2016 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
@dflanigan 
#### What issues does this address?
Fixes #483

#### Any background context?

The removal of functionality from `conftest.py` reflects a need to consolidate fixtures into an appropriate pytest plugin for f5-common-python based testing.

These test suites have bit-rotted.  As a first step
towards resurrection annotate each module with a
docstring listing infrastructure requirements.

Fix flake8 violations (why doesn't CI catch these?!).