### PR TITLE
the f5_os_test package brought overhead no benefit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ __pycache__/
 *.so
 
 # Distribution / packaging
+.containenv
 .Python
 env/
 build/

--- a/f5-openstack-agent-dist/deb_dist/stdeb.cfg
+++ b/f5-openstack-agent-dist/deb_dist/stdeb.cfg
@@ -1,3 +1,3 @@
 [DEFAULT]
 Depends:
-	python-f5-sdk (=1.5.0-1)
+	python-f5-sdk (=2.2.0-1)

--- a/requirements.functest.txt
+++ b/requirements.functest.txt
@@ -10,7 +10,6 @@ git+https://github.com/openstack/neutron-lbaas.git@stable/liberty
 git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@liberty
 
 # Test utilities
-git+https://github.com/F5Networks/f5-openstack-test.git
 git+https://github.com/F5Networks/pytest-symbols.git
 
 mock==2.0.0

--- a/requirements.unittest.txt
+++ b/requirements.unittest.txt
@@ -5,7 +5,6 @@
 git+https://github.com/openstack/neutron@stable/liberty
 git+https://github.com/openstack/oslo.log.git@liberty-eol
 git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@liberty
-git+https://github.com/F5Networks/f5-openstack-test.git
 git+https://github.com/openstack/neutron-lbaas.git@stable/liberty
 
 mock==2.0.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [bdist_rpm]
-requires =  f5-sdk == 1.5.0
+requires =  f5-sdk >= 2.2.0

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setuptools.setup(
             'f5-oslbaasv2-agent = f5_openstack_agent.lbaasv2.drivers.bigip.agent:main'
         ]
     },
-    install_requires=['f5-sdk==1.5.0']
+    install_requires=['f5-sdk>=2.2.0, <3']
 )
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,6 @@
 ''' Test utilities for creation and deletion of pools via the sdk.
 
-This fixture should be promoted to a more general library.  Probably
-f5_os_test.
+This fixture should be promoted to a more general library.
 '''
 # Copyright 2015-2016 F5 Networks Inc.
 #

--- a/test/functional/neutronless/conftest.py
+++ b/test/functional/neutronless/conftest.py
@@ -21,8 +21,8 @@ import time
 
 from f5.bigip import ManagementRoot
 from f5.utils.testutils.registrytools import register_device
-from f5_os_test.order_utils import AGENT_LB_DEL_ORDER
-from f5_os_test.order_utils import order_by_weights
+from f5.utils.testutils.registrytools import AGENT_LB_DEL_ORDER
+from f5.utils.testutils.registrytools import order_by_weights
 from icontrol.exceptions import iControlUnexpectedHTTPError
 
 from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import\

--- a/test/functional/neutronless/disconnected_service/Dockerfile
+++ b/test/functional/neutronless/disconnected_service/Dockerfile
@@ -15,8 +15,6 @@
 
 From test_base:latest
 
-COPY ./f5-openstack-test/ /root/devenv/f5-openstack-test/
-RUN pip install --upgrade /root/devenv/f5-openstack-test
 COPY ./f5-openstack-agent/ /root/devenv/f5-openstack-agent/
 RUN pip install --upgrade /root/devenv/f5-openstack-agent
 WORKDIR /root/devenv/f5-openstack-agent/test/functional/neutronless/l2adjacent

--- a/test/functional/neutronless/service_object_rename/Dockerfiles/Dockerfile.oldnames_agent
+++ b/test/functional/neutronless/service_object_rename/Dockerfiles/Dockerfile.oldnames_agent
@@ -18,7 +18,6 @@ RUN pip install pytest
 RUN pip install pytest-cov
 
 # Install our test extensions.
-RUN pip install --upgrade git+https://github.com/F5Networks/f5-openstack-test.git@liberty
 RUN pip install --upgrade git+https://github.com/F5Networks/pytest-symbols.git
 
 # Enter your fork and branch below

--- a/test/functional/neutronless/service_object_rename/Dockerfiles/Dockerfile.trusty_liberty
+++ b/test/functional/neutronless/service_object_rename/Dockerfiles/Dockerfile.trusty_liberty
@@ -18,7 +18,6 @@ RUN pip install pytest
 RUN pip install pytest-cov
 
 # Install our test extensions.
-RUN pip install --upgrade git+https://github.com/F5Networks/f5-openstack-test.git@liberty
 RUN pip install --upgrade git+https://github.com/F5Networks/pytest-symbols.git
 
 # Enter your fork and branch below

--- a/test/functional/neutronless/service_object_rename/Dockerfiles/Dockerfile.xenial_liberty
+++ b/test/functional/neutronless/service_object_rename/Dockerfiles/Dockerfile.xenial_liberty
@@ -26,7 +26,6 @@ RUN pip install decorator
 RUN pip install -e git+https://github.com/openstack/neutron#egg=neutron
 RUN pip install -e git+https://github.com/openstack/neutron-lbaas.git#egg=neutron_lbaas
 RUN pip install --upgrade git+https://github.com/openstack/oslo.log.git@liberty-eol
-RUN pip install --upgrade git+https://github.com/F5Networks/f5-openstack-test.git@liberty
 # RUN pip install --upgrade git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@liberty
 RUN pip install --upgrade git+https://github.com/F5Networks/pytest-symbols.git
 

--- a/test/functional/neutronless/service_object_rename/Dockerfiles/Dockerfile.xenial_mitaka
+++ b/test/functional/neutronless/service_object_rename/Dockerfiles/Dockerfile.xenial_mitaka
@@ -26,7 +26,6 @@ RUN pip install decorator
 RUN pip install -e git+https://github.com/openstack/neutron#egg=neutron
 RUN pip install -e git+https://github.com/openstack/neutron-lbaas.git#egg=neutron_lbaas
 RUN pip install --upgrade git+https://github.com/openstack/oslo.log.git@stable/mitaka
-RUN pip install --upgrade git+https://github.com/F5Networks/f5-openstack-test.git@liberty
 # RUN pip install --upgrade git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@mitaka
 RUN pip install --upgrade git+https://github.com/F5Networks/pytest-symbols.git
 

--- a/test/functional/neutronless/service_object_rename/conftest.py
+++ b/test/functional/neutronless/service_object_rename/conftest.py
@@ -22,8 +22,8 @@ import time
 
 from f5.bigip import ManagementRoot
 from f5.utils.testutils.registrytools import register_device
-from f5_os_test.order_utils import AGENT_LB_DEL_ORDER
-from f5_os_test.order_utils import order_by_weights
+from f5.utils.testutils.registrytools import AGENT_LB_DEL_ORDER
+from f5.utils.testutils.registrytools import order_by_weights
 from icontrol.exceptions import iControlUnexpectedHTTPError
 
 class MatchFilter(logging.Filter):

--- a/test/functional/neutronless/vcmp/Dockerfile
+++ b/test/functional/neutronless/vcmp/Dockerfile
@@ -25,7 +25,6 @@ RUN pip install decorator
 RUN pip install git+https://github.com/openstack/neutron@stable/$BRANCH
 RUN pip install git+https://github.com/openstack/neutron-lbaas.git@stable/$BRANCH
 RUN pip install git+https://github.com/openstack/oslo.log.git@stable/$BRANCH
-RUN pip install git+https://github.com/F5Networks/f5-openstack-test.git@liberty
 RUN pip install git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@$BRANCH
 RUN pip install git+https://github.com/F5Networks/pytest-symbols.git
 # Enter your fork and branch below


### PR DESCRIPTION
Issues:
Fixes #526, #548

Problem:  Logic was innappropriately bundled into a separate
repository "f5-openstack-test" this caused maintenance,
packaging, and dependency management issues for little benefit.

Analysis:  The logic required by f5-openstack-agent has now
been migrated into f5-common-python (upon which it already depends)

NOTE this PR cannot be closed until the 2.2.0 version of the SDK is
released.

@richbrowne 
#### What issues does this address?
Fixes #526, #548

...

#### What's this change do?
Completely eliminate reference to f5-openstack-test.