### PR TITLE
Feature.agent startup msg fix 418

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent.py
@@ -17,7 +17,8 @@
 import errno
 import inspect
 import sys
-import logging
+
+import f5_openstack_agent.lbaasv2.drivers.bigip.exceptions as exceptions
 
 try:
     from oslo_config import cfg
@@ -25,17 +26,10 @@ try:
     from oslo_service import service
 except ImportError as CriticalError:
     frame = inspect.getframeinfo(inspect.currentframe())
-    project = "f5-oslbaasv2-agent"
-    default_lbaasv2_log = "/var/log/neutron/%s.log" % project
-    logger = logging.getLogger('neutron:f5-oslbaasv2-agent.log')
-    fh = logging.FileHandler(default_lbaasv2_log)
-    fh.setLevel(logging.DEBUG)
-    logger.addHandler(fh)
-    reason = "f5-openstack-agent cannot start due to missing dependency"
-    msg = "(%d) %s: %s [%s:%s]" % (errno.ENOSYS, reason, str(CriticalError),
-                                   frame.filename, str(frame.lineno))
-    logger.exception(msg)
-    sys.exit(errno.ENOSYS)
+    CriticalError = \
+        exceptions.F5MissingDependencies(message=str(CriticalError),
+                                         frame=frame)
+    sys.exit(CriticalError.errno)
 
 
 try:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/exceptions.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/exceptions.py
@@ -13,6 +13,15 @@
 # limitations under the License.
 #
 
+import errno
+import inspect
+import logging
+import os
+import re
+import sys
+import syslog
+import traceback
+
 
 class F5AgentException(Exception):
     pass
@@ -356,3 +365,86 @@ class VXLANDeleteException(F5AgentException):
 
 class BigIPNotLicensedForVcmp(F5AgentException):
     pass
+
+
+class F5MissingDependencies(F5AgentException):
+    default_msg = "%s cannot start due to missing dependency" % \
+        str(sys.argv[0])
+    message_format = "(%d) %s: %s [%s; line:%s]"
+    default_errno = errno.ENOSYS
+    default_project = 'neutron'
+    default_name = 'f5-oslbaasv2-agent'
+
+    def __init__(self, *args, **kargs):
+        self.__set_message(args, kargs)
+        super(F5MissingDependencies, self).__init__(self.message)
+        self.__logger()
+        self.__log_error()
+        self.__check_debug()
+
+    def __check_debug(self):
+        print("__check_debug")
+        debug = False
+        for item in sys.argv:
+            if 'f5-openstack-agent.ini' in item:
+                with open(item, 'r') as fh:
+                    line = fh.readline()
+                    print('line', line)
+                    debug_re = \
+                        re.compile('debug\s*=\s*([Tt]rue|[Ff]alse|[01])')
+                    while line:
+                        match = debug_re.search(line)
+                        if match:  # there should only be one!
+                            if re.search('[tT]|1', match.group(1)):
+                                debug = True
+                            break
+                        line = fh.readline()
+        if debug:
+            # our sys.exc_info queue should still be pointing at our ImportE
+            traceback.print_exc()
+
+    def __get_mod(self):
+        frame = self.frame
+        mod = "f5_openstack_agent.lbaasv2.drivers.bigip."
+        mod = mod + os.path.basename(frame.filename)
+        mod = mod.replace('.py', '')
+        return mod
+
+    def __logger(self):
+        try:
+            self._logger = \
+                logging.getLogger('%s' % (self.__get_mod()))
+            fh = \
+                logging.FileHandler("/var/log/%s/%s.log" %
+                                    (self.default_project, self.default_name))
+            fh.setLevel(logging.DEBUG)
+            self._logger.addHandler(fh)
+        except IOError:
+            self._logger = None
+
+    def __log_error(self):
+        if self._logger:
+            self._logger.fatal(self.message)
+        else:
+            syslog.syslog(syslog.LOG_CRIT, self.message)
+
+    def __set_message(self, args, kargs):
+        details = ', '.join(map(str, args))
+        errno = kargs['errno'] if 'errno' in kargs and kargs['errno'] else \
+            self.default_errno
+        self.errno = errno
+        message = kargs['message'] if 'message' in kargs and kargs['message'] \
+            else self.default_msg
+        exception = ''
+        if 'frame' in kargs and kargs['frame']:
+            frame = kargs['frame']
+        else:
+            my_frames = inspect.getouterframes(inspect.currentframe())[2]
+            frame = inspect.getframeinfo(my_frames[0])
+        if 'exception' in kargs and kargs['exception']:
+            message = kargs['exception']
+        elif details:
+            exception = details
+        self.frame = frame
+        self.message = self.message_format % (errno, message, exception,
+                                              frame.filename, frame.lineno)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent__import_failure.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent__import_failure.py
@@ -1,0 +1,46 @@
+##!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# import pytest
+
+# needs to be run first for capture of 'success' for test_import
+success = False
+agent = None  # if importation works, then this will be defined as not None
+try:
+    import builtins
+except ImportError:
+    import __builtin__ as builtins
+real_import = builtins.__import__
+
+
+def my_custom_import(*args):
+    if 'oslo_config' in args:
+        raise ImportError('foodogzoo')
+    return real_import(*args)
+
+
+builtins.__import__ = my_custom_import
+# get our test scenario:
+try:
+    import f5_openstack_agent.lbaasv2.drivers.bigip.agent as agent
+    assert not agent, "No agent test"  # makes tox style happy...
+except SystemExit:
+    success = True
+builtins.__import__ = real_import
+
+
+def test_import():
+    assert success, "Import Test"

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_exceptions.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_exceptions.py
@@ -1,0 +1,526 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import inspect
+import logging
+import pdb
+import pytest
+import sys
+import traceback
+
+import f5_openstack_agent.lbaasv2.drivers.bigip.exceptions as exceptions
+
+from collections import namedtuple
+from mock import Mock
+from mock import mock_open
+from mock import patch
+
+
+class Test_F5MissingDependencies(object):
+    open_name = 'f5_openstack_agent.lbaasv2.drivers.bigip.exceptions.open'
+
+    def setup_iterations(self):
+        Options = \
+            namedtuple('Options',
+                       'errno, message, details, exception, frame')
+        set_frame = inspect.getframeinfo(inspect.currentframe())
+        items = [Options(None, None, [], None, None),
+                 Options(22, 'missing', [31415926], ImportError('foodogzoo'),
+                         set_frame),
+                 Options(22, 'missing', [31415926], None, set_frame)]
+        logging.FileHandler = Mock()
+        logging.getLogger = Mock()
+        sys.argv.append('f5-openstack-agent.ini')
+        return items, set_frame
+
+    def test_iterations(self):
+        test_items, set_frame = self.setup_iterations()
+        traceback.print_exc = Mock()
+        for tset in test_items:
+            message = tset.message
+            errno = tset.errno
+            details = tset.details
+            exc = tset.exception
+            fr = tset.frame
+            read_lines = 'debug = true\n'
+            m_open = mock_open(read_data=read_lines)
+            with patch(self.open_name, m_open, create=True):
+                exception = \
+                    exceptions.F5MissingDependencies(*details, message=message,
+                                                     errno=errno,
+                                                     exception=exc, frame=fr)
+            assert traceback.print_exc.called
+            with pytest.raises(exceptions.F5MissingDependencies):
+                if errno:
+                    assert errno == exception.errno, "Errno Set Test"
+                else:
+                    assert exceptions.F5MissingDependencies.default_errno == \
+                        exception.errno, "Errno Not Set Test"
+                if details and not exc:
+                    for item in details:
+                        assert str(item) in str(exception), \
+                            "Details Inclusion Test"
+                elif exc:
+                    assert str(exc) in str(exception), \
+                        "Exception Inclusion Test"
+                if fr:
+                    assert str(set_frame.lineno) in str(exception) and \
+                        fr.filename in str(exception), "Frame Inclusion Test"
+                raise exception
+
+    def test_debug_false(self):
+        traceback.print_exc = Mock()
+
+        read_lines = 'debug = false\n'
+        m_open = mock_open(read_data=read_lines)
+        with patch(self.open_name, m_open, create=True):
+            exceptions.F5MissingDependencies()
+        assert not traceback.print_exc.called, 'debug negative test'
+
+
+def test_F5AgentException():
+    with pytest.raises(exceptions.F5AgentException):
+        raise getattr(exceptions, 'F5AgentException')()
+
+
+def test_MinorVersionValidateFailed():
+    with pytest.raises(exceptions.MinorVersionValidateFailed):
+        raise getattr(exceptions, 'MinorVersionValidateFailed')()
+
+
+def test_MajorVersionValidateFailed():
+    with pytest.raises(exceptions.MajorVersionValidateFailed):
+        raise getattr(exceptions, 'MajorVersionValidateFailed')()
+
+
+def test_ProvisioningExtraMBValidateFailed():
+    with pytest.raises(
+            exceptions.ProvisioningExtraMBValidateFailed):
+        raise getattr(exceptions, 'ProvisioningExtraMBValidateFailed')()
+
+
+def test_BigIPDeviceLockAcquireFailed():
+    with pytest.raises(exceptions.BigIPDeviceLockAcquireFailed):
+        raise getattr(exceptions, 'BigIPDeviceLockAcquireFailed')()
+
+
+def test_BigIPClusterInvalidHA():
+    with pytest.raises(exceptions.BigIPClusterInvalidHA):
+        raise getattr(exceptions, 'BigIPClusterInvalidHA')()
+
+
+def test_BigIPClusterSyncFailure():
+    with pytest.raises(exceptions.BigIPClusterSyncFailure):
+        raise getattr(exceptions, 'BigIPClusterSyncFailure')()
+
+
+def test_BigIPClusterPeerAddFailure():
+    with pytest.raises(exceptions.BigIPClusterPeerAddFailure):
+        raise getattr(exceptions, 'BigIPClusterPeerAddFailure')()
+
+
+def test_BigIPClusterConfigSaveFailure():
+    with pytest.raises(exceptions.BigIPClusterConfigSaveFailure):
+        raise getattr(exceptions, 'BigIPClusterConfigSaveFailure')()
+
+
+def test_UnknownMonitorType():
+    with pytest.raises(exceptions.UnknownMonitorType):
+        raise getattr(exceptions, 'UnknownMonitorType')()
+
+
+def test_MissingVTEPAddress():
+    with pytest.raises(exceptions.MissingVTEPAddress):
+        raise getattr(exceptions, 'MissingVTEPAddress')()
+
+
+def test_MissingNetwork():
+    with pytest.raises(exceptions.MissingNetwork):
+        raise getattr(exceptions, 'MissingNetwork')()
+
+
+def test_InvalidNetworkType():
+    with pytest.raises(exceptions.InvalidNetworkType):
+        raise getattr(exceptions, 'InvalidNetworkType')()
+
+
+def test_StaticARPCreationException():
+    with pytest.raises(exceptions.StaticARPCreationException):
+        raise getattr(exceptions, 'StaticARPCreationException')()
+
+
+def test_StaticARPQueryException():
+    with pytest.raises(exceptions.StaticARPQueryException):
+        raise getattr(exceptions, 'StaticARPQueryException')()
+
+
+def test_StaticARPDeleteException():
+    with pytest.raises(exceptions.StaticARPDeleteException):
+        raise getattr(exceptions, 'StaticARPDeleteException')()
+
+
+def test_ClusterCreationException():
+    with pytest.raises(exceptions.ClusterCreationException):
+        raise getattr(exceptions, 'ClusterCreationException')()
+
+
+def test_ClusterUpdateException():
+    with pytest.raises(exceptions.ClusterUpdateException):
+        raise getattr(exceptions, 'ClusterUpdateException')()
+
+
+def test_ClusterQueryException():
+    with pytest.raises(exceptions.ClusterQueryException):
+        raise getattr(exceptions, 'ClusterQueryException')()
+
+
+def test_ClusterDeleteException():
+    with pytest.raises(exceptions.ClusterDeleteException):
+        raise getattr(exceptions, 'ClusterDeleteException')()
+
+
+def test_DeviceCreationException():
+    with pytest.raises(exceptions.DeviceCreationException):
+        raise getattr(exceptions, 'DeviceCreationException')()
+
+
+def test_DeviceUpdateException():
+    with pytest.raises(exceptions.DeviceUpdateException):
+        raise getattr(exceptions, 'DeviceUpdateException')()
+
+
+def test_DeviceQueryException():
+    with pytest.raises(exceptions.DeviceQueryException):
+        raise getattr(exceptions, 'DeviceQueryException')()
+
+
+def test_DeviceDeleteException():
+    with pytest.raises(exceptions.DeviceDeleteException):
+        raise getattr(exceptions, 'DeviceDeleteException')()
+
+
+def test_InterfaceQueryException():
+    with pytest.raises(exceptions.InterfaceQueryException):
+        raise getattr(exceptions, 'InterfaceQueryException')()
+
+
+def test_IAppCreationException():
+    with pytest.raises(exceptions.IAppCreationException):
+        raise getattr(exceptions, 'IAppCreationException')()
+
+
+def test_IAppQueryException():
+    with pytest.raises(exceptions.IAppQueryException):
+        raise getattr(exceptions, 'IAppQueryException')()
+
+
+def test_IAppUpdateException():
+    with pytest.raises(exceptions.IAppUpdateException):
+        raise getattr(exceptions, 'IAppUpdateException')()
+
+
+def test_IAppDeleteException():
+    with pytest.raises(exceptions.IAppDeleteException):
+        raise getattr(exceptions, 'IAppDeleteException')()
+
+
+def test_L2GRETunnelCreationException():
+    with pytest.raises(exceptions.L2GRETunnelCreationException):
+        raise getattr(exceptions, 'L2GRETunnelCreationException')()
+
+
+def test_L2GRETunnelQueryException():
+    with pytest.raises(exceptions.L2GRETunnelQueryException):
+        raise getattr(exceptions, 'L2GRETunnelQueryException')()
+
+
+def test_L2GRETunnelUpdateException():
+    with pytest.raises(exceptions.L2GRETunnelUpdateException):
+        raise getattr(exceptions, 'L2GRETunnelUpdateException')()
+
+
+def test_L2GRETunnelDeleteException():
+    with pytest.raises(exceptions.L2GRETunnelDeleteException):
+        raise getattr(exceptions, 'L2GRETunnelDeleteException')()
+
+
+def test_MemberCreationException():
+    with pytest.raises(exceptions.MemberCreationException):
+        raise getattr(exceptions, 'MemberCreationException')()
+
+
+def test_MemberQueryException():
+    with pytest.raises(exceptions.MemberQueryException):
+        raise getattr(exceptions, 'MemberQueryException')()
+
+
+def test_MemberUpdateException():
+    with pytest.raises(exceptions.MemberUpdateException):
+        raise getattr(exceptions, 'MemberUpdateException')()
+
+
+def test_MemberDeleteException():
+    with pytest.raises(exceptions.MemberDeleteException):
+        raise getattr(exceptions, 'MemberDeleteException')()
+
+
+def test_MonitorCreationException():
+    with pytest.raises(exceptions.MonitorCreationException):
+        raise getattr(exceptions, 'MonitorCreationException')()
+
+
+def test_MonitorQueryException():
+    with pytest.raises(exceptions.MonitorQueryException):
+        raise getattr(exceptions, 'MonitorQueryException')()
+
+
+def test_MonitorUpdateException():
+    with pytest.raises(exceptions.MonitorUpdateException):
+        raise getattr(exceptions, 'MonitorUpdateException')()
+
+
+def test_MonitorDeleteException():
+    with pytest.raises(exceptions.MonitorDeleteException):
+        raise getattr(exceptions, 'MonitorDeleteException')()
+
+
+def test_NATCreationException():
+    with pytest.raises(exceptions.NATCreationException):
+        raise getattr(exceptions, 'NATCreationException')()
+
+
+def test_NATQueryException():
+    with pytest.raises(exceptions.NATQueryException):
+        raise getattr(exceptions, 'NATQueryException')()
+
+
+def test_NATUpdateException():
+    with pytest.raises(exceptions.NATUpdateException):
+        raise getattr(exceptions, 'NATUpdateException')()
+
+
+def test_NATDeleteException():
+    with pytest.raises(exceptions.NATDeleteException):
+        raise getattr(exceptions, 'NATDeleteException')()
+
+
+def test_PoolCreationException():
+    with pytest.raises(exceptions.PoolCreationException):
+        raise getattr(exceptions, 'PoolCreationException')()
+
+
+def test_PoolQueryException():
+    with pytest.raises(exceptions.PoolQueryException):
+        raise getattr(exceptions, 'PoolQueryException')()
+
+
+def test_PoolUpdateException():
+    with pytest.raises(exceptions.PoolUpdateException):
+        raise getattr(exceptions, 'PoolUpdateException')()
+
+
+def test_PoolDeleteException():
+    with pytest.raises(exceptions.PoolDeleteException):
+        raise getattr(exceptions, 'PoolDeleteException')()
+
+
+def test_RouteCreationException():
+    with pytest.raises(exceptions.RouteCreationException):
+        raise getattr(exceptions, 'RouteCreationException')()
+
+
+def test_RouteQueryException():
+    with pytest.raises(exceptions.RouteQueryException):
+        raise getattr(exceptions, 'RouteQueryException')()
+
+
+def test_RouteUpdateException():
+    with pytest.raises(exceptions.RouteUpdateException):
+        raise getattr(exceptions, 'RouteUpdateException')()
+
+
+def test_RouteDeleteException():
+    with pytest.raises(exceptions.RouteDeleteException):
+        raise getattr(exceptions, 'RouteDeleteException')()
+
+
+def test_RouteDomainCreationException():
+    with pytest.raises(exceptions.RouteDomainCreationException):
+        raise getattr(exceptions, 'RouteDomainCreationException')()
+
+
+def test_RouteDomainQueryException():
+    with pytest.raises(exceptions.RouteDomainQueryException):
+        raise getattr(exceptions, 'RouteDomainQueryException')()
+
+
+def test_RouteDomainUpdateException():
+    with pytest.raises(exceptions.RouteDomainUpdateException):
+        raise getattr(exceptions, 'RouteDomainUpdateException')()
+
+
+def test_RouteDomainDeleteException():
+    with pytest.raises(exceptions.RouteDomainDeleteException):
+        raise getattr(exceptions, 'RouteDomainDeleteException')()
+
+
+def test_RuleCreationException():
+    with pytest.raises(exceptions.RuleCreationException):
+        raise getattr(exceptions, 'RuleCreationException')()
+
+
+def test_RuleQueryException():
+    with pytest.raises(exceptions.RuleQueryException):
+        raise getattr(exceptions, 'RuleQueryException')()
+
+
+def test_RuleUpdateException():
+    with pytest.raises(exceptions.RuleUpdateException):
+        raise getattr(exceptions, 'RuleUpdateException')()
+
+
+def test_RuleDeleteException():
+    with pytest.raises(exceptions.RuleDeleteException):
+        raise getattr(exceptions, 'RuleDeleteException')()
+
+
+def test_SelfIPCreationException():
+    with pytest.raises(exceptions.SelfIPCreationException):
+        raise getattr(exceptions, 'SelfIPCreationException')()
+
+
+def test_SelfIPQueryException():
+    with pytest.raises(exceptions.SelfIPQueryException):
+        raise getattr(exceptions, 'SelfIPQueryException')()
+
+
+def test_SelfIPUpdateException():
+    with pytest.raises(exceptions.SelfIPUpdateException):
+        raise getattr(exceptions, 'SelfIPUpdateException')()
+
+
+def test_SelfIPDeleteException():
+    with pytest.raises(exceptions.SelfIPDeleteException):
+        raise getattr(exceptions, 'SelfIPDeleteException')()
+
+
+def test_SNATCreationException():
+    with pytest.raises(exceptions.SNATCreationException):
+        raise getattr(exceptions, 'SNATCreationException')()
+
+
+def test_SNATQueryException():
+    with pytest.raises(exceptions.SNATQueryException):
+        raise getattr(exceptions, 'SNATQueryException')()
+
+
+def test_SNATUpdateException():
+    with pytest.raises(exceptions.SNATUpdateException):
+        raise getattr(exceptions, 'SNATUpdateException')()
+
+
+def test_SNATDeleteException():
+    with pytest.raises(exceptions.SNATDeleteException):
+        raise getattr(exceptions, 'SNATDeleteException')()
+
+
+def test_SystemCreationException():
+    with pytest.raises(exceptions.SystemCreationException):
+        raise getattr(exceptions, 'SystemCreationException')()
+
+
+def test_SystemQueryException():
+    with pytest.raises(exceptions.SystemQueryException):
+        raise getattr(exceptions, 'SystemQueryException')()
+
+
+def test_SystemUpdateException():
+    with pytest.raises(exceptions.SystemUpdateException):
+        raise getattr(exceptions, 'SystemUpdateException')()
+
+
+def test_SystemDeleteException():
+    with pytest.raises(exceptions.SystemDeleteException):
+        raise getattr(exceptions, 'SystemDeleteException')()
+
+
+def test_VirtualServerCreationException():
+    with pytest.raises(exceptions.VirtualServerCreationException):
+        raise getattr(exceptions, 'VirtualServerCreationException')()
+
+
+def test_VirtualServerQueryException():
+    with pytest.raises(exceptions.VirtualServerQueryException):
+        raise getattr(exceptions, 'VirtualServerQueryException')()
+
+
+def test_VirtualServerUpdateException():
+    with pytest.raises(exceptions.VirtualServerUpdateException):
+        raise getattr(exceptions, 'VirtualServerUpdateException')()
+
+
+def test_VirtualServerDeleteException():
+    with pytest.raises(exceptions.VirtualServerDeleteException):
+        raise getattr(exceptions, 'VirtualServerDeleteException')()
+
+
+def test_VLANCreationException():
+    with pytest.raises(exceptions.VLANCreationException):
+        raise getattr(exceptions, 'VLANCreationException')()
+
+
+def test_VLANQueryException():
+    with pytest.raises(exceptions.VLANQueryException):
+        raise getattr(exceptions, 'VLANQueryException')()
+
+
+def test_VLANUpdateException():
+    with pytest.raises(exceptions.VLANUpdateException):
+        raise getattr(exceptions, 'VLANUpdateException')()
+
+
+def test_VLANDeleteException():
+    with pytest.raises(exceptions.VLANDeleteException):
+        raise getattr(exceptions, 'VLANDeleteException')()
+
+
+def test_VXLANCreationException():
+    with pytest.raises(exceptions.VXLANCreationException):
+        raise getattr(exceptions, 'VXLANCreationException')()
+
+
+def test_VXLANQueryException():
+    with pytest.raises(exceptions.VXLANQueryException):
+        raise getattr(exceptions, 'VXLANQueryException')()
+
+
+def test_VXLANUpdateException():
+    with pytest.raises(exceptions.VXLANUpdateException):
+        raise getattr(exceptions, 'VXLANUpdateException')()
+
+
+def test_VXLANDeleteException():
+    with pytest.raises(exceptions.VXLANDeleteException):
+        raise getattr(exceptions, 'VXLANDeleteException')()
+
+
+def test_BigIPNotLicensedForVcmp():
+        with pytest.raises(exceptions.BigIPNotLicensedForVcmp):
+            raise getattr(exceptions, 'BigIPNotLicensedForVcmp')()
+
+
+if __name__ == '__main__':
+    pdb.run('pytest %s' % (sys.argv[0]))


### PR DESCRIPTION
#### What issues does this address?
Fixes #418 
WIP #563 
...

#### What's this change do?
This is another way to handle the dependencies, but errors out gracefully if/when the user runs the agent.py directly.
#### Where should the reviewer start?
In the commit
#### Any background context?
The need to handle this in exceptions is not really there.  One could create a crash.py and handle it there just as simply; however, as all other errors are handled in the exceptions.py, I thought it best to keep it simple with it being there.  Users can then decide whether or not they wish to except on that class upon its creation.  Note that, by default, the arg test will show up in the exception message.