### PR TITLE
add --debug to testenv operations run by buildbot

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -142,7 +142,7 @@ singlebigip:
 
 setup_singlebigip_tests: 
 	@echo executing $@
-	testenv create --name $${!DEVICEVERSION} \
+	testenv --verbose create --name $${DEVICEVERSION} \
 	               --config $${TESTENV_CONF} \
 	               --params bigip_img:$${!DEVICEVERSION}
 
@@ -169,7 +169,8 @@ run_disconnected_service_tests:
 
 cleanup_singlebigip:
 	@echo executing $@
-	testenv delete --name $${!DEVICEVERSION} --config $${TESTENV_CONF} || \
+	testenv --verbose delete --name $${DEVICEVERSION} \
+	               --config $${TESTENV_CONF} || \
 	$(MAKE) -C . clean
 
 #### 


### PR DESCRIPTION
Issues:
Fixes #609

Problem: testenv logs generated by buildbot are lost
after the run

Analysis: by adding the debug flag we set testenv to
send logs to stdout where they will be caught by the
buildbot reporting tool

Tests: The output of the testenv commands will now show up in
nightly.