### PR TITLE
Opflex member can get stuck in PENDING if operations time-out

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1409,9 +1409,16 @@ class iControlDriver(LBaaSBaseDriver):
                 provisioning_status == plugin_const.PENDING_UPDATE):
             if timed_out:
                 operating_status = (lb_const.OFFLINE)
+                if provisioning_status == plugin_const.PENDING_CREATE:
+                    loadbalancer['provisioning_status'] = \
+                        plugin_const.ERROR
+                else:
+                    loadbalancer['provisioning_status'] = \
+                        plugin_const.ACTIVE
             else:
                 operating_status = (lb_const.ONLINE)
-            loadbalancer['provisioning_status'] = plugin_const.ACTIVE
+                loadbalancer['provisioning_status'] = \
+                    plugin_const.ACTIVE
 
             self.plugin_rpc.update_loadbalancer_status(
                 loadbalancer['id'],

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
@@ -91,8 +91,8 @@ class LBaaSv2PluginRPC(object):
     @log_helpers.log_method_call
     def update_loadbalancer_status(self,
                                    lb_id,
-                                   provisioning_status=plugin_const.ERROR,
-                                   operating_status=lb_const.OFFLINE):
+                                   provisioning_status=None,
+                                   operating_status=None):
         """Update the database with loadbalancer status."""
         return self._cast(
             self.context,
@@ -179,8 +179,8 @@ class LBaaSv2PluginRPC(object):
     @log_helpers.log_method_call
     def update_member_status(self,
                              member_id,
-                             provisioning_status=plugin_const.ERROR,
-                             operating_status=lb_const.OFFLINE):
+                             provisioning_status=None,
+                             operating_status=None):
         """Update the database with member status."""
         return self._cast(
             self.context,

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer.py
@@ -157,7 +157,8 @@ def test_create_delete_basic_lb(bigip, services, icd_config, icontrol_driver):
 
     # Delete the loadbalancer
     service = service_iter.next()
-    lb_pending = icontrol_driver._common_service_handler(service, delete_partition=True)
+    lb_pending = icontrol_driver._common_service_handler(service, delete_partition=True,
+                                                         delete_event=True)
     assert not lb_pending
     assert not bigip.folder_exists(folder)
 
@@ -262,6 +263,7 @@ def test_create_delete_basic_lb_nodisconnected(bigip, services, icd_config, icon
 
     # Delete the loadbalancer
     service = service_iter.next()
-    lb_pending = icontrol_driver._common_service_handler(service, delete_partition=True)
+    lb_pending = icontrol_driver._common_service_handler(service, delete_partition=True,
+                                                             delete_event=True)
     assert not lb_pending
     assert not bigip.folder_exists(folder)

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer_disconnected.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer_disconnected.py
@@ -120,7 +120,9 @@ def test_featureoff_nosegid_lb(bigip, disconnected_service_no_seg,
 
     # Delete the loadbalancer
     service = service_iter.next()
-    lb_pending = icontrol_driver._common_service_handler(service)
+    lb_pending = icontrol_driver._common_service_handler(
+        service, delete_partition=True, delete_event=True)
+
     assert not lb_pending
 
     # Assert that update loadbalancer status was called once

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer_opflex.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer_opflex.py
@@ -107,9 +107,9 @@ def test_create_delete_basic_lb(bigip, services, icd_config, icontrol_driver):
     assert not bigip.resource_exists(ResourceType.virtual_address,
                                      virtual_addr_name)
 
-    # Create the VLAN
     service = service_iter.next()
-    icontrol_driver._common_service_handler(service, delete_partition=True)
+    icontrol_driver._common_service_handler(service)
+
     lb_reader = LoadbalancerReader(service)
 
     # Assert tunnel created.
@@ -156,7 +156,7 @@ def test_create_delete_basic_lb(bigip, services, icd_config, icontrol_driver):
 
     # Delete the loadbalancer
     service = service_iter.next()
-    icontrol_driver._common_service_handler(service, delete_partition=True)
+    icontrol_driver._common_service_handler(service, delete_partition=True, delete_event=True)
     assert not bigip.folder_exists(folder)
 
 def test_featureoff_create_delete_basic_lb(bigip, services, icd_config, icontrol_driver):
@@ -259,6 +259,7 @@ def test_featureoff_create_delete_basic_lb(bigip, services, icd_config, icontrol
 
     # Delete the loadbalancer
     service = service_iter.next()
-    icontrol_driver._common_service_handler(service, delete_partition=True)
+    icontrol_driver._common_service_handler(service, delete_partition=True,
+                                            delete_event=True)
     assert not bigip.folder_exists(folder)
     


### PR DESCRIPTION
Issues:
Fixes #589

Problem:
If a port member creation fails after a timeout the loadbalancer
gets put in ‘ERROR’ state, but the member is left in ‘PENDING_CREATE’.
The loadbalancer should actually be left alone and the member set to
‘ERROR’ provisioning status.

Analysis:
Fix the agent_manager handling of pending services to update the
status of the service in the Neutron.  Properly handle exceptions
of objects that are deleted when exceptions occur in the network
setup.

Tests:
test/functional/neutronless/loadbalancer/
test/functional/neutronless/disconnected/
test/functional/neutronless/member/

Manual testing consisted of:
Create loadbalancer service with all objects: listener, pool, members
Create member with and without existing port.
Create member on opflex, add vlan child segment manually and verify
that the member is connected.
Create loadbalancer on opflex network, add vlan child segment
manuall and verify that the virtual get's created.
Create loadbalancer on opflex network, don't add segment and check
that the loadbalacner goes to 'ERROR' state and that it can be
deleted.
Create a member on the opflex network, don't add segment and check
that the member goes to 'ERROR' state after timeout period and verify
it can be deleted.
