### PR TITLE
Icontrol_driver.py: Prep-network exception: icontrol_driver: unsuppor…

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
@@ -142,10 +142,10 @@ class L2ServiceBuilder(object):
         net_type = network['provider:network_type']
 
         # look for host specific interface mapping
-        if net_key + ':' + hostname in self.interface_mapping:
+        if net_key and net_key + ':' + hostname in self.interface_mapping:
             interface = self.interface_mapping[net_key + ':' + hostname]
             tagged = self.tagging_mapping[net_key + ':' + hostname]
-        elif net_key in self.interface_mapping:
+        elif net_key and net_key in self.interface_mapping:
             interface = self.interface_mapping[net_key]
             tagged = self.tagging_mapping[net_key]
         else:
@@ -228,12 +228,12 @@ class L2ServiceBuilder(object):
 
         # Do we have host specific mappings?
         net_key = network['provider:physical_network']
-        if net_key + ':' + bigip.hostname in \
+        if net_key and net_key + ':' + bigip.hostname in \
                 self.interface_mapping:
             interface = self.interface_mapping[
                 net_key + ':' + bigip.hostname]
         # Do we have a mapping for this network
-        elif net_key in self.interface_mapping:
+        elif net_key and net_key in self.interface_mapping:
             interface = self.interface_mapping[net_key]
 
         vlan_name = self.get_vlan_name(network,
@@ -271,14 +271,14 @@ class L2ServiceBuilder(object):
 
         # Do we have host specific mappings?
         net_key = network['provider:physical_network']
-        if net_key + ':' + bigip.hostname in \
+        if net_key and net_key + ':' + bigip.hostname in \
                 self.interface_mapping:
             interface = self.interface_mapping[
                 net_key + ':' + bigip.hostname]
             tagged = self.tagging_mapping[
                 net_key + ':' + bigip.hostname]
         # Do we have a mapping for this network
-        elif net_key in self.interface_mapping:
+        elif net_key and net_key in self.interface_mapping:
             interface = self.interface_mapping[net_key]
             tagged = self.tagging_mapping[net_key]
 
@@ -463,14 +463,14 @@ class L2ServiceBuilder(object):
             vlanid = 0
             # Do we have host specific mappings?
             net_key = network['provider:physical_network']
-            if net_key + ':' + bigip.hostname in \
+            if net_key and net_key + ':' + bigip.hostname in \
                     self.interface_mapping:
                 interface = self.interface_mapping[
                     net_key + ':' + bigip.hostname]
                 tagged = self.tagging_mapping[
                     net_key + ':' + bigip.hostname]
             # Do we have a mapping for this network
-            elif net_key in self.interface_mapping:
+            elif net_key and net_key in self.interface_mapping:
                 interface = self.interface_mapping[net_key]
                 tagged = self.tagging_mapping[net_key]
             if tagged:


### PR DESCRIPTION
@richbrowne 

…ted operand type(s) for +: 'NoneType' and 'str'

Issues:
Fixes #639

Problem:
Attempts to create loadbalancer fail. Loadbalancer object is in FAILED state and F5 agent emits a traceback.

Analysis:
The driver can pass through provider:physical_network = None.  The agent attempts to construct a string using this value, which raises a TypeEror.  The driver needs to populate this field in the service definition (https://github.com/F5Networks/f5-openstack-lbaasv2-driver/issues/485), along with network_type and segmentation_id.  But harden the agent against receiving physical_network = None.

Tests:
*Note* This bug was reproduced on a manual VLAN deployment.  Work is in process to automate a VLAN deployment and add to nightly regression.
Create loadbalancer and listener, confirm objects reach ONLINE state and VLAN interface is created on BIG-IP.