### PR TITLE
force describe to pick nonannotated left tags

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -67,7 +67,7 @@ PROJDIR := $(shell dirname $(realpath $(MAKEFILE_DIR)))
 PROJNAME := $(shell basename $(PROJDIR))
 
 # - <nearest reachable tag>-<num commits since>-g<abbreviated commit id>
-TAGINFO := $(shell git describe --long)
+TAGINFO := $(shell git describe --long --tags --first-parent)
 
 # git branch
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
Issues:
Fixes #600

Problem: Our merge forward policy means that git describe
must traverse merge commits when looking for tags to
annotate GUMBALLS SESSIONS.

Analysis: By adding the '--tags --first-parent' flags to
git describe we enforce correct behavior across merges.

Tests:  The "make functest" command was run against the liberty
branch and the SESSIONS were verified to have the correct tag.
In order to merge forward this test must be rerun against mitaka.
For liberty the correct description prior to this commit is:
8.2.0-16-g227589b
