### PR TITLE
F5 OpenStack build infrastructure updates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,13 +95,14 @@ access to a BIG-IP device or VE instance.
 2. Run the functional tests by supplying the symbol file that you just created
    which includes the information relative to your environment using the
    example file. The example below runs the disconnected services neutronless
-   functional test cases.
+   functional test cases (the tox target changes to the [test/functional](test/functional)
+   directory before running.
 
 ::
 
     $ tox -e functest -- \
       --symbols ~/path/to/symbols/symbols.json \
-      ./test/functional/neutronless/disconnected_service
+      neutronless/disconnected_service
 
 Troubleshooting
 ===============

--- a/requirements.functest.txt
+++ b/requirements.functest.txt
@@ -3,7 +3,7 @@
 
 # OpenStack dependancies
 git+https://github.com/openstack/neutron@stable/liberty
-git+https://github.com/openstack/oslo.log.git@stable/liberty
+git+https://github.com/openstack/oslo.log.git@liberty-eol
 git+https://github.com/openstack/neutron-lbaas.git@stable/liberty
 
 # F5 LBaaS dependancies

--- a/requirements.unittest.txt
+++ b/requirements.unittest.txt
@@ -3,7 +3,7 @@
 
 # app
 git+https://github.com/openstack/neutron@stable/liberty
-git+https://github.com/openstack/oslo.log.git@stable/liberty
+git+https://github.com/openstack/oslo.log.git@liberty-eol
 git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@liberty
 git+https://github.com/F5Networks/f5-openstack-test.git
 git+https://github.com/openstack/neutron-lbaas.git@stable/liberty

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -30,16 +30,19 @@ VENV_ACTIVATE := $(MAKEFILE_DIR)/$(VENV)/bin/activate
 
 # Before we run any tests we need a virtualenv and a few packages
 pre-build:
-	virtualenv $(VENV); \
-	. $(VENV_ACTIVATE); \
-	pip install tox; \
-	pip install git+ssh://git@bldr-git.int.lineratesystems.com/tools/testenv.git; \
-	pip install git+ssh://git@bldr-git.int.lineratesystems.com/velcro/systest-common.git
+	sudo apt-get update; \
+	sudo apt-get install -y libssl-dev; \
+	sudo apt-get install -y libffi-dev; \
+	sudo -H pip install tox; \
+	sudo -H pip install git+ssh://git@bldr-git.int.lineratesystems.com/tools/testenv.git; \
+	sudo -H pip install git+ssh://git@bldr-git.int.lineratesystems.com/velcro/systest-common.git; \
+	sudo -H pip install git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-meta.git; \
+	sudo -H pip install git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-autolog.git; \
+	sudo -H pip install git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-symbols.git;
 
 unit: pre-build
-	. $(VENV_ACTIVATE); \
 	cd $(MAKEFILE_DIR)/../; \
-	tox -e unit-buildbot -- \
+	tox -e unit --sitepackages -- \
 		--exclude incomplete no_regression \
 		--autolog-outputdir $(unit_results) \
 		--autolog-session $(unit_session) \
@@ -59,13 +62,12 @@ disconnected_service:
 
 disconnected_service-setup: pre-build
 	@echo "setting up functional test environment ..."
-	. $(VENV_ACTIVATE); \
 	testenv create base; \
 	testenv create --name $(disconnected_session) --config $(testenv_config); \
 
 disconnected_service-run: pre-build
 	@echo "running disconnected tests ..."
-	tox -e functest-buildbot -- \
+	tox -e functest --sitepackage -- \
 		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
 		--exclude incomplete no_regression \
 		--autolog-outputdir $(disconnected_results) \
@@ -76,11 +78,9 @@ disconnected_service-teardown:
 	@echo "tearing down functional test environment..."
 	if [ ! -e $(disconnected_results) ]; then mkdir -p $(disconnected_results); fi
 	if [ ! -e $(unit_results) ]; then mkdir -p $(unit_results); fi
-	. $(VENV_ACTIVATE); \
 	testenv delete --name $(disconnected_session) --config $(testenv_config)
 
 # Remove the buildbot venv directory and any tox venvs we made
 clean:
-	-rm -rf $(MAKEFILE_DIR)/$(VENV)
 	-rm -rf $(MAKEFILE_DIR)/../.tox/functest-buildbot
 	-rm -rf $(MAKEFILE_DIR)/../.tox/unit-buildbot

--- a/test/functional/neutronless/disconnected_service/test_disconnected_service_creation.py
+++ b/test/functional/neutronless/disconnected_service/test_disconnected_service_creation.py
@@ -190,6 +190,12 @@ def setup_l2adjacent_test(request, bigip, makelogdir):
     loghandler = setup_neutronless_test(request, bigip, makelogdir, vlan=True)
     LOG.info('Test setup: %s' % request.node.name)
 
+    # FIXME: This is a work around for GH issue #487
+    # https://github.com/F5Networks/f5-openstack-agent/issues/487
+    def kill_icontrol():
+        time.sleep(2)
+    request.addfinalizer(kill_icontrol)
+
     try:
         remove_elements(bigip,
                         SEG_INDEPENDENT_LB_URIS |

--- a/test/functional/neutronless/service_object_rename/Dockerfiles/Dockerfile.xenial_liberty
+++ b/test/functional/neutronless/service_object_rename/Dockerfiles/Dockerfile.xenial_liberty
@@ -25,7 +25,7 @@ RUN pip install paramiko
 RUN pip install decorator
 RUN pip install -e git+https://github.com/openstack/neutron#egg=neutron
 RUN pip install -e git+https://github.com/openstack/neutron-lbaas.git#egg=neutron_lbaas
-RUN pip install --upgrade git+https://github.com/openstack/oslo.log.git@stable/liberty
+RUN pip install --upgrade git+https://github.com/openstack/oslo.log.git@liberty-eol
 RUN pip install --upgrade git+https://github.com/F5Networks/f5-openstack-test.git@liberty
 # RUN pip install --upgrade git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@liberty
 RUN pip install --upgrade git+https://github.com/F5Networks/pytest-symbols.git

--- a/tox.ini
+++ b/tox.ini
@@ -16,27 +16,8 @@ deps = -rrequirements.unittest.txt
 changedir = f5_openstack_agent
 commands = py.test -svvra --cov {posargs}
 
-[testenv:unit-buildbot]
-basepython = python2.7
-changedir = f5_openstack_agent
-deps =
-    git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-meta.git
-    git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-autolog.git
-    -rrequirements.unittest.txt
-commands = py.test -svvra --cov {posargs}
-
 [testenv:functest]
 basepython = python2.7
 changedir = test/functional/
 deps = -rrequirements.functest.txt
-commands = py.test --cov -svvra {posargs}
-
-[testenv:functest-buildbot]
-basepython = python2.7
-changedir = test/functional/
-deps =
-    git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-meta.git
-    git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-autolog.git
-    git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-symbols.git
-    -rrequirements.functest.txt
 commands = py.test --cov -svvra {posargs}


### PR DESCRIPTION
@mattgreene 

#### What issues does this address?
Fixes #460 
Fixes #485 

#### What's this change do?

1. Updates the requirements file to use the liberty-eol tag for repos that have it.
2. Fixes buildbot issues for missing dependancies in bastionless tests.
3. Simplifies the tox environment list to user facing ones.

#### Where should the reviewer start?
* Look at the makefile and tox.ini files

#### Any background context?
* Need to do this to get nightly tests passing again.