### PR TITLE
Common network bound to disconnected_network for opflex deployment

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1164,11 +1164,9 @@ class iControlDriver(LBaaSBaseDriver):
             # This loop will only run once.  Using while as a control-flow
             # mechanism to flatten out the code by allowing breaks.
             while (self.network_builder):
-                networks = service['networks']
-                network_id = service['loadbalancer']['network_id']
-                network = networks.get(network_id, {})
 
-                if not self.network_builder.is_common_network(network) and \
+                if not self.service_adapter.vip_on_common_network(service) \
+                     and \
                    not self.disconnected_service.is_service_connected(service):
                     if self.disconnected_service_polling.enabled:
                         # Hierarchical port-binding mode:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
@@ -62,7 +62,10 @@ class ListenerServiceBuilder(object):
 
         service['listener']['operating_status'] = lb_const.ONLINE
         # Hierarchical Port Binding mode adjustments
-        if not self.disconnected_service.is_service_connected(service):
+        if not self.disconnected_service.is_service_connected(service) \
+           and \
+           not self.service_adapter.vip_on_common_network(service):
+
             # start the virtual server on a disconnected network if the neutron
             # network does not yet exist
             network_name = DisconnectedService.network_name

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -57,6 +57,11 @@ class ServiceModelAdapter(object):
     def snat_count(self):
         return self.conf.f5_snat_addresses_per_subnet
 
+    def vip_on_common_network(self, service):
+        loadbalancer = service.get('loadbalancer', {})
+        network_id = loadbalancer.get('network_id', "")
+        return (network_id in self.conf.common_network_ids)
+
     def init_pool_name(self, loadbalancer, pool):
         name = self.prefix + pool["id"]
 
@@ -352,6 +357,11 @@ class ServiceModelAdapter(object):
         if network_id in bigip.assured_networks:
             vip['vlans'].append(
                 bigip.assured_networks[network_id])
+            vip['vlansEnabled'] = True
+            vip.pop('vlansDisabled', None)
+        elif network_id in self.conf.common_network_ids:
+            vip['vlans'].append(
+                self.conf.common_network_ids[network_id])
             vip['vlansEnabled'] = True
             vip.pop('vlansDisabled', None)
 

--- a/test/functional/neutronless/disconnected_service/test_disconnected_service_creation.py
+++ b/test/functional/neutronless/disconnected_service/test_disconnected_service_creation.py
@@ -627,3 +627,27 @@ def test_featureoff_nosegid_common_lb_net(setup_l2adjacent_test, bigip):
     assert rpc.update_loadbalancer_status.call_args_list == [
         call(u'50c5d54a-5a9e-4a80-9e74-8400a461a077', 'ACTIVE', 'ONLINE')
     ]
+
+def test_featureoff_nosegid_create_listener_common_lb_net(setup_l2adjacent_test, bigip):
+    icontroldriver, start_registry = handle_init_registry(bigip, FEATURE_OFF_COMMON_NET)
+    service = deepcopy(NOSEGID_CREATELISTENER)
+    logcall(setup_l2adjacent_test,
+            icontroldriver._common_service_handler,
+            service)
+    after_create_registry = register_device(bigip)
+    create_uris = (set(after_create_registry.keys()) -
+                   set(start_registry.keys()))
+    assert create_uris == SEG_INDEPENDENT_LB_URIS_COMMON_NET | \
+        SEG_INDEPENDENT_LB_URIS | \
+        NOSEG_LB_URIS | NOSEG_LISTENER_URIS
+
+    logfilename = setup_l2adjacent_test.baseFilename
+    assert not ERROR_MSG_MISCONFIG in open(logfilename).read()
+    rpc = icontroldriver.plugin_rpc
+
+    assert rpc.update_loadbalancer_status.call_args_list == [
+        call(u'50c5d54a-5a9e-4a80-9e74-8400a461a077', 'ACTIVE', 'ONLINE')
+    ]
+    assert rpc.update_listener_status.call_args_list == [
+        call(u'105a227a-cdbf-4ce3-844c-9ebedec849e9', 'ACTIVE', 'ONLINE')
+    ]


### PR DESCRIPTION
Issues:
Fixes #538,#523

Problem:
Virtual server is bound to the dummy network disconnected_network
when the segmentation ID is not present.  This occurs even if the
network is defined in the list of common_network_ids.

When a listener is created on a network that does not have a seg
id, the virtual server will be created on the disconnected net,
but it should be connected on the vlan paired with the network
id.

Analysis:
Create a new function in the service_adapter to return true if
the VIP is associated with a network defined in the list of
common networks.  Use this function when creating a virtual server
and determining whether or not a service is connected.

Also, extend the function to add a common_network to the list
of networks that a virtual is enabled on.

Tests:
Disconnected network tests
Added test_featureoff_nosegid_create_listener_common_lb_net

