### PR TITLE
Change test requirements to install from stable/liberty liberty-eol

### DIFF
--- a/requirements.functest.txt
+++ b/requirements.functest.txt
@@ -1,8 +1,8 @@
 -e .
 # OpenStack dependancies
-git+https://github.com/openstack/neutron@stable/liberty
+git+https://github.com/openstack/neutron@liberty-eol
 git+https://github.com/openstack/oslo.log.git@liberty-eol
-git+https://github.com/openstack/neutron-lbaas.git@stable/liberty
+git+https://github.com/openstack/neutron-lbaas.git@liberty-eol
 
 # F5 LBaaS dependancies
 git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@liberty

--- a/requirements.unittest.txt
+++ b/requirements.unittest.txt
@@ -2,10 +2,10 @@
 -e .
 
 # app
-git+https://github.com/openstack/neutron@stable/liberty
+git+https://github.com/openstack/neutron@liberty-eol
 git+https://github.com/openstack/oslo.log.git@liberty-eol
 git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@liberty
-git+https://github.com/openstack/neutron-lbaas.git@stable/liberty
+git+https://github.com/openstack/neutron-lbaas.git@liberty-eol
 
 mock==2.0.0
 pytest==3.0.3


### PR DESCRIPTION
Issues:
Fixes #590

Problem:
Neutron project has EOL'd liberty. We install neutron for
unittests so the repo tag needs to change from stable/liberty
to liberty-eol.

Analysis:
Change stable/liberty to liberty-eol

Tests:
Unittests
Functests

@<reviewer_id>
#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?
