### PR TITLE
Update lbaas_builder.py

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -257,8 +257,6 @@ class LBaaSBuilder(object):
                     member['provisioning_status'] = plugin_const.ERROR
                     raise f5_ex.MemberCreationException(err.message)
 
-                member['provisioning_status'] = plugin_const.ACTIVE
-
             self._update_subnet_hints(member["provisioning_status"],
                                       member["subnet_id"],
                                       member["network_id"],


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
#499 Neutron Pool member's status attribute not reflecting BIG-IP Pool member state

#### What's this change do?
Removes setting member_status to active.

#### Where should the reviewer start?
lbaas_builder.py

#### Any background context?
This line was incorrectly added when I changed from liberty to master base branch in my original PR, and relied on a different implementation of update_,member_status in icontrol_driver. 
