### PR TITLE
place unstable tests in the noregression manifest

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -153,8 +153,9 @@ setup_singlebigip_tests:
 run_singlebigip_tests: 
 	@echo executing $@
 	tox -e singlebigip --sitepackage -- \
+	    --ignore test_network.py \
+	    --meta $(MAKEFILE_DIR)/noregression/singlebigip.yaml \
 		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
-		--exclude incomplete no_regression \
 		--autolog-outputdir $${GUMBALLS_PROJECT} \
 		--autolog-session $${GUMBALLS_SESSION} \
 		$(PROJDIR)/test/functional/singlebigip
@@ -165,8 +166,8 @@ run_disconnected_service_tests:
 	export GP_SUFFIX=disconnected_$${GP_SUFFIX} &&
 	export GUMBALLS_PROJECT=$(RESULTS_DIR)/$${GP_SUFFIX} &&
 	tox -e disconnected_service --sitepackage -- \
+	    --meta $(MAKEFILE_DIR)/noregression/disconnected_service.yaml \
 		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
-		--exclude incomplete no_regression \
 		--autolog-outputdir $${GUMBALLS_PROJECT} \
 		--autolog-session $${GUMBALLS_SESSION} \
 		$(PROJDIR)/test/functional/neutronless/disconnected_service

--- a/systest/noregression/disconnected_service.yaml
+++ b/systest/noregression/disconnected_service.yaml
@@ -1,0 +1,10 @@
+{
+    "exclude": ["test_featureoff_nosegid_common_lb_net",
+                "test_featureoff_nosegid_create_listener_common_lb_net",
+                "test_featureoff_withsegid_lb",
+                "test_featureoff_withsegid_listener",
+                "test_nosegid_listener_timeout",
+                "test_nosegid_to_segid",
+                "test_withsegid_lb",
+                "test_withsegid_listener"]
+}

--- a/systest/noregression/singlebigip.yaml
+++ b/systest/noregression/singlebigip.yaml
@@ -1,0 +1,14 @@
+{
+    "exclude": ["test_device_name",
+                "test_auto_sync",
+                "test_get_mgmt_addr_by_device",
+                "test_create_listener",
+                "test_get_composite_score",
+                "test_get_mem_health_score",
+                "test_get_cpu_health_score",
+                "test_get_inbound_throughput",
+                "test_get_outbound_throughput",
+                "test_get_node_count",
+                "test_get_tenant_count",
+                "test_get_route_domain_count"]
+}


### PR DESCRIPTION
Issues:
Fixes #611

Problem: The build infrastructure is not yet stable.  To
stabilize it we need to discover the root causes of the
instability.  It's possible that poorly managed (torn down,
or setup) tests introduce instability into the regression
run.   It's likely that tests that have this effect will
fail.

Analysis: To isolate causes of instability in the regression
infrastructure we are marking unstable tests "no regression"
in manifest files that are external to the test code itself.

Tests: The determination of which tests are unstable and stable
was conducted using the bbot sandbox:
https://bldr-git.int.lineratesystems.com/kevin/bbot-sandbox
