### PR TITLE
F5 sdk dependency version should be pinned in agent setup.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -72,6 +72,11 @@ version = VERSION
 # The full version, including alpha/beta/rc tags.
 release = VERSION
 
+# F5 SDK release version should be set here
+f5_sdk_version = '2.3.1'
+# F5 icontrol REST version should be set here
+f5_icontrol_version = '1.3.0'
+
 # OpenStack release
 
 openstack_release = "Liberty"
@@ -326,6 +331,16 @@ rst_epilog = '''
 .. |f5_agent_rpm_url| replace:: https://github.com/F5Networks/f5-openstack-agent/releases/download/v%(version)s/f5-openstack-agent-%(version)s-1.el7.noarch.rpm
 .. |f5_agent_deb_package| replace:: python-f5-openstack-agent_%(version)s-1_1404_all.deb
 .. |f5_agent_rpm_package| replace:: f5-openstack-agent-%(version)s-1.el7.noarch.rpm
+.. |f5_sdk_deb_url| replace:: https://github.com/F5Networks/f5-common-python/releases/download/v%(f5_sdk_version)s/python-f5-sdk_%(f5_sdk_version)s-1_1404_all.deb
+.. |f5_sdk_rpm_url| replace:: https://github.com/F5Networks/f5-common-python/releases/download/v%(f5_sdk_version)s/f5-sdk-%(f5_sdk_version)s-1.el7.noarch.rpm
+.. |f5_sdk_rpm_package| replace:: f5-sdk-%(f5_sdk_version)s-1.el7.noarch.rpm
+.. |f5_sdk_deb_package| replace:: python-f5-sdk_%(f5_sdk_version)s-1_1404_all.deb
+.. |f5_icontrol_deb_url| replace:: https://github.com/F5Networks/f5-icontrol-rest-python/releases/download/v%(f5_icontrol_version)s/python-f5-icontrol-rest_%(f5_icontrol_version)s-1_1404_all.deb
+.. |f5_icontrol_rpm_url| replace:: https://github.com/F5Networks/f5-icontrol-rest-python/releases/download/v%(f5_icontrol_version)s/f5-icontrol-rest-%(f5_icontrol_version)s-1.el7.noarch.rpm
+.. |f5_icontrol_rpm_package| replace:: f5-icontrol-rest-%(f5_icontrol_version)s-1.el7.noarch.rpm
+.. |f5_icontrol_deb_package| replace:: python-f5-icontrol-rest_%(f5_icontrol_version)s-1_1404_all.deb
 ''' % {
-  'version': version
+  'version': version,
+  'f5_sdk_version': f5_sdk_version,
+  'f5_icontrol_version': f5_icontrol_version
 }

--- a/docs/topic_install-f5-agent.rst
+++ b/docs/topic_install-f5-agent.rst
@@ -27,12 +27,12 @@ The ``f5-openstack-agent`` package can be installed using ``dpkg`` tools.
 
 1. Download and install the dependencies:
 
-.. code-block:: bash
+.. parsed-literal::
 
-    $ curl -L -O https://github.com/F5Networks/f5-common-python/releases/download/v2.2.2/python-f5-sdk_2.2.2-1_1404_all.deb
-    $ curl -L -O https://github.com/F5Networks/f5-icontrol-rest-python/releases/download/v1.3.0/python-f5-icontrol-rest_1.3.0-1_1404_all.deb
-    $ sudo dpkg –i python-f5-icontrol-rest_1.3.0-1_1404_all.deb
-    $ sudo dpkg –i python-f5-sdk_2.2.2-1_1404_all.deb
+    $ curl -L -O |f5_sdk_deb_url|
+    $ curl -L -O |f5_icontrol_deb_url|
+    $ sudo dpkg –i |f5_icontrol_deb_package|
+    $ sudo dpkg –i |f5_sdk_deb_package|
 
 2. Download and install the f5-openstack-agent:
 
@@ -49,11 +49,11 @@ The ``f5-openstack-agent`` package can be installed using ``rpm`` tools.
 
 1. Download and install the dependencies:
 
-.. code-block:: bash
+.. parsed-literal::
 
-    $ curl -L -O https://github.com/F5Networks/f5-common-python/releases/download/v2.2.2/f5-sdk-2.2.2-1.el7.noarch.rpm
-    $ curl -L -O https://github.com/F5Networks/f5-icontrol-rest-python/releases/download/v1.3.0/f5-icontrol-rest-1.3.0-1.el7.noarch.rpm
-    $ sudo rpm –ivh f5-icontrol-rest-1.3.0-1.el7.noarch.rpm f5-sdk-2.2.2-1.el7.noarch.rpm
+    $ curl -L -O |f5_sdk_rpm_url|
+    $ curl -L -O |f5_icontrol_rpm_url|
+    $ sudo rpm -ivh |f5_icontrol_rpm_package| |f5_sdk_rpm_package|
 
 
 2. Download and install the f5-openstack-agent:

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,6 @@ setuptools.setup(
             'f5-oslbaasv2-agent = f5_openstack_agent.lbaasv2.drivers.bigip.agent:main'
         ]
     },
-    install_requires=['f5-sdk>=2.2.2, <3']
+    install_requires=['f5-sdk==2.3.1']
 )
 


### PR DESCRIPTION
@mattgreene 

#### What issues does this address?
Fixes #657

#### What's this change do?
The f5-sdk version is now restricted or pinned in the setup.py to 2.3.1.
We'll move this as we see fit going forward when we need appropriate
releases of the sdk. This also coincides with a doc change to ensure the
proper released versions of the sdk and icontrol rest are referenced.

#### Where should the reviewer start?
Start at the setup.py change. Then refer to the doc changes.

#### Any background context?
We should restrict the version for this package to be able to better
test, control, and document the package that users are installing.
Another good thing about pinning against a specific sdk version is that
we are not subject to any failings that occur in the sdk project.