### PR TITLE
Issues: Install test does not test validity of packages (rpm/deb)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ before_install:
 
 install:
     - pip install tox
-    - pip install ordereddict
-    - pip install six
 script:
     - tox -e style,unit
     - f5-openstack-agent-dist/scripts/package_agent.sh "redhat" "7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ before_install:
 
 install:
     - pip install tox
+    - pip install ordereddict
+    - pip install six
 script:
     - tox -e style,unit
     - f5-openstack-agent-dist/scripts/package_agent.sh "redhat" "7"
@@ -28,8 +30,8 @@ script:
 after_success:
   - md5sum ${PKG_RELEASE_EL7} > ${PKG_RELEASE_EL7}.md5 && md5sum --check ${PKG_RELEASE_EL7}.md5
   - md5sum ${PKG_RELEASE_1404} > ${PKG_RELEASE_1404}.md5 && md5sum --check ${PKG_RELEASE_1404}.md5
-  - f5-openstack-agent-dist/scripts/test_install.sh "redhat" "7"
-  - f5-openstack-agent-dist/scripts/test_install.sh "ubuntu" "14.04"
+  - f5-openstack-agent-dist/scripts/test_install.sh "redhat" "7" ${PKG_RELEASE_EL7}
+  - f5-openstack-agent-dist/scripts/test_install.sh "ubuntu" "14.04" ${PKG_RELEASE_1404}
 deploy:
   - provider: releases
     api_key:

--- a/f5-openstack-agent-dist/Docker/redhat/install_test/Dockerfile.centos7
+++ b/f5-openstack-agent-dist/Docker/redhat/install_test/Dockerfile.centos7
@@ -7,6 +7,6 @@ COPY ./fetch_and_install_deps.py /
 
 RUN chmod 500 /fetch_and_install_deps.py
 
-ENTRYPOINT ["/fetch_and_install_deps", "/var/wdir"]
+ENTRYPOINT ["/fetch_and_install_deps.py", "/var/wdir"]
 # by default, the following will be used for the last execution:
 CMD ["/var/wdir/f5-openstack-agent-dist/rpms/build/f5-openstack-agent-*.el7.noarch.rpm"]

--- a/f5-openstack-agent-dist/Docker/redhat/install_test/Dockerfile.centos7
+++ b/f5-openstack-agent-dist/Docker/redhat/install_test/Dockerfile.centos7
@@ -1,5 +1,12 @@
+# Dockerfile
 FROM centos:7
 
 RUN yum update -y && yum install git python-requests -y
 
 COPY ./fetch_and_install_deps.py /
+
+RUN chmod 500 /fetch_and_install_deps.py
+
+ENTRYPOINT ["/fetch_and_install_deps", "/var/wdir"]
+# by default, the following will be used for the last execution:
+CMD ["/var/wdir/f5-openstack-agent-dist/rpms/build/f5-openstack-agent-*.el7.noarch.rpm"]

--- a/f5-openstack-agent-dist/Docker/redhat/install_test/fetch_and_install_deps.py
+++ b/f5-openstack-agent-dist/Docker/redhat/install_test/fetch_and_install_deps.py
@@ -8,7 +8,6 @@ import sys
 
 from collections import deque, namedtuple
 
-f5_sdk_pattern = re.compile("^f5-sdk\s*=\s*(\d+\.\d+\.\d+)$")
 f5_icontrol_rest_pattern = re.compile(
     "^f5-icontrol-rest\s*=\s*(\d+\.\d+\.\d+)$")
 dep_match_re = re.compile('^((python|f5-sdk)[\w\-]*)\s([<>=]{1,2})\s(\S+)')

--- a/f5-openstack-agent-dist/Docker/redhat/install_test/fetch_and_install_deps.py
+++ b/f5-openstack-agent-dist/Docker/redhat/install_test/fetch_and_install_deps.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function
+
 import glob
 import os
 import re
@@ -8,25 +10,23 @@ import sys
 
 from collections import deque, namedtuple
 
-f5_icontrol_rest_pattern = re.compile(
-    "^f5-icontrol-rest\s*=\s*(\d+\.\d+\.\d+)$")
 dep_match_re = re.compile('^((python|f5-sdk)[\w\-]*)\s([<>=]{1,2})\s(\S+)')
 
 
 def usage():
-    print "fetch_dependencies.py working_dir"
+    print("fetch_dependencies.py working_dir")
 
 
 def runCommand(cmd):
     output = ""
-    print " -- %s" % (cmd)
+    print(" -- %s" % (cmd))
     try:
         p = subprocess.Popen(cmd.split(),
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
         (output) = p.communicate()[0]
-    except OSError, e:
-        print >>sys.stderr, "Execution failed: ", e
+    except OSError as e:
+        print("Execution failed: ", e, file=sys.stderr)
     return (output, p.returncode)
 
 
@@ -36,27 +36,27 @@ def fetch_agent_dependencies(dist_dir, version, release, agent_pkg):
     requires = deque()
     # Copy agent package to /tmp
     cpCmd = "cp %s /tmp" % agent_pkg
-    print "Copying agent package to /tmp install directory"
+    print("Copying agent package to /tmp install directory")
     (output, status) = runCommand(cpCmd)
     if status != 0:
-        print "Failed to copy f5-openstack-agent package"
+        print("Failed to copy f5-openstack-agent package")
     else:
-        print "Success"
+        print("Success")
 
     # Get the sdk requirement.
     requiresCmd = "rpm -qRp %s" % agent_pkg
     agent_pkg_base = os.path.basename(agent_pkg)
-    print "Getting dependencies for %s." % agent_pkg_base
+    print("Getting dependencies for %s." % agent_pkg_base)
     (output, status) = runCommand(requiresCmd)
 
     if status != 0:
-        print "Can't get package dependencies for %s" % agent_pkg_base
+        print("Can't get package dependencies for %s" % agent_pkg_base)
         return 1
     else:
-        print "Success"
+        print("Success")
 
     for line in output.split('\n'):
-        print line, dep_match_re.pattern
+        print(line, dep_match_re.pattern)
         match = dep_match_re.match(line)
         if match:
             groups = list(match.groups())
@@ -67,9 +67,8 @@ def fetch_agent_dependencies(dist_dir, version, release, agent_pkg):
                 requires.append(my_dep)
 
     # we know we will always need this...
-    print requires
     if not f5_sdk_version:
-        print "Can't find f5-sdk dependency for %s" % (agent_pkg)
+        print("Can't find f5-sdk dependency for %s" % (agent_pkg))
         return 1
 
     # Check if the required packages are present, then install the ones we are
@@ -82,26 +81,29 @@ def fetch_agent_dependencies(dist_dir, version, release, agent_pkg):
     curlCmd = ("curl -L -o /tmp/%s %s/f5-sdk-%s-1.el7.noarch.rpm" %
                (f5_sdk_pkg, github_sdk_url, f5_sdk_version))
 
-    print "Fetching f5-sdk package from github"
+    print("Fetching f5-sdk package from github")
     (output, status) = runCommand(curlCmd)
 
     # Get the icontrol rest dependency
     requiresCmd = "rpm -qRp /tmp/%s" % (f5_sdk_pkg)
-    print "Getting dependencies for %s." % (f5_sdk_pkg)
+    print("Getting dependencies for %s." % (f5_sdk_pkg))
     (output, status) = runCommand(requiresCmd)
     if status != 0:
-        print "Failed to to get requirements for %s." % (f5_sdk_pkg)
+        print("Failed to to get requirements for %s." % (f5_sdk_pkg))
         return 1
     else:
-        print "Success"
+        print("Success")
 
     for line in output.split('\n'):
-        m = f5_icontrol_rest_pattern.match(line)
+        m = dep_match_re.search(line)
         if m:
-            f5_icr_version = m.group(1)
-            break
+            my_dep = ReqDetails(*m.groups())
+            if 'f5-icontrol-rest' in my_dep.name and \
+                    re.search('^>?=', my_dep.oper):
+                f5_icr_version = my_dep.version
+                break
     if not f5_sdk_version:
-        print "Can't find f5-sdk dependency for %s" % (f5_sdk_pkg)
+        print("Can't find f5-sdk dependency for %s" % (f5_sdk_pkg))
         return 1
 
     # Fectch the icontrol rest package
@@ -112,21 +114,21 @@ def fetch_agent_dependencies(dist_dir, version, release, agent_pkg):
     curlCmd = ("curl -L -o /tmp/%s %s/%s" %
                (f5_icr_pkg, github_icr_url, f5_icr_pkg))
 
-    print "Fetching f5-icontrol-reset package from github"
+    print("Fetching f5-icontrol-reset package from github")
     (output, status) = runCommand(curlCmd)
 
     if status != 0:
-        print "Failed to to fetch f5-icontrol-rest package."
+        print("Failed to to fetch f5-icontrol-rest package.")
         return 1
     else:
-        print "Success on F5 Libraries"
+        print("Success on F5 Libraries")
     return check_other_dependencies(requires, dist_dir, agent_pkg)
 
 
 def check_other_dependencies(requires, dist_dir, agent_pkg):
     # triage the packages already installed
     rpm_list_cmd = "rpm -qa"
-    print "Collecting a list of already-install pkgs"
+    print("Collecting a list of already-install pkgs")
     (output, status) = runCommand(rpm_list_cmd)
     to_get = deque()
     ignore = []
@@ -135,7 +137,7 @@ def check_other_dependencies(requires, dist_dir, agent_pkg):
         if my_dep.name not in output and my_dep.name not in ignore:
             to_get.append(my_dep)
     # install the repo-stored rpm's
-    print "Grabbing the ones we have copies of"
+    print("Grabbing the ones we have copies of")
     to_install = glob.glob(dist_dir + "/Docker/redhat/7/*.rpm")
     for rpm_file in to_install:
         for rpm_dep in to_get:
@@ -144,14 +146,14 @@ def check_other_dependencies(requires, dist_dir, agent_pkg):
         rpm_install_cmd = "rpm -i %s" % rpm_file
         runCommand(rpm_install_cmd)
     if to_get:
-        print "WARNING: there are missing dependencies!"
+        print("WARNING: there are missing dependencies!")
         while to_get:
             dep = to_get.popleft()
-            print "%s %s %s" % (dep.name, dep.oper, dep.version)
+            print("%s %s %s" % (dep.name, dep.oper, dep.version))
     else:
-        print """Succsess!
+        print("""Succsess!
 All dependencies search satisfied!  However, by-version check may still fail...
-"""
+""")
     # change to be dynamic if we decide to be more rigorous at this stage...
     return 0
 
@@ -160,7 +162,7 @@ def install_agent_pkgs(repo):
     installCmd = "rpm -ivh /tmp/*.rpm"
     (output, status) = runCommand(installCmd)
     if status != 0:
-        print "Agent install failed"
+        print("Agent install failed")
         sys.exit(1)
 
 
@@ -173,9 +175,9 @@ def main(args):
     pkg_fullname = args[2]
     try:
         os.chdir("/var/wdir")
-    except OSError, e:
-        print >>sys.stderr, "Can't change to directory %s (%s)" % (working_dir,
-                                                                   e)
+    except OSError as e:
+        print("Can't change to directory %s (%s)" % (working_dir, e),
+              file=sys.stderr)
 
     dist_dir = os.path.join(working_dir, "f5-openstack-agent-dist")
     version_tool = os.path.join(dist_dir, "scripts/get-version-release.py")

--- a/f5-openstack-agent-dist/Docker/ubuntu/install_test/Dockerfile.trusty
+++ b/f5-openstack-agent-dist/Docker/ubuntu/install_test/Dockerfile.trusty
@@ -5,8 +5,6 @@ COPY ./fetch_and_install_deps.py /
 RUN apt-get update -y && apt-get install software-properties-common -y
 RUN apt-add-repository cloud-archive:liberty
 RUN apt-get update -y && apt-get dist-upgrade -y --force-yes
-RUN apt-add-repository cloud-archive:mitaka
-RUN apt-get update -y
 RUN apt-get install python-requests git curl -y --force-yes
 RUN apt-get install python-six
 RUN chmod 700 /fetch_and_install_deps.py

--- a/f5-openstack-agent-dist/Docker/ubuntu/install_test/Dockerfile.trusty
+++ b/f5-openstack-agent-dist/Docker/ubuntu/install_test/Dockerfile.trusty
@@ -4,7 +4,10 @@ FROM ubuntu:trusty
 RUN apt-get update -y && apt-get install software-properties-common -y
 RUN apt-add-repository cloud-archive:liberty
 RUN apt-get update -y && apt-get dist-upgrade -y --force-yes
+RUN apt-add-repository cloud-archive:mitaka
+RUN apt-get update -y
 RUN apt-get install python-requests git curl -y --force-yes
+RUN apt-get install python-six
 
 COPY ./fetch_and_install_deps.py /
 

--- a/f5-openstack-agent-dist/Docker/ubuntu/install_test/Dockerfile.trusty
+++ b/f5-openstack-agent-dist/Docker/ubuntu/install_test/Dockerfile.trusty
@@ -1,5 +1,6 @@
 # Dockerfile
 FROM ubuntu:trusty
+COPY ./fetch_and_install_deps.py /
 
 RUN apt-get update -y && apt-get install software-properties-common -y
 RUN apt-add-repository cloud-archive:liberty
@@ -8,6 +9,9 @@ RUN apt-add-repository cloud-archive:mitaka
 RUN apt-get update -y
 RUN apt-get install python-requests git curl -y --force-yes
 RUN apt-get install python-six
+RUN chmod 700 /fetch_and_install_deps.py
 
-COPY ./fetch_and_install_deps.py /
+ENTRYPOINT ["/fetch_and_install_deps.py", "/var/wdir"]
+# The following is the default, last arg if you ran the docker container on its own...
+CMD ["/var/wdir/f5-openstack-agent/deb_dist/python-f5-openstack-agent_*_1404_all.deb"]
 

--- a/f5-openstack-agent-dist/Docker/ubuntu/install_test/fetch_and_install_deps.py
+++ b/f5-openstack-agent-dist/Docker/ubuntu/install_test/fetch_and_install_deps.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function
+
 import glob
 import os
 import re
@@ -12,22 +14,19 @@ dep_match_re = re.compile('^\s*([\w\-]+)\s\(([=<>]+)\s([^\)]+)')
 
 
 def usage():
-    print sys.argv
-    print "fetch_dependencies.py working_dir pkg.deb"
-
+    print("fetch_dependencies.py working_dir pkg.deb")
 
 
 def runCommand(cmd):
     output = ""
-    print cmd
     try:
         p = subprocess.Popen(cmd.split(),
                              stdout=subprocess.PIPE,
                              stderr=subprocess.PIPE)
         (output) = p.communicate()[0]
-    except OSError, e:
-        print >>sys.stderr, "Execution failed: [%s:%s] " % \
-            (cmd, os.listdir('/var/wdir')), e
+    except OSError as e:
+        print("Execution failed: [%s:%s] " % (cmd, os.listdir('/var/wdir')), e,
+              file=sys.stderr)
     return (output, p.returncode)
 
 
@@ -38,32 +37,30 @@ def fetch_agent_dependencies(dist_dir, version, release, agent_pkg):
     requires = deque()
     # Copy agent package to /tmp
     cpCmd = "cp %s /tmp" % agent_pkg
-    print "Copying agent package to /tmp install directory"
+    print("Copying agent package to /tmp install directory")
     (output, status) = runCommand(cpCmd)
     if status != 0:
-        print "Failed to copy f5-openstack-agent package"
+        print("Failed to copy f5-openstack-agent package")
     else:
-        print "Success"
+        print("Success")
 
     # Get the openstack-agent requirement.
     requiresCmd = "dpkg -I %s" % agent_pkg
     agent_pkg_base = os.path.basename(agent_pkg)
-    print "Getting dependencies for %s." % agent_pkg_base
+    print("Getting dependencies for %s." % agent_pkg_base)
     (output, status) = runCommand(requiresCmd)
 
     if status != 0:
-        print "Can't get package dependencies for %s (%s)" % \
-            (agent_pkg_base, output)
+        print("Can't get package dependencies for %s (%s)" %
+              (agent_pkg_base, output))
         return 1
     else:
-        print "Success"
+        print("Success")
 
     for line in output.split('\n'):
-        print line
         if 'Depends' not in line:
             continue
         for dep in output.split(','):
-            print dep, dep_match_re.pattern
             match = dep_match_re.match(dep)
             if match:
                 groups = list(match.groups())
@@ -77,7 +74,7 @@ def fetch_agent_dependencies(dist_dir, version, release, agent_pkg):
     # we know we will always need this...
     print("requires:", requires)
     if not f5_sdk_version:
-        print "Can't find sdk dependency for %s" % (agent_pkg)
+        print("Can't find sdk dependency for %s" % (agent_pkg))
         return 1
 
     # Check if the required packages are present, then install the ones we are
@@ -93,21 +90,20 @@ def fetch_agent_dependencies(dist_dir, version, release, agent_pkg):
         ("curl -L -o /tmp/%s %s/python-f5-sdk_%s_1404_all.deb" %
          (f5_sdk_pkg, github_sdk_url, f5_sdk_version))
 
-    print "Fetching f5-sdk package from github"
-    print curlCmd
+    print("Fetching f5-sdk package from github")
     (output, status) = runCommand(curlCmd)
 
     # Get the sdk dependency
     requiresCmd = "dpkg -I /tmp/%s" % (f5_sdk_pkg)
-    print "Getting dependencies for %s." % (f5_sdk_pkg)
+    print("Getting dependencies for %s." % (f5_sdk_pkg))
     (output, status) = runCommand(requiresCmd)
 
     if status != 0:
-        print ('output', output)
-        print "Failed to get requirements for %s." % (f5_sdk_pkg)
+        print(('output', output))
+        print("Failed to get requirements for %s." % (f5_sdk_pkg))
         return 1
     else:
-        print "Success"
+        print("Success")
 
     sdk_requires = deque()
     for line in output.split('\n'):
@@ -118,7 +114,7 @@ def fetch_agent_dependencies(dist_dir, version, release, agent_pkg):
             if match:
                 groups = list(match.groups())
                 my_dep = ReqDetails(*groups)
-                print "icontrol:", my_dep
+                print("icontrol:", my_dep)
                 if 'icontrol' in my_dep.name:
                     if re.search('^>?=', my_dep.oper):
                         f5_icontrol_rest_version = my_dep.version
@@ -129,7 +125,7 @@ def fetch_agent_dependencies(dist_dir, version, release, agent_pkg):
     # we know we will always need this...
     print("sdk_requires:", sdk_requires)
     if not f5_icontrol_rest_version:
-        print "Can't find icontrol rest dependency for %s" % (agent_pkg)
+        print("Can't find icontrol rest dependency for %s" % (agent_pkg))
         return 1
 
     # Check if the required packages are present, then install the ones we are
@@ -145,20 +141,18 @@ def fetch_agent_dependencies(dist_dir, version, release, agent_pkg):
         ("curl -L -o /tmp/%s %s/%s" %
          (f5_icontrol_rest_pkg, github_sdk_url, f5_icontrol_rest_pkg))
 
-    print "Fetching f5-icontrol-rest package from github"
-    print curlCmd
+    print("Fetching f5-icontrol-rest package from github")
     (output, status) = runCommand(curlCmd)
 
     # Get the icontrol rest dependency
     requiresCmd = "dpkg -I /tmp/%s" % (f5_icontrol_rest_pkg)
-    print "Getting dependencies for %s." % (f5_icontrol_rest_pkg)
+    print("Getting dependencies for %s." % (f5_icontrol_rest_pkg))
     (output, status) = runCommand(requiresCmd)
     if status != 0:
-        print ('output', output)
-        print "Failed to get requirements for %s." % (f5_icontrol_rest_pkg)
+        print("Failed to get requirements for %s." % (f5_icontrol_rest_pkg))
         return 1
     else:
-        print "Success"
+        print("Success")
 
     return check_other_dependencies(requires, dist_dir, agent_pkg)
 
@@ -166,7 +160,7 @@ def fetch_agent_dependencies(dist_dir, version, release, agent_pkg):
 def check_other_dependencies(requires, dist_dir, agent_pkg):
     # triage the packages already installed
     rpm_list_cmd = "dpkg -l"
-    print "Collecting a list of already-install pkgs"
+    print("Collecting a list of already-install pkgs")
     (output, status) = runCommand(rpm_list_cmd)
     to_get = deque()
     ignore = ['f5-sdk']
@@ -175,7 +169,7 @@ def check_other_dependencies(requires, dist_dir, agent_pkg):
         if my_dep.name not in output and my_dep.name not in ignore:
             to_get.append(my_dep)
     # install the repo-stored rpm's
-    print "Grabbing the ones we have copies of"
+    print("Grabbing the ones we have copies of")
     to_install = glob.glob(dist_dir + "/Docker/ubuntu/14.04/*.deb")
     for deb_file in to_install:
         for rpm_dep in to_get:
@@ -184,14 +178,14 @@ def check_other_dependencies(requires, dist_dir, agent_pkg):
         rpm_install_cmd = "dpkg -i %s" % deb_file
         runCommand(rpm_install_cmd)
     if to_get:
-        print "WARNING: there are missing dependencies!"
+        print("WARNING: there are missing dependencies!")
         while to_get:
             dep = to_get.popleft()
-            print "%s %s %s" % (dep.name, dep.oper, dep.version)
+            print("%s %s %s" % (dep.name, dep.oper, dep.version))
     else:
-        print """Succsess!
+        print("""Succsess!
 All dependencies search satisfied!  However, by-version check may still fail...
-"""
+""")
     # change to be dynamic if we decide to be more rigorous at this stage...
     return 0
 
@@ -203,15 +197,14 @@ def install_agent_pkgs(repo):
     for item in order:
         for dpkg in dpkgs:
             if item in dpkg:
-                print "Installing: %s" % dpkg
+                print("Installing: %s" % dpkg)
                 installCmd = "dpkg -i %s" % dpkg
                 (output, status) = runCommand(installCmd)
-                print output
                 if status != 0:
-                    print "SDK install failed (%s)" % (str(status))
+                    print("SDK install failed (%s)" % (str(status)))
                     sys.exit(1)
                 else:
-                    print "SDK Succeeded in install test"
+                    print("SDK Succeeded in install test")
 
 
 def main(args):
@@ -223,9 +216,9 @@ def main(args):
     pkg_fullname = args[2]
     try:
         os.chdir("/var/wdir")
-    except OSError, e:
-        print >>sys.stderr, "Can't change to directory %s (%s)" % (working_dir,
-                                                                   e)
+    except OSError as e:
+        print("Can't change to directory %s (%s)" %
+              (working_dir, e), file=sys.stderr)
 
     dist_dir = os.path.join(working_dir, "f5-openstack-agent-dist")
     version_tool = os.path.join(dist_dir, "scripts/get-version-release.py")

--- a/f5-openstack-agent-dist/Docker/ubuntu/install_test/fetch_and_install_deps.py
+++ b/f5-openstack-agent-dist/Docker/ubuntu/install_test/fetch_and_install_deps.py
@@ -8,14 +8,13 @@ import sys
 
 from collections import deque, namedtuple
 
-f5_sdk_rest_pattern = re.compile("^f5-sdk\s*=\s*(\d+\.\d+\.\d+)$")
-f5_sdk_rest_pattern = re.compile(
-    "^f5-sdk-rest\s*=\s*(\d+\.\d+\.\d+)$")
 dep_match_re = re.compile('^\s*([\w\-]+)\s\(([=<>]+)\s([^\)]+)')
 
 
 def usage():
-    print "fetch_dependencies.py working_dir"
+    print sys.argv
+    print "fetch_dependencies.py working_dir pkg.deb"
+
 
 
 def runCommand(cmd):

--- a/f5-openstack-agent-dist/scripts/get-version-release.py
+++ b/f5-openstack-agent-dist/scripts/get-version-release.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+from __future__ import print_function
+
 import argparse
 import re
 import subprocess
@@ -18,8 +20,8 @@ def runCommand(cmd):
                              stderr=subprocess.PIPE
                              )
         (output) = p.communicate()[0]
-    except OSError, e:
-        print >>sys.stderr, "Execution failed:", e
+    except OSError as e:
+        print("Execution failed:", e, file=sys.stderr)
 
     return (output, p.returncode)
 

--- a/f5-openstack-agent-dist/scripts/test_install.sh
+++ b/f5-openstack-agent-dist/scripts/test_install.sh
@@ -2,6 +2,7 @@
 
 OS_TYPE=$1
 OS_VERSION=$2
+PKG_FULLNAME=$3
 PKG_NAME="f5-openstack-agent"
 DIST_DIR="${PKG_NAME}-dist"
 
@@ -27,6 +28,6 @@ DOCKER_FILE="${DOCKER_DIR}/Dockerfile.${CONTAINER_TYPE}"
 
 docker build -t ${BUILD_CONTAINER} -f ${DOCKER_FILE} ${DOCKER_DIR}
 docker run --privileged --rm -v $(pwd):${WORKING_DIR} ${BUILD_CONTAINER} /usr/bin/python \
-	   /fetch_and_install_deps.py ${WORKING_DIR}
+	   /fetch_and_install_deps.py ${WORKING_DIR} ${PKG_FULLNAME}
 
 exit 0


### PR DESCRIPTION
Fixes #494

Problem:
The test install algorithm to work with a more generic pool

Analysis:
I made the changes to make it so that the .deb and .rpm install tests
would do what they're supposed to do.  Before this change, the .deb and
.rpm failures were not being properly tracked and would always fail due
to improper regExp handling of expected strings.

Tests:
This is a test.  To validate that this executes properly, use the
.travis_yml file in its normal execution phasing.

@<reviewer_id>
#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?
