### PR TITLE
Fix listener update

### DIFF
--- a/test/functional/neutronless/listener/test_listener_update.py
+++ b/test/functional/neutronless/listener/test_listener_update.py
@@ -1,0 +1,132 @@
+# coding=utf-8
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from copy import deepcopy
+import json
+import logging
+import os
+import pytest
+import requests
+
+from f5_openstack_agent.lbaasv2.drivers.bigip.resource_helper import \
+    ResourceType
+
+requests.packages.urllib3.disable_warnings()
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def services():
+    neutron_services_filename = (
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            '../../testdata/service_requests/listener_update.json')
+    )
+    return (json.load(open(neutron_services_filename)))
+
+
+@pytest.fixture()
+def icd_config():
+    oslo_config_filename = (
+        os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                     '../../config/basic_agent_config.json')
+    )
+    OSLO_CONFIGS = json.load(open(oslo_config_filename))
+
+    config = deepcopy(OSLO_CONFIGS)
+    config['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
+    config['icontrol_username'] = pytest.symbols.bigip_username
+    config['icontrol_password'] = pytest.symbols.bigip_password
+    config['environment_prefix'] = 'Project'
+
+    return config
+
+
+def get_next_listener(service_iterator, icontrol_driver, bigip, env_prefix):
+
+    service = service_iterator.next()
+    listener = service['listeners'][0]
+    folder = '{0}_{1}'.format(env_prefix, listener['tenant_id'])
+    icontrol_driver._common_service_handler(service)
+
+    listener_name = '{0}_{1}'.format(env_prefix, listener['id'])
+    return bigip.get_resource(
+        ResourceType.virtual, listener_name, partition=folder)
+
+
+def get_folder_name(service, env_prefix):
+    return '{0}_{1}'.format(env_prefix, service['loadbalancer']['tenant_id'])
+
+
+def test_listener_update(
+        bigip,
+        services,
+        icd_config,
+        icontrol_driver):
+
+    env_prefix = icd_config['environment_prefix']
+    service_iter = iter(services)
+
+    # Create loadbalancer
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+
+    # Create listener (no name, description)
+    l = get_next_listener(service_iter, icontrol_driver, bigip, env_prefix)
+    assert l.name.startswith('Project_')
+    assert not hasattr(l, 'description')
+    assert l.connectionLimit == 0
+    assert l.enabled
+
+    # Update name ('spring'). Description is changed to include name.
+    l = get_next_listener(service_iter, icontrol_driver, bigip, env_prefix)
+    assert l.name.startswith('Project_')
+    assert l.description == 'spring:'
+    assert l.connectionLimit == 0
+    assert l.enabled
+
+    # Update description ('has sprung')
+    l = get_next_listener(service_iter, icontrol_driver, bigip, env_prefix)
+    assert l.name.startswith('Project_')
+    assert l.description == 'spring: has-sprung'
+    assert l.connectionLimit == 0
+    assert l.enabled
+
+    # Update connection limit (200)
+    l = get_next_listener(service_iter, icontrol_driver, bigip, env_prefix)
+    assert l.name.startswith('Project_')
+    assert l.description == 'spring: has-sprung'
+    assert l.connectionLimit == 200
+    assert l.enabled
+
+    # Update admin_state_up (False)
+    l = get_next_listener(service_iter, icontrol_driver, bigip, env_prefix)
+    assert l.name.startswith('Project_')
+    assert l.description == 'spring: has-sprung'
+    assert l.connectionLimit == 200
+    assert l.disabled
+
+    # Delete listener
+    service = service_iter.next()
+    folder = get_folder_name(service, env_prefix)
+    icontrol_driver._common_service_handler(service)
+
+    # Delete loadbalancer
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service, delete_partition=True)
+
+    # All objects deleted
+    assert not bigip.folder_exists(folder)

--- a/test/functional/testdata/service_requests/listener_update.json
+++ b/test/functional/testdata/service_requests/listener_update.json
@@ -1,0 +1,1039 @@
+[{
+  "healthmonitors": [], 
+  "listeners": [], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+    "listeners": [], 
+    "name": "lb1", 
+    "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+    "operating_status": "OFFLINE", 
+    "provider": null, 
+    "provisioning_status": "PENDING_CREATE", 
+    "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8", 
+    "vip_address": "10.2.3.107", 
+    "vip_port": {
+      "admin_state_up": false, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "unbound", 
+      "binding:vnic_type": "normal", 
+      "device_id": "61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+      "device_owner": "neutron:LOADBALANCERV2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-10-2-3-107.openstacklocal.", 
+          "hostname": "host-10-2-3-107", 
+          "ip_address": "10.2.3.107"
+        }
+      ], 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.3.107", 
+          "subnet_id": "108c9db3-6b9b-442e-8b93-42ce265d7b59"
+        }
+      ], 
+      "id": "40403ef3-7de2-49b1-a685-948ac30f7370", 
+      "mac_address": "fa:16:3e:ca:30:9b", 
+      "name": "loadbalancer-61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+      "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "security_groups": [
+        "462ac45c-af06-4738-baf9-ce911088b58d"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }, 
+    "vip_port_id": "40403ef3-7de2-49b1-a685-948ac30f7370", 
+    "vip_subnet_id": "108c9db3-6b9b-442e-8b93-42ce265d7b59", 
+    "vxlan_vteps": [
+      "201.0.169.1", 
+      "201.0.166.1", 
+      "201.0.168.1", 
+      "201.0.160.10"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "41016ade-73b2-496b-b0b7-821553dabcae": {
+      "admin_state_up": true, 
+      "id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "mtu": 0, 
+      "name": "testlab-server-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 46, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "108c9db3-6b9b-442e-8b93-42ce265d7b59", 
+        "8d711da1-9dfd-4ee6-8534-f08b89370b85"
+      ], 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "108c9db3-6b9b-442e-8b93-42ce265d7b59": {
+      "allocation_pools": [
+        {
+          "end": "10.2.3.150", 
+          "start": "10.2.3.100"
+        }
+      ], 
+      "cidr": "10.2.3.0/24", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": null, 
+      "host_routes": [], 
+      "id": "108c9db3-6b9b-442e-8b93-42ce265d7b59", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "testlab-server-v4-subnet", 
+      "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": null, 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "b2291c35-17db-46ba-8c75-cfcd7663e539", 
+      "loadbalancer_id": "61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+      "name": "", 
+      "operating_status": "OFFLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "PENDING_CREATE", 
+      "sni_containers": [], 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+    "listeners": [
+      {
+        "id": "b2291c35-17db-46ba-8c75-cfcd7663e539"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+    "operating_status": "ONLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8", 
+    "vip_address": "10.2.3.107", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:1e7f2f28-2d0f-5d65-8bd5-7bf90c10b3b3", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "550684bd-3908-5d09-9be0-89fdfca23d76", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-10-2-3-107.openstacklocal.", 
+          "hostname": "host-10-2-3-107", 
+          "ip_address": "10.2.3.107"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.3.107", 
+          "subnet_id": "108c9db3-6b9b-442e-8b93-42ce265d7b59"
+        }
+      ], 
+      "id": "40403ef3-7de2-49b1-a685-948ac30f7370", 
+      "mac_address": "fa:16:3e:ca:30:9b", 
+      "name": "loadbalancer-61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+      "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "security_groups": [
+        "462ac45c-af06-4738-baf9-ce911088b58d"
+      ], 
+      "status": "ACTIVE", 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }, 
+    "vip_port_id": "40403ef3-7de2-49b1-a685-948ac30f7370", 
+    "vip_subnet_id": "108c9db3-6b9b-442e-8b93-42ce265d7b59", 
+    "vxlan_vteps": [
+      "201.0.169.1", 
+      "201.0.166.1", 
+      "201.0.168.1", 
+      "201.0.160.10"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "41016ade-73b2-496b-b0b7-821553dabcae": {
+      "admin_state_up": true, 
+      "id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "mtu": 0, 
+      "name": "testlab-server-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 46, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "8d711da1-9dfd-4ee6-8534-f08b89370b85", 
+        "108c9db3-6b9b-442e-8b93-42ce265d7b59"
+      ], 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "108c9db3-6b9b-442e-8b93-42ce265d7b59": {
+      "allocation_pools": [
+        {
+          "end": "10.2.3.150", 
+          "start": "10.2.3.100"
+        }
+      ], 
+      "cidr": "10.2.3.0/24", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": null, 
+      "host_routes": [], 
+      "id": "108c9db3-6b9b-442e-8b93-42ce265d7b59", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "testlab-server-v4-subnet", 
+      "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": null, 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "b2291c35-17db-46ba-8c75-cfcd7663e539", 
+      "loadbalancer_id": "61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+      "name": "spring", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "PENDING_UPDATE", 
+      "sni_containers": [], 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+    "listeners": [
+      {
+        "id": "b2291c35-17db-46ba-8c75-cfcd7663e539"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+    "operating_status": "ONLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8", 
+    "vip_address": "10.2.3.107", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:1e7f2f28-2d0f-5d65-8bd5-7bf90c10b3b3", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "550684bd-3908-5d09-9be0-89fdfca23d76", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-10-2-3-107.openstacklocal.", 
+          "hostname": "host-10-2-3-107", 
+          "ip_address": "10.2.3.107"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.3.107", 
+          "subnet_id": "108c9db3-6b9b-442e-8b93-42ce265d7b59"
+        }
+      ], 
+      "id": "40403ef3-7de2-49b1-a685-948ac30f7370", 
+      "mac_address": "fa:16:3e:ca:30:9b", 
+      "name": "loadbalancer-61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+      "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "security_groups": [
+        "462ac45c-af06-4738-baf9-ce911088b58d"
+      ], 
+      "status": "ACTIVE", 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }, 
+    "vip_port_id": "40403ef3-7de2-49b1-a685-948ac30f7370", 
+    "vip_subnet_id": "108c9db3-6b9b-442e-8b93-42ce265d7b59", 
+    "vxlan_vteps": [
+      "201.0.169.1", 
+      "201.0.166.1", 
+      "201.0.168.1", 
+      "201.0.160.10"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "41016ade-73b2-496b-b0b7-821553dabcae": {
+      "admin_state_up": true, 
+      "id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "mtu": 0, 
+      "name": "testlab-server-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 46, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "8d711da1-9dfd-4ee6-8534-f08b89370b85", 
+        "108c9db3-6b9b-442e-8b93-42ce265d7b59"
+      ], 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8", 
+      "vlan_transparent": null
+    }
+  }, 
+  "old_listener": {
+    "admin_state_up": true, 
+    "connection_limit": -1, 
+    "default_pool_id": null, 
+    "default_tls_container_id": null, 
+    "description": "", 
+    "id": "b2291c35-17db-46ba-8c75-cfcd7663e539", 
+    "loadbalancer_id": "61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+    "name": "", 
+    "operating_status": "ONLINE", 
+    "protocol": "HTTP", 
+    "protocol_port": 80, 
+    "provisioning_status": "ACTIVE", 
+    "sni_containers": [], 
+    "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+  }, 
+  "pools": [], 
+  "subnets": {
+    "108c9db3-6b9b-442e-8b93-42ce265d7b59": {
+      "allocation_pools": [
+        {
+          "end": "10.2.3.150", 
+          "start": "10.2.3.100"
+        }
+      ], 
+      "cidr": "10.2.3.0/24", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": null, 
+      "host_routes": [], 
+      "id": "108c9db3-6b9b-442e-8b93-42ce265d7b59", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "testlab-server-v4-subnet", 
+      "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": null, 
+      "default_tls_container_id": null, 
+      "description": "has-sprung", 
+      "id": "b2291c35-17db-46ba-8c75-cfcd7663e539", 
+      "loadbalancer_id": "61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+      "name": "spring", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "PENDING_UPDATE", 
+      "sni_containers": [], 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+    "listeners": [
+      {
+        "id": "b2291c35-17db-46ba-8c75-cfcd7663e539"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+    "operating_status": "ONLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8", 
+    "vip_address": "10.2.3.107", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:1e7f2f28-2d0f-5d65-8bd5-7bf90c10b3b3", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "550684bd-3908-5d09-9be0-89fdfca23d76", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-10-2-3-107.openstacklocal.", 
+          "hostname": "host-10-2-3-107", 
+          "ip_address": "10.2.3.107"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.3.107", 
+          "subnet_id": "108c9db3-6b9b-442e-8b93-42ce265d7b59"
+        }
+      ], 
+      "id": "40403ef3-7de2-49b1-a685-948ac30f7370", 
+      "mac_address": "fa:16:3e:ca:30:9b", 
+      "name": "loadbalancer-61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+      "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "security_groups": [
+        "462ac45c-af06-4738-baf9-ce911088b58d"
+      ], 
+      "status": "ACTIVE", 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }, 
+    "vip_port_id": "40403ef3-7de2-49b1-a685-948ac30f7370", 
+    "vip_subnet_id": "108c9db3-6b9b-442e-8b93-42ce265d7b59", 
+    "vxlan_vteps": [
+      "201.0.169.1", 
+      "201.0.166.1", 
+      "201.0.168.1", 
+      "201.0.160.10"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "41016ade-73b2-496b-b0b7-821553dabcae": {
+      "admin_state_up": true, 
+      "id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "mtu": 0, 
+      "name": "testlab-server-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 46, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "8d711da1-9dfd-4ee6-8534-f08b89370b85", 
+        "108c9db3-6b9b-442e-8b93-42ce265d7b59"
+      ], 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8", 
+      "vlan_transparent": null
+    }
+  }, 
+  "old_listener": {
+    "admin_state_up": true, 
+    "connection_limit": -1, 
+    "default_pool_id": null, 
+    "default_tls_container_id": null, 
+    "description": "", 
+    "id": "b2291c35-17db-46ba-8c75-cfcd7663e539", 
+    "loadbalancer_id": "61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+    "name": "spring", 
+    "operating_status": "ONLINE", 
+    "protocol": "HTTP", 
+    "protocol_port": 80, 
+    "provisioning_status": "ACTIVE", 
+    "sni_containers": [], 
+    "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+  }, 
+  "pools": [], 
+  "subnets": {
+    "108c9db3-6b9b-442e-8b93-42ce265d7b59": {
+      "allocation_pools": [
+        {
+          "end": "10.2.3.150", 
+          "start": "10.2.3.100"
+        }
+      ], 
+      "cidr": "10.2.3.0/24", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": null, 
+      "host_routes": [], 
+      "id": "108c9db3-6b9b-442e-8b93-42ce265d7b59", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "testlab-server-v4-subnet", 
+      "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": 200, 
+      "default_pool_id": null, 
+      "default_tls_container_id": null, 
+      "description": "has-sprung", 
+      "id": "b2291c35-17db-46ba-8c75-cfcd7663e539", 
+      "loadbalancer_id": "61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+      "name": "spring", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "PENDING_UPDATE", 
+      "sni_containers": [], 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+    "listeners": [
+      {
+        "id": "b2291c35-17db-46ba-8c75-cfcd7663e539"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+    "operating_status": "ONLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8", 
+    "vip_address": "10.2.3.107", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:1e7f2f28-2d0f-5d65-8bd5-7bf90c10b3b3", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "550684bd-3908-5d09-9be0-89fdfca23d76", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-10-2-3-107.openstacklocal.", 
+          "hostname": "host-10-2-3-107", 
+          "ip_address": "10.2.3.107"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.3.107", 
+          "subnet_id": "108c9db3-6b9b-442e-8b93-42ce265d7b59"
+        }
+      ], 
+      "id": "40403ef3-7de2-49b1-a685-948ac30f7370", 
+      "mac_address": "fa:16:3e:ca:30:9b", 
+      "name": "loadbalancer-61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+      "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "security_groups": [
+        "462ac45c-af06-4738-baf9-ce911088b58d"
+      ], 
+      "status": "ACTIVE", 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }, 
+    "vip_port_id": "40403ef3-7de2-49b1-a685-948ac30f7370", 
+    "vip_subnet_id": "108c9db3-6b9b-442e-8b93-42ce265d7b59", 
+    "vxlan_vteps": [
+      "201.0.169.1", 
+      "201.0.166.1", 
+      "201.0.168.1", 
+      "201.0.160.10"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "41016ade-73b2-496b-b0b7-821553dabcae": {
+      "admin_state_up": true, 
+      "id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "mtu": 0, 
+      "name": "testlab-server-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 46, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "108c9db3-6b9b-442e-8b93-42ce265d7b59", 
+        "8d711da1-9dfd-4ee6-8534-f08b89370b85"
+      ], 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8", 
+      "vlan_transparent": null
+    }
+  }, 
+  "old_listener": {
+    "admin_state_up": true, 
+    "connection_limit": -1, 
+    "default_pool_id": null, 
+    "default_tls_container_id": null, 
+    "description": "has-sprung", 
+    "id": "b2291c35-17db-46ba-8c75-cfcd7663e539", 
+    "loadbalancer_id": "61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+    "name": "spring", 
+    "operating_status": "ONLINE", 
+    "protocol": "HTTP", 
+    "protocol_port": 80, 
+    "provisioning_status": "ACTIVE", 
+    "sni_containers": [], 
+    "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+  }, 
+  "pools": [], 
+  "subnets": {
+    "108c9db3-6b9b-442e-8b93-42ce265d7b59": {
+      "allocation_pools": [
+        {
+          "end": "10.2.3.150", 
+          "start": "10.2.3.100"
+        }
+      ], 
+      "cidr": "10.2.3.0/24", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": null, 
+      "host_routes": [], 
+      "id": "108c9db3-6b9b-442e-8b93-42ce265d7b59", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "testlab-server-v4-subnet", 
+      "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "listeners": [
+    {
+      "admin_state_up": false, 
+      "connection_limit": 200, 
+      "default_pool_id": null, 
+      "default_tls_container_id": null, 
+      "description": "has-sprung", 
+      "id": "b2291c35-17db-46ba-8c75-cfcd7663e539", 
+      "loadbalancer_id": "61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+      "name": "spring", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "PENDING_UPDATE", 
+      "sni_containers": [], 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+    "listeners": [
+      {
+        "id": "b2291c35-17db-46ba-8c75-cfcd7663e539"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+    "operating_status": "ONLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8", 
+    "vip_address": "10.2.3.107", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:1e7f2f28-2d0f-5d65-8bd5-7bf90c10b3b3", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "550684bd-3908-5d09-9be0-89fdfca23d76", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-10-2-3-107.openstacklocal.", 
+          "hostname": "host-10-2-3-107", 
+          "ip_address": "10.2.3.107"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.3.107", 
+          "subnet_id": "108c9db3-6b9b-442e-8b93-42ce265d7b59"
+        }
+      ], 
+      "id": "40403ef3-7de2-49b1-a685-948ac30f7370", 
+      "mac_address": "fa:16:3e:ca:30:9b", 
+      "name": "loadbalancer-61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+      "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "security_groups": [
+        "462ac45c-af06-4738-baf9-ce911088b58d"
+      ], 
+      "status": "ACTIVE", 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }, 
+    "vip_port_id": "40403ef3-7de2-49b1-a685-948ac30f7370", 
+    "vip_subnet_id": "108c9db3-6b9b-442e-8b93-42ce265d7b59", 
+    "vxlan_vteps": [
+      "201.0.169.1", 
+      "201.0.166.1", 
+      "201.0.168.1", 
+      "201.0.160.10"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "41016ade-73b2-496b-b0b7-821553dabcae": {
+      "admin_state_up": true, 
+      "id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "mtu": 0, 
+      "name": "testlab-server-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 46, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "8d711da1-9dfd-4ee6-8534-f08b89370b85", 
+        "108c9db3-6b9b-442e-8b93-42ce265d7b59"
+      ], 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8", 
+      "vlan_transparent": null
+    }
+  }, 
+  "old_listener": {
+    "admin_state_up": true, 
+    "connection_limit": 200, 
+    "default_pool_id": null, 
+    "default_tls_container_id": null, 
+    "description": "has-sprung", 
+    "id": "b2291c35-17db-46ba-8c75-cfcd7663e539", 
+    "loadbalancer_id": "61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+    "name": "spring", 
+    "operating_status": "ONLINE", 
+    "protocol": "HTTP", 
+    "protocol_port": 80, 
+    "provisioning_status": "ACTIVE", 
+    "sni_containers": [], 
+    "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+  }, 
+  "pools": [], 
+  "subnets": {
+    "108c9db3-6b9b-442e-8b93-42ce265d7b59": {
+      "allocation_pools": [
+        {
+          "end": "10.2.3.150", 
+          "start": "10.2.3.100"
+        }
+      ], 
+      "cidr": "10.2.3.0/24", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": null, 
+      "host_routes": [], 
+      "id": "108c9db3-6b9b-442e-8b93-42ce265d7b59", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "testlab-server-v4-subnet", 
+      "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "listeners": [
+    {
+      "admin_state_up": false, 
+      "connection_limit": 200, 
+      "default_pool_id": null, 
+      "default_tls_container_id": null, 
+      "description": "has-sprung", 
+      "id": "b2291c35-17db-46ba-8c75-cfcd7663e539", 
+      "loadbalancer_id": "61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+      "name": "spring", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "PENDING_DELETE", 
+      "sni_containers": [], 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+    "listeners": [
+      {
+        "id": "b2291c35-17db-46ba-8c75-cfcd7663e539"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+    "operating_status": "ONLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8", 
+    "vip_address": "10.2.3.107", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:1e7f2f28-2d0f-5d65-8bd5-7bf90c10b3b3", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "550684bd-3908-5d09-9be0-89fdfca23d76", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-10-2-3-107.openstacklocal.", 
+          "hostname": "host-10-2-3-107", 
+          "ip_address": "10.2.3.107"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.3.107", 
+          "subnet_id": "108c9db3-6b9b-442e-8b93-42ce265d7b59"
+        }
+      ], 
+      "id": "40403ef3-7de2-49b1-a685-948ac30f7370", 
+      "mac_address": "fa:16:3e:ca:30:9b", 
+      "name": "loadbalancer-61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+      "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "security_groups": [
+        "462ac45c-af06-4738-baf9-ce911088b58d"
+      ], 
+      "status": "ACTIVE", 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }, 
+    "vip_port_id": "40403ef3-7de2-49b1-a685-948ac30f7370", 
+    "vip_subnet_id": "108c9db3-6b9b-442e-8b93-42ce265d7b59", 
+    "vxlan_vteps": [
+      "201.0.169.1", 
+      "201.0.166.1", 
+      "201.0.168.1", 
+      "201.0.160.10"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "41016ade-73b2-496b-b0b7-821553dabcae": {
+      "admin_state_up": true, 
+      "id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "mtu": 0, 
+      "name": "testlab-server-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 46, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "8d711da1-9dfd-4ee6-8534-f08b89370b85", 
+        "108c9db3-6b9b-442e-8b93-42ce265d7b59"
+      ], 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "108c9db3-6b9b-442e-8b93-42ce265d7b59": {
+      "allocation_pools": [
+        {
+          "end": "10.2.3.150", 
+          "start": "10.2.3.100"
+        }
+      ], 
+      "cidr": "10.2.3.0/24", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": null, 
+      "host_routes": [], 
+      "id": "108c9db3-6b9b-442e-8b93-42ce265d7b59", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "testlab-server-v4-subnet", 
+      "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "listeners": [], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+    "listeners": [], 
+    "name": "lb1", 
+    "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+    "operating_status": "ONLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_DELETE", 
+    "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8", 
+    "vip_address": "10.2.3.107", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:1e7f2f28-2d0f-5d65-8bd5-7bf90c10b3b3", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "550684bd-3908-5d09-9be0-89fdfca23d76", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-10-2-3-107.openstacklocal.", 
+          "hostname": "host-10-2-3-107", 
+          "ip_address": "10.2.3.107"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.3.107", 
+          "subnet_id": "108c9db3-6b9b-442e-8b93-42ce265d7b59"
+        }
+      ], 
+      "id": "40403ef3-7de2-49b1-a685-948ac30f7370", 
+      "mac_address": "fa:16:3e:ca:30:9b", 
+      "name": "loadbalancer-61d3691c-650e-4c6c-9cac-cc6c3f37f729", 
+      "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "security_groups": [
+        "462ac45c-af06-4738-baf9-ce911088b58d"
+      ], 
+      "status": "ACTIVE", 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }, 
+    "vip_port_id": "40403ef3-7de2-49b1-a685-948ac30f7370", 
+    "vip_subnet_id": "108c9db3-6b9b-442e-8b93-42ce265d7b59", 
+    "vxlan_vteps": [
+      "201.0.169.1", 
+      "201.0.166.1", 
+      "201.0.168.1", 
+      "201.0.160.10"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "41016ade-73b2-496b-b0b7-821553dabcae": {
+      "admin_state_up": true, 
+      "id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "mtu": 0, 
+      "name": "testlab-server-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 46, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "108c9db3-6b9b-442e-8b93-42ce265d7b59", 
+        "8d711da1-9dfd-4ee6-8534-f08b89370b85"
+      ], 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "108c9db3-6b9b-442e-8b93-42ce265d7b59": {
+      "allocation_pools": [
+        {
+          "end": "10.2.3.150", 
+          "start": "10.2.3.100"
+        }
+      ], 
+      "cidr": "10.2.3.0/24", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": null, 
+      "host_routes": [], 
+      "id": "108c9db3-6b9b-442e-8b93-42ce265d7b59", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "testlab-server-v4-subnet", 
+      "network_id": "41016ade-73b2-496b-b0b7-821553dabcae", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "850bb4bb39634d46b54ca9a4c258b3a8"
+    }
+  }
+}]


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
Fixes #565 

#### What's this change do?
Changes agent to NOT delete virtual server for a PENDING_UPDATE of a listener. Instead, the update command is called directly.

#### Where should the reviewer start?
lbaas_builder.py

#### Any background context?
This code to delete was originally there because virtual servers were named with the listener name, and therefore the name could not be updated without deleting the virtual server. Now that all objects are name with the UUID, and not the OpenStack name attribute, objects can be directly updated, including name changes.
