### PR TITLE
Add symlinks to support disconnected service tests.

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -44,7 +44,7 @@ DEPLOYS := $(foreach v, $(DEVICES), $(v)-overcloud $(v)-undercloud)
         singlebigip \
         setup_singlebigip_tests \
         run_singlebigip_tests \
-        cleanup_singelbigip \
+        cleanup_singlebigip \
         run_disconnected_service_tests \
         clean
 
@@ -139,8 +139,8 @@ singlebigip:
 	export GP_SUFFIX=$@_$${GP_SUFFIX} &&
 	export GUMBALLS_PROJECT=$(RESULTS_DIR)/$${GP_SUFFIX} &&
 	$(MAKE) -C . setup_singlebigip_tests &&
-	$(MAKE) -C . run_singlebigip_tests || \
-	$(MAKE) -C . run_disconnected_service_tests || \
+	$(MAKE) -C . run_singlebigip_tests ;\
+	$(MAKE) -C . run_disconnected_service_tests ;\
 	$(MAKE) -C . cleanup_singlebigip
 
 setup_singlebigip_tests: 
@@ -161,7 +161,6 @@ run_singlebigip_tests:
 		--autolog-session $${GUMBALLS_SESSION} \
 	    $${RUNTARGETS}
 
-# disconnected_singlebigip_f5-openstack-agent_liberty-12_1_1-overcloud
 run_disconnected_service_tests:
 	@echo executing $@
 	export GP_SUFFIX=disconnected_$${GP_SUFFIX} &&
@@ -179,7 +178,7 @@ cleanup_singlebigip:
 	@echo executing $@
 	echo running testenv delete with stack name $${OSTACK_NAME} &&
 	testenv --debug delete --name $${OSTACK_NAME} \
-	               --config $${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${OSTACK_NAME}.log || \
+	               --config $${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${OSTACK_NAME}.log ;\
 	$(MAKE) -C . clean
 
 #### 

--- a/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-11_5_4-overcloud/conftest.py
+++ b/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-11_5_4-overcloud/conftest.py
@@ -1,0 +1,1 @@
+../../../test/functional/neutronless/disconnected_service/conftest.py

--- a/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-11_5_4-overcloud/disconnected_service
+++ b/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-11_5_4-overcloud/disconnected_service
@@ -1,0 +1,1 @@
+../../../test/functional/neutronless/disconnected_service/

--- a/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-11_5_4-overcloud/noregress.yaml
+++ b/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-11_5_4-overcloud/noregress.yaml
@@ -1,3 +1,9 @@
 {
-    "exclude": []
+    "exclude": ["test_featureoff_nosegid_create_listener_common_lb_net",
+                "test_featureoff_nosegid_common_lb_net",
+                "test_withsegid_listener",
+                "test_featureoff_withsegid_listener",
+                "test_withsegid_lb",
+                "test_featureoff_withsegid_lb",
+                "test_featureoff_nosegid_listener"]
 }

--- a/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-11_6_0-overcloud/conftest.py
+++ b/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-11_6_0-overcloud/conftest.py
@@ -1,0 +1,1 @@
+../../../test/functional/neutronless/disconnected_service/conftest.py

--- a/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-11_6_0-overcloud/disconnected_service
+++ b/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-11_6_0-overcloud/disconnected_service
@@ -1,0 +1,1 @@
+../../../test/functional/neutronless/disconnected_service/

--- a/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-11_6_0-overcloud/noregress.yaml
+++ b/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-11_6_0-overcloud/noregress.yaml
@@ -1,3 +1,10 @@
 {
-    "exclude": []
+    "exclude": ["test_featureoff_nosegid_create_listener_common_lb_net",
+                "test_featureoff_nosegid_common_lb_net",
+                "test_withsegid_listener",
+                "test_withsegid_lb",
+                "test_featureoff_withsegid_lb",
+                "test_featureoff_withsegid_listener",
+                "test_featureoff_nosegid_lb",
+                "test_featureoff_nosegid_listener"]
 }

--- a/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-11_6_1-overcloud/conftest.py
+++ b/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-11_6_1-overcloud/conftest.py
@@ -1,0 +1,1 @@
+../../../test/functional/neutronless/disconnected_service/conftest.py

--- a/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-11_6_1-overcloud/disconnected_service
+++ b/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-11_6_1-overcloud/disconnected_service
@@ -1,0 +1,1 @@
+../../../test/functional/neutronless/disconnected_service/

--- a/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-11_6_1-overcloud/noregress.yaml
+++ b/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-11_6_1-overcloud/noregress.yaml
@@ -1,3 +1,9 @@
 {
-    "exclude": []
+    "exclude": ["test_featureoff_nosegid_create_listener_common_lb_net",
+                "test_featureoff_nosegid_common_lb_net",
+                "test_featureoff_grm_listener",
+                "test_featureoff_withsegid_listener",
+                "test_withsegid_listener",
+                "test_withsegid_lb",
+                "test_featureoff_withsegid_lb"]
 }

--- a/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-12_1_1-overcloud/conftest.py
+++ b/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-12_1_1-overcloud/conftest.py
@@ -1,0 +1,1 @@
+../../../test/functional/neutronless/disconnected_service/conftest.py

--- a/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-12_1_1-overcloud/disconnected_service
+++ b/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-12_1_1-overcloud/disconnected_service
@@ -1,0 +1,1 @@
+../../../test/functional/neutronless/disconnected_service/

--- a/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-12_1_1-overcloud/noregress.yaml
+++ b/systest/projects/disconnected_singlebigip_f5-openstack-agent_liberty-12_1_1-overcloud/noregress.yaml
@@ -1,3 +1,9 @@
 {
-    "exclude": []
+    "exclude": ["test_featureoff_withsegid_lb",
+                "test_withsegid_lb",
+                "test_featureoff_withsegid_listener",
+                "test_withsegid_listener",
+                "test_featureoff_grm_listener",
+                "test_featureoff_nosegid_common_lb_net",
+                "test_featureoff_nosegid_create_listener_common_lb_net"]
 }

--- a/systest/projects/singlebigip_f5-openstack-agent_liberty-11_6_0-overcloud/noregress.yaml
+++ b/systest/projects/singlebigip_f5-openstack-agent_liberty-11_6_0-overcloud/noregress.yaml
@@ -8,5 +8,7 @@
                 "test_get_node_count",
                 "test_get_route_domain_count",
                 "test_get_inbound_throughput",
-                "test_get_outbound_throughput"]
+                "test_get_outbound_throughput",
+                "test_get_tenant_count",
+                "test_get_tunnel_count"]
 }

--- a/systest/projects/singlebigip_f5-openstack-agent_liberty-11_6_1-overcloud/noregress.yaml
+++ b/systest/projects/singlebigip_f5-openstack-agent_liberty-11_6_1-overcloud/noregress.yaml
@@ -8,5 +8,7 @@
                 "test_get_inbound_throughput",
                 "test_get_outbound_throughput",
                 "test_get_node_count",
-                "test_get_route_domain_count"]
+                "test_get_route_domain_count",
+                "test_get_tenant_count",
+                "test_get_tunnel_count"]
 }

--- a/systest/projects/singlebigip_f5-openstack-agent_liberty-12_1_1-overcloud/noregress.yaml
+++ b/systest/projects/singlebigip_f5-openstack-agent_liberty-12_1_1-overcloud/noregress.yaml
@@ -9,5 +9,6 @@
                 "test_get_outbound_throughput",
                 "test_get_node_count",
                 "test_get_tenant_count",
-                "test_get_route_domain_count"]
+                "test_get_route_domain_count",
+                "test_get_tunnel_count"]
 }


### PR DESCRIPTION
@mattgreene

Hi Matt, this PR debugs/implements test exclusion on the agent liberty branch.   The intent is to establish a baseline set of tests that consistently pass.  Once that baseline exists "noisier" tests can be inspected/fixed and added to the set of running tests.   Is this still our plan for the agent?

Issues:
Fixes #647

Problem: disconnected_service tests were not sym-linked from the projects
subdirectories and, as a result were not run in the nightly regression.

Analysis: Adding the symlinks cause the tests to run.

Tests: This fix was tested by running in a local "buildbot sandbox".

#### What's this change do?

   * Makefile:
        L47   --   fix typo
        L142 --   make 2nd target run, even if first succeeds
        L164 --   remove dev note
        L181 --    make "clean" target execute even if testenv delete succeeds
   * conftest.py symlinks:
        make py.test find the appropriate fixtures
   * noregress.yaml s:
        exclude more tests
