### PR TITLE
Default pool ID ignored in listener update

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -128,9 +128,6 @@ class LBaaSBuilder(object):
                 if pool:
                     svc['pool'] = pool
 
-            svc['pool'] = self.get_pool_by_id(
-                service, listener.get('default_pool_id', ''))
-
             if listener['provisioning_status'] == plugin_const.PENDING_UPDATE:
                 try:
                     self.listener_builder.update_listener(svc, bigips)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -122,6 +122,15 @@ class LBaaSBuilder(object):
                    "listener": listener,
                    "networks": networks}
 
+            default_pool_id = listener.get('default_pool_id', '')
+            if default_pool_id:
+                pool = self.get_pool_by_id(service, default_pool_id)
+                if pool:
+                    svc['pool'] = pool
+
+            svc['pool'] = self.get_pool_by_id(
+                service, listener.get('default_pool_id', ''))
+
             if listener['provisioning_status'] == plugin_const.PENDING_UPDATE:
                 try:
                     self.listener_builder.update_listener(svc, bigips)
@@ -361,7 +370,7 @@ class LBaaSBuilder(object):
 
     @staticmethod
     def get_pool_by_id(service, pool_id):
-        if "pools" in service:
+        if pool_id and "pools" in service:
             pools = service["pools"]
             for pool in pools:
                 if pool["id"] == pool_id:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -97,7 +97,8 @@ class ServiceModelAdapter(object):
             listener["session_persistence"] = \
                 service["pool"]["session_persistence"]
 
-        vip = self._map_virtual(loadbalancer, listener)
+        vip = self._map_virtual(
+            loadbalancer, listener, service.get('pool', None))
         self._add_bigip_items(listener, vip)
         return vip
 
@@ -320,8 +321,12 @@ class ServiceModelAdapter(object):
         else:
             return 'round-robin'
 
-    def _map_virtual(self, loadbalancer, listener):
+    def _map_virtual(self, loadbalancer, listener, pool=None):
         vip = self._init_virtual_name(loadbalancer, listener)
+
+        if pool:
+            p = self.init_pool_name(loadbalancer, pool)
+            vip["pool"] = p["name"]
 
         vip["description"] = self.get_resource_description(listener)
 


### PR DESCRIPTION
Issues:
Fixes #645

Problem: default_pool_id  is not processed by agent.

Analysis:

Tests:

@<reviewer_id>
#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?
