### PR TITLE
Setting the weight of a LBaaS pool member does not cause the BIG-IP t…

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -424,6 +424,12 @@ class ServiceModelAdapter(object):
         else:
             member["session"] = "user-disabled"
 
+        if lbaas_member["weight"] == 0:
+            member["ratio"] = 1
+            member["session"] = "user-disabled"
+        else:
+            member["ratio"] = lbaas_member["weight"]
+
         if ':' in ip_address:
             member['name'] = ip_address + '.' + str(port)
         else:

--- a/test/functional/neutronless/member/test_single_member_weight_updates.py
+++ b/test/functional/neutronless/member/test_single_member_weight_updates.py
@@ -1,0 +1,195 @@
+# coding=utf-8
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from copy import deepcopy
+from f5_openstack_agent.lbaasv2.drivers.bigip.resource_helper import \
+    ResourceType
+import json
+import logging
+import os
+import pytest
+import requests
+import urllib
+
+from ..testlib.resource_validator import ResourceValidator
+from ..testlib.service_reader import LoadbalancerReader
+
+
+requests.packages.urllib3.disable_warnings()
+
+LOG = logging.getLogger(__name__)
+
+"""
+Commands to create a member for the weight testing.
+
+(neutron) lbaas-member-create --protocol-port 8080 --address 192.168.101.9 --subnet admin-subnet pool1
+Created a new member:
++----------------+--------------------------------------+
+| Field          | Value                                |
++----------------+--------------------------------------+
+| address        | 192.168.101.9                        |
+| admin_state_up | True                                 |
+| id             | a3e24756-4131-4157-a6cc-f9066260ad61 |
+| name           |                                      |
+| protocol_port  | 8080                                 |
+| subnet_id      | 2b7ca4b5-a2b9-4234-91ed-5236afac1166 |
+| tenant_id      | dfd83103ce2047d5b20ccd6ef272f3cc     |
+| weight         | 1                                    |
++----------------+--------------------------------------+
+(neutron) lbaas-member-update --weight 5 a3e24756-4131-4157-a6cc-f9066260ad61 pool1
+Updated member: a3e24756-4131-4157-a6cc-f9066260ad61
+(neutron) lbaas-member-update --weight 1 a3e24756-4131-4157-a6cc-f9066260ad61 pool1
+Updated member: a3e24756-4131-4157-a6cc-f9066260ad61
+(neutron) lbaas-member-update --weight 0 a3e24756-4131-4157-a6cc-f9066260ad61 pool1
+Updated member: a3e24756-4131-4157-a6cc-f9066260ad61
+(neutron) lbaas-member-update --weight 1 a3e24756-4131-4157-a6cc-f9066260ad61 pool1
+Updated member: a3e24756-4131-4157-a6cc-f9066260ad61
+(neutron) lbaas-member-update --weight 256 a3e24756-4131-4157-a6cc-f9066260ad61 pool1
+Updated member: a3e24756-4131-4157-a6cc-f9066260ad61
+(neutron) lbaas-member-update --weight 257 a3e24756-4131-4157-a6cc-f9066260ad61 pool1
+Invalid input for weight. Reason: '257' is too large - must be no larger than '256'.
+Neutron server returns request_ids: ['req-5517a572-3f7f-4f8c-812c-268c252b382b']
+(neutron) lbaas-member-update --weight 1 a3e24756-4131-4157-a6cc-f9066260ad61 pool1
+Updated member: a3e24756-4131-4157-a6cc-f9066260ad61
+(neutron) lbaas-member-delete a3e24756-4131-4157-a6cc-f9066260ad61 pool1
+Deleted member: a3e24756-4131-4157-a6cc-f9066260ad61
+"""
+@pytest.fixture(scope="module")
+def services():
+    neutron_services_filename = (
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            '../../testdata/service_requests/single_member_weight_updates.json')
+    )
+    return (json.load(open(neutron_services_filename)))
+
+
+@pytest.fixture()
+def icd_config():
+    oslo_config_filename = (
+        os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                     '../../config/basic_agent_config.json')
+    )
+    OSLO_CONFIGS = json.load(open(oslo_config_filename))
+
+    config = deepcopy(OSLO_CONFIGS)
+    config['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
+    config['icontrol_username'] = pytest.symbols.bigip_username
+    config['icontrol_password'] = pytest.symbols.bigip_password
+    config['f5_vtep_selfip_name'] = pytest.symbols.f5_vtep_selfip_name
+    config['environment_prefix'] = "Project"
+
+    return config
+
+def get_next_member(service_iterator, icontrol_driver, bigip, env_prefix):
+
+    service = service_iterator.next()
+    member = service['members'][0]
+    pool = service['pools'][0]
+    folder = '{0}_{1}'.format(env_prefix, pool['tenant_id'])
+    icontrol_driver._common_service_handler(service)
+
+    pool_name = '{0}_{1}'.format(env_prefix, pool['id'])
+    member_name = '{0}:{1}'.format(member['address'],
+                                   member['protocol_port'])
+    node_name = '{0}'.format(member['address'])
+
+    p = bigip.get_resource(ResourceType.pool, pool_name, partition=folder)
+    m = p.members_s.members
+    m = m.load(name=urllib.quote(member_name), partition=folder)
+
+    return m
+
+def get_names_from_service(service, env_prefix):
+    member = service['members'][0]
+    member_name = '{0}:{1}'.format(member['address'],
+                                   member['protocol_port'])
+    pool = service['pools'][0]
+    pool_name = '{0}_{1}'.format(env_prefix, pool['id'])
+
+    folder = '{0}_{1}'.format(env_prefix, pool['tenant_id'])
+
+    node_name = '{0}'.format(member['address'])
+
+    return (member_name, pool_name, node_name, folder)
+
+def test_single_member_weight_updates(
+        bigip,
+        services,
+        icd_config,
+        icontrol_driver):
+
+    env_prefix = icd_config['environment_prefix']
+    service_iter = iter(services)
+
+    # create loadbalancer with pool
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+    
+    # Create a member
+    m = get_next_member(service_iter, icontrol_driver, bigip, env_prefix)
+    assert m.session == "user-enabled"
+    assert m.ratio == 1
+
+    # Update the member weight to 5
+    m = get_next_member(service_iter, icontrol_driver, bigip, env_prefix)
+    assert m.ratio == 5
+    assert m.session == "user-enabled"
+
+    # Set the member weight to 1
+    m = get_next_member(service_iter, icontrol_driver, bigip, env_prefix)
+    assert m.ratio == 1
+    assert m.session == "user-enabled"
+
+    # Set the member weight to 0 (not a valid weight for BIG-IP)
+    m = get_next_member(service_iter, icontrol_driver, bigip, env_prefix)
+    assert m.ratio == 1
+    assert m.session == "user-disabled"
+
+    # Set the weight back to 1
+    m = get_next_member(service_iter, icontrol_driver, bigip, env_prefix)
+    assert m.ratio == 1
+    assert m.session == "user-enabled"
+
+    # Set the weight to the Neutron max
+    m = get_next_member(service_iter, icontrol_driver, bigip, env_prefix)
+    assert m.ratio == 256
+    assert m.session == "user-enabled"
+
+    # Set the weight to 1
+    m = get_next_member(service_iter, icontrol_driver, bigip, env_prefix)
+    assert m.ratio == 1
+    assert m.session == "user-enabled"
+
+    # Delete the member
+    service = service_iter.next()
+    (member_name, pool_name, node_name, folder) = \
+        get_names_from_service(service, env_prefix)
+    icontrol_driver._common_service_handler(service)
+    p = bigip.get_resource(ResourceType.pool, pool_name, partition=folder)
+    m = p.members_s.members
+    assert not m.exists(name=urllib.quote(member_name), partition=folder)
+
+    # Delete the rest of the objects, pool, listener, loadbalancer
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service, delete_partition=True)
+    
+    assert not bigip.folder_exists(folder)

--- a/test/functional/neutronless/testlib/fake_rpc.py
+++ b/test/functional/neutronless/testlib/fake_rpc.py
@@ -174,6 +174,10 @@ class FakeRPCPlugin(object):
         pass
 
     @track_call
+    def member_destroyed(self, id):
+        pass
+
+    @track_call
     def get_all_loadbalancers(self, env=None, group=None, host=None):
         return_value = [
             {'lb_id': u'50c5d54a-5a9e-4a80-9e74-8400a461a077'}

--- a/test/functional/testdata/service_requests/single_member_weight_updates.json
+++ b/test/functional/testdata/service_requests/single_member_weight_updates.json
@@ -1,0 +1,2381 @@
+[{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c", 
+      "l7_policies": [], 
+      "loadbalancer_id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "name": "vs1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+    "listeners": [
+      {
+        "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+    "operating_status": "ONLINE", 
+    "pools": [
+      {
+        "id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f"
+      }
+    ], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+    "vip_address": "192.168.101.11", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "mitaka-stack:2db9ff02-7a10-53d8-a70d-8a61885e98af", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-02-03T22:20:24", 
+      "description": null, 
+      "device_id": "29ffa909-fe45-5512-899e-b4eaee6d4ff8", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "192.168.101.11", 
+          "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+        }
+      ], 
+      "id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+      "mac_address": "fa:16:3e:1b:82:4b", 
+      "name": "loadbalancer-00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "port_security_enabled": true, 
+      "security_groups": [
+        "7bd66c3f-6893-4d5a-ba10-f678b0637609"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T22:20:25"
+    }, 
+    "vip_port_id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+    "vip_subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+    "vxlan_vteps": [
+      "10.1.0.170", 
+      "10.1.0.147"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "6b3b89eb-94c2-490b-8270-0e46a70ae25a": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-02-03T20:08:46", 
+      "description": "", 
+      "id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "admin-net", 
+      "port_security_enabled": true, 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 1007, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+      ], 
+      "tags": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:08:46", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "l7_policies": [], 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listener_id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c", 
+      "listeners": [
+        {
+          "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c"
+        }
+      ], 
+      "loadbalancer_id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "members": [], 
+      "name": "pool1", 
+      "operating_status": "OFFLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "PENDING_CREATE", 
+      "sessionpersistence": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc"
+    }
+  ], 
+  "subnets": {
+    "2b7ca4b5-a2b9-4234-91ed-5236afac1166": {
+      "allocation_pools": [
+        {
+          "end": "192.168.101.254", 
+          "start": "192.168.101.2"
+        }
+      ], 
+      "cidr": "192.168.101.0/24", 
+      "created_at": "2017-02-03T20:09:06", 
+      "description": "", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.101.1", 
+      "host_routes": [], 
+      "id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "admin-subnet", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:09:06"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c", 
+      "l7_policies": [], 
+      "loadbalancer_id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "name": "vs1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+    "listeners": [
+      {
+        "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+    "operating_status": "ONLINE", 
+    "pools": [
+      {
+        "id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f"
+      }
+    ], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+    "vip_address": "192.168.101.11", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "mitaka-stack:2db9ff02-7a10-53d8-a70d-8a61885e98af", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-02-03T22:20:24", 
+      "description": null, 
+      "device_id": "29ffa909-fe45-5512-899e-b4eaee6d4ff8", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "192.168.101.11", 
+          "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+        }
+      ], 
+      "id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+      "mac_address": "fa:16:3e:1b:82:4b", 
+      "name": "loadbalancer-00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "port_security_enabled": true, 
+      "security_groups": [
+        "7bd66c3f-6893-4d5a-ba10-f678b0637609"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T22:20:25"
+    }, 
+    "vip_port_id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+    "vip_subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+    "vxlan_vteps": [
+      "10.1.0.170", 
+      "10.1.0.147"
+    ]
+  }, 
+  "members": [
+    {
+      "address": "192.168.101.9", 
+      "admin_state_up": true, 
+      "gre_vteps": [], 
+      "id": "a3e24756-4131-4157-a6cc-f9066260ad61", 
+      "name": "", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "operating_status": "OFFLINE", 
+      "pool_id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "port": {
+        "admin_state_up": true, 
+        "allowed_address_pairs": [], 
+        "binding:host_id": "mitaka-stack", 
+        "binding:profile": {}, 
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true, 
+          "port_filter": true
+        }, 
+        "binding:vif_type": "ovs", 
+        "binding:vnic_type": "normal", 
+        "created_at": "2017-02-03T20:25:46", 
+        "description": "", 
+        "device_id": "7d064286-d2d0-4d86-83bb-d16038d6312f", 
+        "device_owner": "compute:nova", 
+        "dns_name": null, 
+        "extra_dhcp_opts": [], 
+        "fixed_ips": [
+          {
+            "ip_address": "192.168.101.9", 
+            "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+          }
+        ], 
+        "id": "62c00807-6e5c-4bfe-9c28-9bfb0cf8be65", 
+        "mac_address": "fa:16:3e:20:05:18", 
+        "name": "", 
+        "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+        "port_security_enabled": true, 
+        "security_groups": [
+          "7bd66c3f-6893-4d5a-ba10-f678b0637609"
+        ], 
+        "status": "ACTIVE", 
+        "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+        "updated_at": "2017-02-03T22:06:56"
+      }, 
+      "protocol_port": 8080, 
+      "provisioning_status": "PENDING_CREATE", 
+      "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "vxlan_vteps": [
+        "10.1.0.147"
+      ], 
+      "weight": 1
+    }
+  ], 
+  "networks": {
+    "6b3b89eb-94c2-490b-8270-0e46a70ae25a": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-02-03T20:08:46", 
+      "description": "", 
+      "id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "admin-net", 
+      "port_security_enabled": true, 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 1007, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+      ], 
+      "tags": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:08:46", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "l7_policies": [], 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listener_id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c", 
+      "listeners": [
+        {
+          "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c"
+        }
+      ], 
+      "loadbalancer_id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "members": [
+        {
+          "id": "a3e24756-4131-4157-a6cc-f9066260ad61"
+        }
+      ], 
+      "name": "pool1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "ACTIVE", 
+      "sessionpersistence": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc"
+    }
+  ], 
+  "subnets": {
+    "2b7ca4b5-a2b9-4234-91ed-5236afac1166": {
+      "allocation_pools": [
+        {
+          "end": "192.168.101.254", 
+          "start": "192.168.101.2"
+        }
+      ], 
+      "cidr": "192.168.101.0/24", 
+      "created_at": "2017-02-03T20:09:06", 
+      "description": "", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.101.1", 
+      "host_routes": [], 
+      "id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "admin-subnet", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:09:06"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c", 
+      "l7_policies": [], 
+      "loadbalancer_id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "name": "vs1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+    "listeners": [
+      {
+        "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+    "operating_status": "ONLINE", 
+    "pools": [
+      {
+        "id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f"
+      }
+    ], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+    "vip_address": "192.168.101.11", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "mitaka-stack:2db9ff02-7a10-53d8-a70d-8a61885e98af", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-02-03T22:20:24", 
+      "description": null, 
+      "device_id": "29ffa909-fe45-5512-899e-b4eaee6d4ff8", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "192.168.101.11", 
+          "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+        }
+      ], 
+      "id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+      "mac_address": "fa:16:3e:1b:82:4b", 
+      "name": "loadbalancer-00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "port_security_enabled": true, 
+      "security_groups": [
+        "7bd66c3f-6893-4d5a-ba10-f678b0637609"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T22:20:25"
+    }, 
+    "vip_port_id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+    "vip_subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+    "vxlan_vteps": [
+      "10.1.0.170", 
+      "10.1.0.147"
+    ]
+  }, 
+  "members": [
+    {
+      "address": "192.168.101.9", 
+      "admin_state_up": true, 
+      "gre_vteps": [], 
+      "id": "a3e24756-4131-4157-a6cc-f9066260ad61", 
+      "name": "", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "operating_status": "ONLINE", 
+      "pool_id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "port": {
+        "admin_state_up": true, 
+        "allowed_address_pairs": [], 
+        "binding:host_id": "mitaka-stack", 
+        "binding:profile": {}, 
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true, 
+          "port_filter": true
+        }, 
+        "binding:vif_type": "ovs", 
+        "binding:vnic_type": "normal", 
+        "created_at": "2017-02-03T20:25:46", 
+        "description": "", 
+        "device_id": "7d064286-d2d0-4d86-83bb-d16038d6312f", 
+        "device_owner": "compute:nova", 
+        "dns_name": null, 
+        "extra_dhcp_opts": [], 
+        "fixed_ips": [
+          {
+            "ip_address": "192.168.101.9", 
+            "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+          }
+        ], 
+        "id": "62c00807-6e5c-4bfe-9c28-9bfb0cf8be65", 
+        "mac_address": "fa:16:3e:20:05:18", 
+        "name": "", 
+        "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+        "port_security_enabled": true, 
+        "security_groups": [
+          "7bd66c3f-6893-4d5a-ba10-f678b0637609"
+        ], 
+        "status": "ACTIVE", 
+        "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+        "updated_at": "2017-02-03T22:06:56"
+      }, 
+      "protocol_port": 8080, 
+      "provisioning_status": "PENDING_UPDATE", 
+      "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "vxlan_vteps": [
+        "10.1.0.147"
+      ], 
+      "weight": 5
+    }
+  ], 
+  "networks": {
+    "6b3b89eb-94c2-490b-8270-0e46a70ae25a": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-02-03T20:08:46", 
+      "description": "", 
+      "id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "admin-net", 
+      "port_security_enabled": true, 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 1007, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+      ], 
+      "tags": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:08:46", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "l7_policies": [], 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listener_id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c", 
+      "listeners": [
+        {
+          "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c"
+        }
+      ], 
+      "loadbalancer_id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "members": [
+        {
+          "id": "a3e24756-4131-4157-a6cc-f9066260ad61"
+        }
+      ], 
+      "name": "pool1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "ACTIVE", 
+      "sessionpersistence": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc"
+    }
+  ], 
+  "subnets": {
+    "2b7ca4b5-a2b9-4234-91ed-5236afac1166": {
+      "allocation_pools": [
+        {
+          "end": "192.168.101.254", 
+          "start": "192.168.101.2"
+        }
+      ], 
+      "cidr": "192.168.101.0/24", 
+      "created_at": "2017-02-03T20:09:06", 
+      "description": "", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.101.1", 
+      "host_routes": [], 
+      "id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "admin-subnet", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:09:06"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c", 
+      "l7_policies": [], 
+      "loadbalancer_id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "name": "vs1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+    "listeners": [
+      {
+        "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+    "operating_status": "ONLINE", 
+    "pools": [
+      {
+        "id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f"
+      }
+    ], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+    "vip_address": "192.168.101.11", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "mitaka-stack:2db9ff02-7a10-53d8-a70d-8a61885e98af", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-02-03T22:20:24", 
+      "description": null, 
+      "device_id": "29ffa909-fe45-5512-899e-b4eaee6d4ff8", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "192.168.101.11", 
+          "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+        }
+      ], 
+      "id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+      "mac_address": "fa:16:3e:1b:82:4b", 
+      "name": "loadbalancer-00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "port_security_enabled": true, 
+      "security_groups": [
+        "7bd66c3f-6893-4d5a-ba10-f678b0637609"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T22:20:25"
+    }, 
+    "vip_port_id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+    "vip_subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+    "vxlan_vteps": [
+      "10.1.0.170", 
+      "10.1.0.147"
+    ]
+  }, 
+  "members": [
+    {
+      "address": "192.168.101.9", 
+      "admin_state_up": true, 
+      "gre_vteps": [], 
+      "id": "a3e24756-4131-4157-a6cc-f9066260ad61", 
+      "name": "", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "operating_status": "ONLINE", 
+      "pool_id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "port": {
+        "admin_state_up": true, 
+        "allowed_address_pairs": [], 
+        "binding:host_id": "mitaka-stack", 
+        "binding:profile": {}, 
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true, 
+          "port_filter": true
+        }, 
+        "binding:vif_type": "ovs", 
+        "binding:vnic_type": "normal", 
+        "created_at": "2017-02-03T20:25:46", 
+        "description": "", 
+        "device_id": "7d064286-d2d0-4d86-83bb-d16038d6312f", 
+        "device_owner": "compute:nova", 
+        "dns_name": null, 
+        "extra_dhcp_opts": [], 
+        "fixed_ips": [
+          {
+            "ip_address": "192.168.101.9", 
+            "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+          }
+        ], 
+        "id": "62c00807-6e5c-4bfe-9c28-9bfb0cf8be65", 
+        "mac_address": "fa:16:3e:20:05:18", 
+        "name": "", 
+        "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+        "port_security_enabled": true, 
+        "security_groups": [
+          "7bd66c3f-6893-4d5a-ba10-f678b0637609"
+        ], 
+        "status": "ACTIVE", 
+        "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+        "updated_at": "2017-02-03T22:06:56"
+      }, 
+      "protocol_port": 8080, 
+      "provisioning_status": "PENDING_UPDATE", 
+      "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "vxlan_vteps": [
+        "10.1.0.147"
+      ], 
+      "weight": 1
+    }
+  ], 
+  "networks": {
+    "6b3b89eb-94c2-490b-8270-0e46a70ae25a": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-02-03T20:08:46", 
+      "description": "", 
+      "id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "admin-net", 
+      "port_security_enabled": true, 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 1007, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+      ], 
+      "tags": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:08:46", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "l7_policies": [], 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listener_id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c", 
+      "listeners": [
+        {
+          "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c"
+        }
+      ], 
+      "loadbalancer_id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "members": [
+        {
+          "id": "a3e24756-4131-4157-a6cc-f9066260ad61"
+        }
+      ], 
+      "name": "pool1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "ACTIVE", 
+      "sessionpersistence": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc"
+    }
+  ], 
+  "subnets": {
+    "2b7ca4b5-a2b9-4234-91ed-5236afac1166": {
+      "allocation_pools": [
+        {
+          "end": "192.168.101.254", 
+          "start": "192.168.101.2"
+        }
+      ], 
+      "cidr": "192.168.101.0/24", 
+      "created_at": "2017-02-03T20:09:06", 
+      "description": "", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.101.1", 
+      "host_routes": [], 
+      "id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "admin-subnet", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:09:06"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c", 
+      "l7_policies": [], 
+      "loadbalancer_id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "name": "vs1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+    "listeners": [
+      {
+        "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+    "operating_status": "ONLINE", 
+    "pools": [
+      {
+        "id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f"
+      }
+    ], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+    "vip_address": "192.168.101.11", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "mitaka-stack:2db9ff02-7a10-53d8-a70d-8a61885e98af", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-02-03T22:20:24", 
+      "description": null, 
+      "device_id": "29ffa909-fe45-5512-899e-b4eaee6d4ff8", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "192.168.101.11", 
+          "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+        }
+      ], 
+      "id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+      "mac_address": "fa:16:3e:1b:82:4b", 
+      "name": "loadbalancer-00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "port_security_enabled": true, 
+      "security_groups": [
+        "7bd66c3f-6893-4d5a-ba10-f678b0637609"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T22:20:25"
+    }, 
+    "vip_port_id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+    "vip_subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+    "vxlan_vteps": [
+      "10.1.0.170", 
+      "10.1.0.147"
+    ]
+  }, 
+  "members": [
+    {
+      "address": "192.168.101.9", 
+      "admin_state_up": true, 
+      "gre_vteps": [], 
+      "id": "a3e24756-4131-4157-a6cc-f9066260ad61", 
+      "name": "", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "operating_status": "ONLINE", 
+      "pool_id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "port": {
+        "admin_state_up": true, 
+        "allowed_address_pairs": [], 
+        "binding:host_id": "mitaka-stack", 
+        "binding:profile": {}, 
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true, 
+          "port_filter": true
+        }, 
+        "binding:vif_type": "ovs", 
+        "binding:vnic_type": "normal", 
+        "created_at": "2017-02-03T20:25:46", 
+        "description": "", 
+        "device_id": "7d064286-d2d0-4d86-83bb-d16038d6312f", 
+        "device_owner": "compute:nova", 
+        "dns_name": null, 
+        "extra_dhcp_opts": [], 
+        "fixed_ips": [
+          {
+            "ip_address": "192.168.101.9", 
+            "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+          }
+        ], 
+        "id": "62c00807-6e5c-4bfe-9c28-9bfb0cf8be65", 
+        "mac_address": "fa:16:3e:20:05:18", 
+        "name": "", 
+        "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+        "port_security_enabled": true, 
+        "security_groups": [
+          "7bd66c3f-6893-4d5a-ba10-f678b0637609"
+        ], 
+        "status": "ACTIVE", 
+        "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+        "updated_at": "2017-02-03T22:06:56"
+      }, 
+      "protocol_port": 8080, 
+      "provisioning_status": "PENDING_UPDATE", 
+      "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "vxlan_vteps": [
+        "10.1.0.147"
+      ], 
+      "weight": 0
+    }
+  ], 
+  "networks": {
+    "6b3b89eb-94c2-490b-8270-0e46a70ae25a": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-02-03T20:08:46", 
+      "description": "", 
+      "id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "admin-net", 
+      "port_security_enabled": true, 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 1007, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+      ], 
+      "tags": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:08:46", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "l7_policies": [], 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listener_id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c", 
+      "listeners": [
+        {
+          "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c"
+        }
+      ], 
+      "loadbalancer_id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "members": [
+        {
+          "id": "a3e24756-4131-4157-a6cc-f9066260ad61"
+        }
+      ], 
+      "name": "pool1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "ACTIVE", 
+      "sessionpersistence": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc"
+    }
+  ], 
+  "subnets": {
+    "2b7ca4b5-a2b9-4234-91ed-5236afac1166": {
+      "allocation_pools": [
+        {
+          "end": "192.168.101.254", 
+          "start": "192.168.101.2"
+        }
+      ], 
+      "cidr": "192.168.101.0/24", 
+      "created_at": "2017-02-03T20:09:06", 
+      "description": "", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.101.1", 
+      "host_routes": [], 
+      "id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "admin-subnet", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:09:06"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c", 
+      "l7_policies": [], 
+      "loadbalancer_id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "name": "vs1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+    "listeners": [
+      {
+        "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+    "operating_status": "ONLINE", 
+    "pools": [
+      {
+        "id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f"
+      }
+    ], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+    "vip_address": "192.168.101.11", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "mitaka-stack:2db9ff02-7a10-53d8-a70d-8a61885e98af", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-02-03T22:20:24", 
+      "description": null, 
+      "device_id": "29ffa909-fe45-5512-899e-b4eaee6d4ff8", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "192.168.101.11", 
+          "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+        }
+      ], 
+      "id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+      "mac_address": "fa:16:3e:1b:82:4b", 
+      "name": "loadbalancer-00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "port_security_enabled": true, 
+      "security_groups": [
+        "7bd66c3f-6893-4d5a-ba10-f678b0637609"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T22:20:25"
+    }, 
+    "vip_port_id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+    "vip_subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+    "vxlan_vteps": [
+      "10.1.0.170", 
+      "10.1.0.147"
+    ]
+  }, 
+  "members": [
+    {
+      "address": "192.168.101.9", 
+      "admin_state_up": true, 
+      "gre_vteps": [], 
+      "id": "a3e24756-4131-4157-a6cc-f9066260ad61", 
+      "name": "", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "operating_status": "ONLINE", 
+      "pool_id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "port": {
+        "admin_state_up": true, 
+        "allowed_address_pairs": [], 
+        "binding:host_id": "mitaka-stack", 
+        "binding:profile": {}, 
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true, 
+          "port_filter": true
+        }, 
+        "binding:vif_type": "ovs", 
+        "binding:vnic_type": "normal", 
+        "created_at": "2017-02-03T20:25:46", 
+        "description": "", 
+        "device_id": "7d064286-d2d0-4d86-83bb-d16038d6312f", 
+        "device_owner": "compute:nova", 
+        "dns_name": null, 
+        "extra_dhcp_opts": [], 
+        "fixed_ips": [
+          {
+            "ip_address": "192.168.101.9", 
+            "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+          }
+        ], 
+        "id": "62c00807-6e5c-4bfe-9c28-9bfb0cf8be65", 
+        "mac_address": "fa:16:3e:20:05:18", 
+        "name": "", 
+        "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+        "port_security_enabled": true, 
+        "security_groups": [
+          "7bd66c3f-6893-4d5a-ba10-f678b0637609"
+        ], 
+        "status": "ACTIVE", 
+        "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+        "updated_at": "2017-02-03T22:06:56"
+      }, 
+      "protocol_port": 8080, 
+      "provisioning_status": "PENDING_UPDATE", 
+      "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "vxlan_vteps": [
+        "10.1.0.147"
+      ], 
+      "weight": 1
+    }
+  ], 
+  "networks": {
+    "6b3b89eb-94c2-490b-8270-0e46a70ae25a": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-02-03T20:08:46", 
+      "description": "", 
+      "id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "admin-net", 
+      "port_security_enabled": true, 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 1007, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+      ], 
+      "tags": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:08:46", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "l7_policies": [], 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listener_id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c", 
+      "listeners": [
+        {
+          "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c"
+        }
+      ], 
+      "loadbalancer_id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "members": [
+        {
+          "id": "a3e24756-4131-4157-a6cc-f9066260ad61"
+        }
+      ], 
+      "name": "pool1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "ACTIVE", 
+      "sessionpersistence": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc"
+    }
+  ], 
+  "subnets": {
+    "2b7ca4b5-a2b9-4234-91ed-5236afac1166": {
+      "allocation_pools": [
+        {
+          "end": "192.168.101.254", 
+          "start": "192.168.101.2"
+        }
+      ], 
+      "cidr": "192.168.101.0/24", 
+      "created_at": "2017-02-03T20:09:06", 
+      "description": "", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.101.1", 
+      "host_routes": [], 
+      "id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "admin-subnet", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:09:06"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c", 
+      "l7_policies": [], 
+      "loadbalancer_id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "name": "vs1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+    "listeners": [
+      {
+        "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+    "operating_status": "ONLINE", 
+    "pools": [
+      {
+        "id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f"
+      }
+    ], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+    "vip_address": "192.168.101.11", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "mitaka-stack:2db9ff02-7a10-53d8-a70d-8a61885e98af", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-02-03T22:20:24", 
+      "description": null, 
+      "device_id": "29ffa909-fe45-5512-899e-b4eaee6d4ff8", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "192.168.101.11", 
+          "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+        }
+      ], 
+      "id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+      "mac_address": "fa:16:3e:1b:82:4b", 
+      "name": "loadbalancer-00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "port_security_enabled": true, 
+      "security_groups": [
+        "7bd66c3f-6893-4d5a-ba10-f678b0637609"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T22:20:25"
+    }, 
+    "vip_port_id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+    "vip_subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+    "vxlan_vteps": [
+      "10.1.0.170", 
+      "10.1.0.147"
+    ]
+  }, 
+  "members": [
+    {
+      "address": "192.168.101.9", 
+      "admin_state_up": true, 
+      "gre_vteps": [], 
+      "id": "a3e24756-4131-4157-a6cc-f9066260ad61", 
+      "name": "", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "operating_status": "ONLINE", 
+      "pool_id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "port": {
+        "admin_state_up": true, 
+        "allowed_address_pairs": [], 
+        "binding:host_id": "mitaka-stack", 
+        "binding:profile": {}, 
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true, 
+          "port_filter": true
+        }, 
+        "binding:vif_type": "ovs", 
+        "binding:vnic_type": "normal", 
+        "created_at": "2017-02-03T20:25:46", 
+        "description": "", 
+        "device_id": "7d064286-d2d0-4d86-83bb-d16038d6312f", 
+        "device_owner": "compute:nova", 
+        "dns_name": null, 
+        "extra_dhcp_opts": [], 
+        "fixed_ips": [
+          {
+            "ip_address": "192.168.101.9", 
+            "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+          }
+        ], 
+        "id": "62c00807-6e5c-4bfe-9c28-9bfb0cf8be65", 
+        "mac_address": "fa:16:3e:20:05:18", 
+        "name": "", 
+        "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+        "port_security_enabled": true, 
+        "security_groups": [
+          "7bd66c3f-6893-4d5a-ba10-f678b0637609"
+        ], 
+        "status": "ACTIVE", 
+        "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+        "updated_at": "2017-02-03T22:06:56"
+      }, 
+      "protocol_port": 8080, 
+      "provisioning_status": "PENDING_UPDATE", 
+      "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "vxlan_vteps": [
+        "10.1.0.147"
+      ], 
+      "weight": 256
+    }
+  ], 
+  "networks": {
+    "6b3b89eb-94c2-490b-8270-0e46a70ae25a": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-02-03T20:08:46", 
+      "description": "", 
+      "id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "admin-net", 
+      "port_security_enabled": true, 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 1007, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+      ], 
+      "tags": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:08:46", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "l7_policies": [], 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listener_id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c", 
+      "listeners": [
+        {
+          "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c"
+        }
+      ], 
+      "loadbalancer_id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "members": [
+        {
+          "id": "a3e24756-4131-4157-a6cc-f9066260ad61"
+        }
+      ], 
+      "name": "pool1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "ACTIVE", 
+      "sessionpersistence": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc"
+    }
+  ], 
+  "subnets": {
+    "2b7ca4b5-a2b9-4234-91ed-5236afac1166": {
+      "allocation_pools": [
+        {
+          "end": "192.168.101.254", 
+          "start": "192.168.101.2"
+        }
+      ], 
+      "cidr": "192.168.101.0/24", 
+      "created_at": "2017-02-03T20:09:06", 
+      "description": "", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.101.1", 
+      "host_routes": [], 
+      "id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "admin-subnet", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:09:06"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c", 
+      "l7_policies": [], 
+      "loadbalancer_id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "name": "vs1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+    "listeners": [
+      {
+        "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+    "operating_status": "ONLINE", 
+    "pools": [
+      {
+        "id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f"
+      }
+    ], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+    "vip_address": "192.168.101.11", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "mitaka-stack:2db9ff02-7a10-53d8-a70d-8a61885e98af", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-02-03T22:20:24", 
+      "description": null, 
+      "device_id": "29ffa909-fe45-5512-899e-b4eaee6d4ff8", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "192.168.101.11", 
+          "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+        }
+      ], 
+      "id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+      "mac_address": "fa:16:3e:1b:82:4b", 
+      "name": "loadbalancer-00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "port_security_enabled": true, 
+      "security_groups": [
+        "7bd66c3f-6893-4d5a-ba10-f678b0637609"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T22:20:25"
+    }, 
+    "vip_port_id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+    "vip_subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+    "vxlan_vteps": [
+      "10.1.0.170", 
+      "10.1.0.147"
+    ]
+  }, 
+  "members": [
+    {
+      "address": "192.168.101.9", 
+      "admin_state_up": true, 
+      "gre_vteps": [], 
+      "id": "a3e24756-4131-4157-a6cc-f9066260ad61", 
+      "name": "", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "operating_status": "ONLINE", 
+      "pool_id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "port": {
+        "admin_state_up": true, 
+        "allowed_address_pairs": [], 
+        "binding:host_id": "mitaka-stack", 
+        "binding:profile": {}, 
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true, 
+          "port_filter": true
+        }, 
+        "binding:vif_type": "ovs", 
+        "binding:vnic_type": "normal", 
+        "created_at": "2017-02-03T20:25:46", 
+        "description": "", 
+        "device_id": "7d064286-d2d0-4d86-83bb-d16038d6312f", 
+        "device_owner": "compute:nova", 
+        "dns_name": null, 
+        "extra_dhcp_opts": [], 
+        "fixed_ips": [
+          {
+            "ip_address": "192.168.101.9", 
+            "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+          }
+        ], 
+        "id": "62c00807-6e5c-4bfe-9c28-9bfb0cf8be65", 
+        "mac_address": "fa:16:3e:20:05:18", 
+        "name": "", 
+        "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+        "port_security_enabled": true, 
+        "security_groups": [
+          "7bd66c3f-6893-4d5a-ba10-f678b0637609"
+        ], 
+        "status": "ACTIVE", 
+        "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+        "updated_at": "2017-02-03T22:06:56"
+      }, 
+      "protocol_port": 8080, 
+      "provisioning_status": "PENDING_UPDATE", 
+      "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "vxlan_vteps": [
+        "10.1.0.147"
+      ], 
+      "weight": 1
+    }
+  ], 
+  "networks": {
+    "6b3b89eb-94c2-490b-8270-0e46a70ae25a": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-02-03T20:08:46", 
+      "description": "", 
+      "id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "admin-net", 
+      "port_security_enabled": true, 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 1007, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+      ], 
+      "tags": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:08:46", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "l7_policies": [], 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listener_id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c", 
+      "listeners": [
+        {
+          "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c"
+        }
+      ], 
+      "loadbalancer_id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "members": [
+        {
+          "id": "a3e24756-4131-4157-a6cc-f9066260ad61"
+        }
+      ], 
+      "name": "pool1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "ACTIVE", 
+      "sessionpersistence": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc"
+    }
+  ], 
+  "subnets": {
+    "2b7ca4b5-a2b9-4234-91ed-5236afac1166": {
+      "allocation_pools": [
+        {
+          "end": "192.168.101.254", 
+          "start": "192.168.101.2"
+        }
+      ], 
+      "cidr": "192.168.101.0/24", 
+      "created_at": "2017-02-03T20:09:06", 
+      "description": "", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.101.1", 
+      "host_routes": [], 
+      "id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "admin-subnet", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:09:06"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c", 
+      "l7_policies": [], 
+      "loadbalancer_id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "name": "vs1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+    "listeners": [
+      {
+        "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+    "operating_status": "ONLINE", 
+    "pools": [
+      {
+        "id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f"
+      }
+    ], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+    "vip_address": "192.168.101.11", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "mitaka-stack:2db9ff02-7a10-53d8-a70d-8a61885e98af", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-02-03T22:20:24", 
+      "description": null, 
+      "device_id": "29ffa909-fe45-5512-899e-b4eaee6d4ff8", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "192.168.101.11", 
+          "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+        }
+      ], 
+      "id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+      "mac_address": "fa:16:3e:1b:82:4b", 
+      "name": "loadbalancer-00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "port_security_enabled": true, 
+      "security_groups": [
+        "7bd66c3f-6893-4d5a-ba10-f678b0637609"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T22:20:25"
+    }, 
+    "vip_port_id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+    "vip_subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+    "vxlan_vteps": [
+      "10.1.0.170", 
+      "10.1.0.147"
+    ]
+  }, 
+  "members": [
+    {
+      "address": "192.168.101.9", 
+      "admin_state_up": true, 
+      "gre_vteps": [], 
+      "id": "a3e24756-4131-4157-a6cc-f9066260ad61", 
+      "name": "", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "operating_status": "ONLINE", 
+      "pool_id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "port": {
+        "admin_state_up": true, 
+        "allowed_address_pairs": [], 
+        "binding:host_id": "mitaka-stack", 
+        "binding:profile": {}, 
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true, 
+          "port_filter": true
+        }, 
+        "binding:vif_type": "ovs", 
+        "binding:vnic_type": "normal", 
+        "created_at": "2017-02-03T20:25:46", 
+        "description": "", 
+        "device_id": "7d064286-d2d0-4d86-83bb-d16038d6312f", 
+        "device_owner": "compute:nova", 
+        "dns_name": null, 
+        "extra_dhcp_opts": [], 
+        "fixed_ips": [
+          {
+            "ip_address": "192.168.101.9", 
+            "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+          }
+        ], 
+        "id": "62c00807-6e5c-4bfe-9c28-9bfb0cf8be65", 
+        "mac_address": "fa:16:3e:20:05:18", 
+        "name": "", 
+        "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+        "port_security_enabled": true, 
+        "security_groups": [
+          "7bd66c3f-6893-4d5a-ba10-f678b0637609"
+        ], 
+        "status": "ACTIVE", 
+        "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+        "updated_at": "2017-02-03T22:06:56"
+      }, 
+      "protocol_port": 8080, 
+      "provisioning_status": "PENDING_DELETE", 
+      "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "vxlan_vteps": [
+        "10.1.0.147"
+      ], 
+      "weight": 1
+    }
+  ], 
+  "networks": {
+    "6b3b89eb-94c2-490b-8270-0e46a70ae25a": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-02-03T20:08:46", 
+      "description": "", 
+      "id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "admin-net", 
+      "port_security_enabled": true, 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 1007, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+      ], 
+      "tags": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:08:46", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "l7_policies": [], 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listener_id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c", 
+      "listeners": [
+        {
+          "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c"
+        }
+      ], 
+      "loadbalancer_id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "members": [
+        {
+          "id": "a3e24756-4131-4157-a6cc-f9066260ad61"
+        }
+      ], 
+      "name": "pool1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "ACTIVE", 
+      "sessionpersistence": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc"
+    }
+  ], 
+  "subnets": {
+    "2b7ca4b5-a2b9-4234-91ed-5236afac1166": {
+      "allocation_pools": [
+        {
+          "end": "192.168.101.254", 
+          "start": "192.168.101.2"
+        }
+      ], 
+      "cidr": "192.168.101.0/24", 
+      "created_at": "2017-02-03T20:09:06", 
+      "description": "", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.101.1", 
+      "host_routes": [], 
+      "id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "admin-subnet", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:09:06"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c", 
+      "l7_policies": [], 
+      "loadbalancer_id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "name": "vs1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+    "listeners": [
+      {
+        "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+    "operating_status": "ONLINE", 
+    "pools": [
+      {
+        "id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f"
+      }
+    ], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+    "vip_address": "192.168.101.11", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "mitaka-stack:2db9ff02-7a10-53d8-a70d-8a61885e98af", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-02-03T22:20:24", 
+      "description": null, 
+      "device_id": "29ffa909-fe45-5512-899e-b4eaee6d4ff8", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "192.168.101.11", 
+          "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+        }
+      ], 
+      "id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+      "mac_address": "fa:16:3e:1b:82:4b", 
+      "name": "loadbalancer-00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "port_security_enabled": true, 
+      "security_groups": [
+        "7bd66c3f-6893-4d5a-ba10-f678b0637609"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T22:20:25"
+    }, 
+    "vip_port_id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+    "vip_subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+    "vxlan_vteps": [
+      "10.1.0.170", 
+      "10.1.0.147"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "6b3b89eb-94c2-490b-8270-0e46a70ae25a": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-02-03T20:08:46", 
+      "description": "", 
+      "id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "admin-net", 
+      "port_security_enabled": true, 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 1007, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+      ], 
+      "tags": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:08:46", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "47d89d6e-4bec-47b9-a4cf-9ca86297e93f", 
+      "l7_policies": [], 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listener_id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c", 
+      "listeners": [
+        {
+          "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c"
+        }
+      ], 
+      "loadbalancer_id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "members": [], 
+      "name": "pool1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "PENDING_DELETE", 
+      "sessionpersistence": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc"
+    }
+  ], 
+  "subnets": {
+    "2b7ca4b5-a2b9-4234-91ed-5236afac1166": {
+      "allocation_pools": [
+        {
+          "end": "192.168.101.254", 
+          "start": "192.168.101.2"
+        }
+      ], 
+      "cidr": "192.168.101.0/24", 
+      "created_at": "2017-02-03T20:09:06", 
+      "description": "", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.101.1", 
+      "host_routes": [], 
+      "id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "admin-subnet", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:09:06"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": null, 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c", 
+      "l7_policies": [], 
+      "loadbalancer_id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "name": "vs1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "PENDING_DELETE", 
+      "sni_containers": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+    "listeners": [
+      {
+        "id": "f249bc6d-90d0-465e-97cc-4651c2e94c8c"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+    "operating_status": "ONLINE", 
+    "pools": [], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+    "vip_address": "192.168.101.11", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "mitaka-stack:2db9ff02-7a10-53d8-a70d-8a61885e98af", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-02-03T22:20:24", 
+      "description": null, 
+      "device_id": "29ffa909-fe45-5512-899e-b4eaee6d4ff8", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "192.168.101.11", 
+          "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+        }
+      ], 
+      "id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+      "mac_address": "fa:16:3e:1b:82:4b", 
+      "name": "loadbalancer-00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "port_security_enabled": true, 
+      "security_groups": [
+        "7bd66c3f-6893-4d5a-ba10-f678b0637609"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T22:20:25"
+    }, 
+    "vip_port_id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+    "vip_subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+    "vxlan_vteps": [
+      "10.1.0.170", 
+      "10.1.0.147"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "6b3b89eb-94c2-490b-8270-0e46a70ae25a": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-02-03T20:08:46", 
+      "description": "", 
+      "id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "admin-net", 
+      "port_security_enabled": true, 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 1007, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+      ], 
+      "tags": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:08:46", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "2b7ca4b5-a2b9-4234-91ed-5236afac1166": {
+      "allocation_pools": [
+        {
+          "end": "192.168.101.254", 
+          "start": "192.168.101.2"
+        }
+      ], 
+      "cidr": "192.168.101.0/24", 
+      "created_at": "2017-02-03T20:09:06", 
+      "description": "", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.101.1", 
+      "host_routes": [], 
+      "id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "admin-subnet", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:09:06"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+    "listeners": [], 
+    "name": "lb1", 
+    "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+    "operating_status": "ONLINE", 
+    "pools": [], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_DELETE", 
+    "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+    "vip_address": "192.168.101.11", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "mitaka-stack:2db9ff02-7a10-53d8-a70d-8a61885e98af", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-02-03T22:20:24", 
+      "description": null, 
+      "device_id": "29ffa909-fe45-5512-899e-b4eaee6d4ff8", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "192.168.101.11", 
+          "subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+        }
+      ], 
+      "id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+      "mac_address": "fa:16:3e:1b:82:4b", 
+      "name": "loadbalancer-00ffc5ec-04e4-4d89-a000-374e9e6f31d4", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "port_security_enabled": true, 
+      "security_groups": [
+        "7bd66c3f-6893-4d5a-ba10-f678b0637609"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T22:20:25"
+    }, 
+    "vip_port_id": "d97783f8-76bb-42ce-b52a-783bfbb59790", 
+    "vip_subnet_id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+    "vxlan_vteps": [
+      "10.1.0.170", 
+      "10.1.0.147"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "6b3b89eb-94c2-490b-8270-0e46a70ae25a": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-02-03T20:08:46", 
+      "description": "", 
+      "id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "admin-net", 
+      "port_security_enabled": true, 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 1007, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "2b7ca4b5-a2b9-4234-91ed-5236afac1166"
+      ], 
+      "tags": [], 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:08:46", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "2b7ca4b5-a2b9-4234-91ed-5236afac1166": {
+      "allocation_pools": [
+        {
+          "end": "192.168.101.254", 
+          "start": "192.168.101.2"
+        }
+      ], 
+      "cidr": "192.168.101.0/24", 
+      "created_at": "2017-02-03T20:09:06", 
+      "description": "", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.101.1", 
+      "host_routes": [], 
+      "id": "2b7ca4b5-a2b9-4234-91ed-5236afac1166", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "admin-subnet", 
+      "network_id": "6b3b89eb-94c2-490b-8270-0e46a70ae25a", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "dfd83103ce2047d5b20ccd6ef272f3cc", 
+      "updated_at": "2017-02-03T20:09:06"
+    }
+  }
+}]


### PR DESCRIPTION
…o do ratio based LBing

Issues:
Fixes #498

Problem:
The weight attribute no long forces the load balancing to use a ratio
based load balancing method and set the ratio attribute on each member
which would appropriately handle the weight behavior from the LBaaSv2 API.

Analysis:
Adding lbaas weight to member ratio attribute.  If the lbaas
weight is 0, this has the effect of disabling the member.

Tests:
test/functional/neutronless/member/test_single_member_weight_updates.py

@jlongstaf 
#### What issues does this address?
Fixes #498

#### What's this change do?
Adds logic to manipulate weights of BigIP pool members

#### Where should the reviewer start?

#### Any background context?
