### PR TITLE
Neutron Pool member's status attribute not reflecting BIG-IP pool member status

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/cluster_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/cluster_manager.py
@@ -93,6 +93,18 @@ class ClusterManager(object):
 
         return None
 
+    def is_device_active(self, bigip):
+        active = False
+        try:
+            device_name = self.get_device_name(bigip)
+            act = bigip.tm.cm.devices.device.load(
+                name=device_name, partition='Common')
+            active = act.failoverState.lower() == 'active'
+        except Exception as exc:
+            LOG.error("Unable to get device info. %s", exc.message)
+
+        return active
+
     def sync(self, bigip, name, force_now=False):
         state = ''
         sync_start_time = time.time()

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1267,21 +1267,23 @@ class iControlDriver(LBaaSBaseDriver):
 
         self._update_loadbalancer_status(service)
 
-    @log_helpers.log_method_call
     def _update_member_status(self, members):
         """Update member status in OpenStack """
         for member in members:
-            # update both provisioning and operating status
-            provisioning_status = member.get('provisioning_status', None)
-            operating_status = member.get('operating_status', None)
-
-            if provisioning_status == plugin_const.PENDING_DELETE:
-                self.plugin_rpc.member_destroyed(member['id'])
-            else:
-                self.plugin_rpc.update_member_status(
-                    member['id'],
-                    provisioning_status=provisioning_status,
-                    operating_status=operating_status)
+            if 'provisioning_status' in member:
+                provisioning_status = member['provisioning_status']
+                if (provisioning_status == plugin_const.PENDING_CREATE or
+                        provisioning_status == plugin_const.PENDING_UPDATE):
+                        self.plugin_rpc.update_member_status(
+                            member['id'],
+                            plugin_const.ACTIVE,
+                            lb_const.ONLINE
+                        )
+                elif provisioning_status == plugin_const.PENDING_DELETE:
+                    self.plugin_rpc.member_destroyed(
+                        member['id'])
+                elif provisioning_status == plugin_const.ERROR:
+                    self.plugin_rpc.update_member_status(member['id'])
 
     def _update_health_monitor_status(self, health_monitors):
         """Update pool monitor status in OpenStack """
@@ -1424,8 +1426,18 @@ class iControlDriver(LBaaSBaseDriver):
             if self.network_builder:
                 # append route domain to member address
                 self.network_builder._annotate_service_route_domains(service)
+
+            # get currrent member status
             self.lbaas_builder.update_operating_status(service)
-            self._update_member_status(service['members'])
+
+            # udpate Neutron
+            for member in service['members']:
+                if member['provisioning_status'] == plugin_const.ACTIVE:
+                    operating_status = member.get('operating_status', None)
+                    self.plugin_rpc.update_member_status(
+                        member['id'],
+                        provisioning_status=None,
+                        operating_status=operating_status)
 
     def get_active_bigip(self):
         bigips = self.get_all_bigips()

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
@@ -15,6 +15,7 @@
 #
 
 from oslo_log import log as logging
+
 from requests import HTTPError
 import urllib
 
@@ -172,8 +173,6 @@ class PoolServiceBuilder(object):
                         raise
 
     def update_member(self, service, bigips):
-        # TODO(jl) handle state -- SDK enforces at least state=None
-
         pool = self.service_adapter.get_pool(service)
         member = self.service_adapter.get_member(service)
         part = pool["partition"]
@@ -199,3 +198,40 @@ class PoolServiceBuilder(object):
         else:
             hm = self.http_mon_helper
         return hm
+
+    def get_member_status(self, service, bigip, status_keys):
+        """Return status values for a single pool.
+
+        Status keys to collect are defined as an array of strings in input
+        status_keys.
+
+        :param service: Has pool and member name/partition
+        :param bigip: BIG-IP to get member status from.
+        :param status_keys: Array of strings that define which status keys to
+        collect.
+        :return: A dict with key/value pairs for each status defined in
+        input status_keys.
+        """
+        member_status = {}
+        pool = self.service_adapter.get_pool(service)
+        member = self.service_adapter.get_member(service)
+        part = pool["partition"]
+        try:
+            p = self.pool_helper.load(bigip,
+                                      name=pool["name"],
+                                      partition=part)
+
+            m = p.members_s.members
+            if m.exists(name=urllib.quote(member["name"]), partition=part):
+                m = m.load(name=urllib.quote(member["name"]), partition=part)
+                member_status = self.pool_helper.collect_stats(
+                    m, stat_keys=status_keys)
+            else:
+                LOG.error("Unable to get member status. "
+                          "Member %s does not exist.", member["name"])
+
+        except Exception as e:
+            # log error but continue on
+            LOG.error("Error getting member status: %s", e.message)
+
+        return member_status


### PR DESCRIPTION

@richbrowne 
#### What issues does this address?
Fixes #499
Operating status is not updated for pool members.

#### What's this change do?
Adds a periodic task to agent along with supporting code for getting
operating status of members and updating Neutron database.

#### Where should the reviewer start?
Start with agent_manager.py and evaluate the new periodic task function. Then move to icontrol_driver.py and lbaas_driver.py.

#### Any background context?
LBaaSv2 supports both provisioning status and operating status. Note that we are only concerned with member operating status, as Neutron handles displaying operating status of other objects (listener, pool, loadbalancer) based on member operating status.

Tests were developed in the driver repo, f5-openstack-lbaasv2-driver. See https://github.com/F5Networks/f5-openstack-lbaasv2-driver/pull/376

Test run:
`f5lbaasdriver/test/tempest/tests/api/test_member_status.py::MemberStatusTestJSON::test_disabled SKIPPED
f5lbaasdriver/test/tempest/tests/api/test_member_status.py::MemberStatusTestJSON::test_no_monitor PASSED
f5lbaasdriver/test/tempest/tests/api/test_member_status.py::MemberStatusTestJSON::test_offline PASSED
f5lbaasdriver/test/tempest/tests/api/test_member_status.py::MemberStatusTestJSON::test_online PASSED`