### PR TITLE
update_loadbalancer_status getting called twice

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1320,8 +1320,6 @@ class iControlDriver(LBaaSBaseDriver):
         if 'l7policies' in service:
             self._update_l7policy_status(service['l7policies'])
 
-        self._update_loadbalancer_status(service)
-
         self._update_loadbalancer_status(service, timed_out)
 
     def _update_member_status(self, members, timed_out):


### PR DESCRIPTION
Issues:
Fixes #643

Problem:
The update_loadbalancer_status call gets called twice after
deploying a service. This results in a database deadlock
occurring on the driver side, which was filed in the driver
as issue 472. The driver side fix is to handle database deadlocks
by catching the exception and retrying the operation.

Analysis:
Need to remove the extra call, that was included as part of a
bad merge.

Tests:
L7 tempest tests.

