### PR TITLE
Derive projname from remote

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -67,7 +67,7 @@ PROJDIR := $(shell dirname $(realpath $(MAKEFILE_DIR)))
 PROJNAME := $(shell basename $(PROJDIR))
 
 # - <nearest reachable tag>-<num commits since>-g<abbreviated commit id>
-TAGINFO := $(shell git describe --long)
+TAGINFO := $(shell git describe --long --tags --first-parent)
 
 # git branch
 BRANCH := $(shell git rev-parse --abbrev-ref HEAD)

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -63,9 +63,6 @@ SCRIPT_DIR := $(MAKEFILE_DIR)/scripts
 # /ABS/PATH/PROJECT
 PROJDIR := $(shell dirname $(realpath $(MAKEFILE_DIR)))
 
-# PROJECT
-PROJNAME := $(shell basename $(PROJDIR))
-
 # - <nearest reachable tag>-<num commits since>-g<abbreviated commit id>
 TAGINFO := $(shell git describe --long --tags --first-parent)
 
@@ -76,7 +73,6 @@ BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 # for test reuslts.
 RESULTS_DIR := $(MAKEFILE_DIR)/test_results
 
-
 #### INITIALIZATION SECTION
 #    Since all tests will run on the same buildbot worker, and we do not (yet)
 #    require different packages for different suites, all packages are
@@ -86,7 +82,7 @@ RESULTS_DIR := $(MAKEFILE_DIR)/test_results
 functest: 
 	-@echo executing $@
 	sudo -E -H $(SCRIPT_DIR)/install_test_infra.sh &&
-	export GP_SUFFIX=$(PROJNAME)_$(BRANCH)-unit &&
+	export GP_SUFFIX=f5-openstack-agent_$(BRANCH)-unit &&
 	export GUMBALLS_PROJECT=$(RESULTS_DIR)/$${GP_SUFFIX} &&
 	tox -e unit --sitepackages -- \
 		--exclude incomplete no_regression \
@@ -112,7 +108,7 @@ $(DEPLOYS):
 	export CLOUD=`python -c 'print("$@".split("-")[1])'` &&
 	export TIMESTAMP=`date +"%Y%m%d-%H%M%S"` &&
 	export GUMBALLS_SESSION=$(TAGINFO)_$${TIMESTAMP} &&
-	export GP_SUFFIX=$(PROJNAME)_$(BRANCH)-$@ &&
+	export GP_SUFFIX=f5-openstack-agent_$(BRANCH)-$@ &&
 	$(MAKE) -C . run_$${CLOUD}_tests
 
 # Currently does nothing in f5-openstack-agent


### PR DESCRIPTION
@mattgreene 
 
base the $(PROJNAME) variable on remote origin.

Issues:
Fixes #603

Problem: The systest Makefile $(PROJECT) variable assumed
    that FOO/systest/Makefile mapped "FOO" to the name of the
    project being tested.   Buildbot runs a `git clone SPAM .`
    command in a directory named "build".  This means that the
    "FOO/systest/Makefile" pattern _actually_ maps to
    "build/systest/Makefile".  Clearly the names of "PROJECT"
    variables cannot be derived from this filesystem path.

 Analysis:  The solution is to use the remote that the
    project was cloned from to derive PROJNAME.

Tests:  This was tested manually by verifying that "PROJNAME",
    when derived from `git remote show -n origin` does in fact map
    to 'f5-openstack-agent' in the case of this repository.