### PR TITLE
vCMP Neutronless tests failing with bad assertions

### DIFF
--- a/test/functional/neutronless/vcmp/test_vcmp.py
+++ b/test/functional/neutronless/vcmp/test_vcmp.py
@@ -154,7 +154,6 @@ def check_host_and_guest_vlans_on_delete(vcmp_host, bigip):
     assert GUEST_VLAN not in bigip_vlans
     assert COMMON_VLAN not in bigip_vlans
     vcmp_host['guest'].refresh()
-    assert not hasattr(vcmp_host['guest'], 'vlans')
     assert vcmp_host['bigip'].tm.net.vlans.vlan.exists(
         name='vlan-46', partition='Common') is False
     assert bigip.tm.sys.folders.folder.exists(
@@ -228,7 +227,9 @@ def test_vcmp_deletelb(setup_bigip_devices, bigip, vcmp_setup, vcmp_uris):
             deepcopy(DELETELB),
             delete_partition=True)
     # After the deletelb is called above, the vcmp guest should no longer
+    # have the vlan attached
     check_host_and_guest_vlans_on_delete(vcmp_host[0], bigip)
+    assert not hasattr(vcmp_host[0]['guest'], 'vlans')
 
 
 def test_vcmp_deletelb_with_mgmt_vlan(
@@ -339,6 +340,7 @@ def test_vcmp_delete_listener(
             deepcopy(DELETELB),
             delete_partition=True)
     check_host_and_guest_vlans_on_delete(vcmp_host[0], bigip)
+    assert not hasattr(vcmp_host[0]['guest'], 'vlans')
 
 
 @mock.patch('f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver.'
@@ -514,3 +516,4 @@ def test_vcmp_delete_listener_flat(
             deepcopy(DELETELB),
             delete_partition=True)
     check_host_and_guest_vlans_on_delete(vcmp_host[0], bigip)
+    assert not hasattr(vcmp_host[0]['guest'], 'vlans')


### PR DESCRIPTION
@jlongstaf 

#### What issues does this address?
Fixes: Issue #532

#### Any background context?
It appears that the proper source code changes were made here, but test updates were not done properly to mirror the code changes. This issue tracks the update of only those tests to reflect the vCMP code changes for #447.

#### What's this change do?
Fixed the bad assertions, which were left over from a merge of code prior to the 447 fix.

#### Where should the reviewer start?
Only test_vcmp.py changes here.

