### PR TITLE
Add singleve tests to nightly from "test"

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -28,15 +28,16 @@ VENV_ACTIVATE := $(MAKEFILE_DIR)/$(VENV)/bin/activate
 
 # Before we run any tests we need a virtualenv and a few packages
 pre-build:
-	sudo apt-get update; \
-	sudo apt-get install -y libssl-dev; \
-	sudo apt-get install -y libffi-dev; \
-	sudo -H pip install tox; \
-	sudo -H pip install git+ssh://git@bldr-git.int.lineratesystems.com/tools/testenv.git; \
-	sudo -H pip install git+ssh://git@bldr-git.int.lineratesystems.com/velcro/systest-common.git; \
-	sudo -H pip install git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-meta.git; \
-	sudo -H pip install git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-autolog.git; \
-	sudo -H pip install git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-symbols.git;
+	sudo -E apt-get update; \
+	sudo -E apt-get install -y libssl-dev; \
+	sudo -E apt-get install -y libffi-dev; \
+	sudo -E -H pip install --upgrade pip; \
+	sudo -E -H pip install tox; \
+	sudo -E -H pip install git+ssh://git@bldr-git.int.lineratesystems.com/tools/testenv.git; \
+	sudo -E -H pip install git+ssh://git@bldr-git.int.lineratesystems.com/velcro/systest-common.git; \
+	sudo -E -H pip install git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-meta.git; \
+	sudo -E -H pip install git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-autolog.git; \
+	sudo -E -H pip install git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-symbols.git;
 
 unit: pre-build
 	cd $(MAKEFILE_DIR)/../; \
@@ -52,6 +53,7 @@ functest:
 functest_all:
 	@echo "automated functional tests..."
 	$(MAKE) -C . disconnected_service
+	$(MAKE) -C . singleve
 
 disconnected_service:
 	$(MAKE) -C . disconnected_service-setup
@@ -60,8 +62,8 @@ disconnected_service:
 
 disconnected_service-setup: pre-build
 	@echo "setting up functional test environment ..."
-	testenv create base; \
-	testenv create --name $(disconnected_session) --config $(testenv_config); \
+	TESTENV_PATH=/usr/local/share/testenv testenv create base; \
+	TESTENV_PATH=/usr/local/share/testenv testenv create --name $(disconnected_session) --config $(testenv_config); \
 
 disconnected_service-run: pre-build
 	@echo "running disconnected tests ..."
@@ -76,7 +78,32 @@ disconnected_service-teardown:
 	@echo "tearing down functional test environment..."
 	if [ ! -e $(disconnected_results) ]; then mkdir -p $(disconnected_results); fi
 	if [ ! -e $(unit_results) ]; then mkdir -p $(unit_results); fi
-	testenv delete --name $(disconnected_session) --config $(testenv_config)
+	TESTENV_PATH=/usr/local/share/testenv testenv delete --name $(disconnected_session) --config $(testenv_config)
+
+singleve:
+	$(MAKE) -C . singleve-setup
+	$(MAKE) -C . singleve-run
+	$(MAKE) -C . singleve-teardown
+
+singleve-setup: pre-build
+	@echo "setting up functional test environment ..."
+	TESTENV_PATH=/usr/local/share/testenv testenv create base; \
+	TESTENV_PATH=/usr/local/share/testenv testenv create --name singleve --config $(testenv_config); \
+
+singleve-run: pre-build
+	@echo "running disconnected tests ..."
+	tox -e functest --sitepackage -- \
+		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
+		--exclude incomplete no_regression \
+		--autolog-outputdir $(RESULTSDIR) \
+		--autolog-session singleve \
+		singleve || $(MAKE) -C . singleve-teardown
+
+singleve-teardown:
+	@echo "tearing down functional test environment..."
+	if [ ! -e singleve_results ]; then mkdir -p singleve_results; fi
+	if [ ! -e $(unit_results) ]; then mkdir -p $(unit_results); fi
+	TESTENV_PATH=/usr/local/share/testenv testenv delete --name singleve --config $(testenv_config)
 
 # Remove the buildbot venv directory and any tox venvs we made
 clean:

--- a/test/functional/singleve/test_pool.py
+++ b/test/functional/singleve/test_pool.py
@@ -27,17 +27,17 @@ from f5_openstack_agent.lbaasv2.drivers.bigip.loadbalancer_service import \
     LoadBalancerServiceBuilder
 
 
-def test_create_listener():
+def test_create_listener(symbols):
     lb_service = LoadBalancerServiceBuilder()
     pool_builder = PoolServiceBuilder()
-    bigips = [BigIP('10.190.5.7', 'admin', 'admin')]
+    bigips = [BigIP(symbols.bigip_mgmt_ip_public, 'admin', 'admin')]
     service = json.load(open("service.json"))["service"]
 
     try:
         # create partition
         lb_service.prep_service(service, bigips)
 
-        # create BIG-IP® virtual servers
+        # create BIG-IP virtual servers
         pools = service["pools"]
         loadbalancer = service["loadbalancer"]
 

--- a/test/functional/singleve/test_ssl_profile.py
+++ b/test/functional/singleve/test_ssl_profile.py
@@ -52,8 +52,7 @@ JbZPlUsnZV6Xo/b7StCfDd0ODLugbxq87lHx/RN2WC3/M223gLx7S0Py0ZEdHWDm
 GpmzRO2r9gpv/VEMlKsCQQCV+EffCQ4wKBIYeCchdntop1/A9PWWCS+pjUNdIJNR
 CKxlxUfEZw9yNfLw9g0FKxrdSZiHCAw7fwN7s+CszjT4
 -----END RSA PRIVATE KEY-----"""
-
-def test_create_client_ssl_profile():
+def test_create_client_ssl_profile(symbols):
 
     # set of valid and invalid parent profile names
     test_parents = [None,
@@ -62,7 +61,7 @@ def test_create_client_ssl_profile():
                     "clientssl",
                     "clientssl-insecure-compatible"]
 
-    bigip = ManagementRoot('10.190.7.235', 'admin', 'admin')
+    bigip = ManagementRoot(symbols.bigip_mgmt_ip_public, 'admin', 'admin')
 
     for parent in test_parents:
         name = random_name('Project_', 16)

--- a/tox.ini
+++ b/tox.ini
@@ -21,3 +21,9 @@ basepython = python2.7
 changedir = test/functional/
 deps = -rrequirements.functest.txt
 commands = py.test --cov -svvra {posargs}
+
+[testenv:singleve]
+basepython = python2.7
+changedir = test/functional/
+deps = -rrequirements.functest.txt
+commands = py.test --cov -svvra {posargs}


### PR DESCRIPTION
@dflanigan when this PR is merged we can close:

https://jira.pdsea.f5net.com/browse/OPENSTACK-690

But, let's wait on travis before we merge!

Issues:
Fixes:#513

Problem: Older tests exist that have not been incorporated into
the nightly regression.  This commit adds "single ve" requiring
tests to the nightly regression infrastructure.

Analysis:  This expands our automated testing!

Tests: See nightly!

@dflanigan 
#### What issues does this address?
Fixes #513 
WIP #483 
...
