### PR TITLE
Ratio load balancing method not set for pools with weighted members

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -143,6 +143,7 @@ class LBaaSBuilder(object):
             if pool['provisioning_status'] != plugin_const.PENDING_DELETE:
                 svc = {"loadbalancer": loadbalancer,
                        "pool": pool}
+                svc['members'] = self._get_pool_members(service, pool['id'])
 
                 # get associated listener for pool
                 self.add_listener_pool(service, svc)
@@ -175,6 +176,15 @@ class LBaaSBuilder(object):
                     pool['provisioning_status'] = plugin_const.ERROR
                     loadbalancer['provisioning_status'] = plugin_const.ERROR
                     raise f5_ex.PoolCreationException(err.message)
+
+    def _get_pool_members(self, service, pool_id):
+        '''Return a list of members associated with given pool.'''
+
+        members = []
+        for member in service['members']:
+            if member['pool_id'] == pool_id:
+                members.append(member)
+        return members
 
     def _update_listener_pool(self, service, listener_id, pool_name, bigips):
         listener = self.get_listener_by_id(service, listener_id)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -44,12 +44,13 @@ class ServiceModelAdapter(object):
 
     def get_pool(self, service):
         pool = service["pool"]
+        members = service.get('members', [])
         loadbalancer = service["loadbalancer"]
         healthmonitor = None
         if "healthmonitor" in service:
             healthmonitor = service["healthmonitor"]
 
-        return self._map_pool(loadbalancer, pool, healthmonitor)
+        return self._map_pool(loadbalancer, pool, healthmonitor, members)
 
     def snat_mode(self):
         return self.conf.f5_snat_mode
@@ -277,18 +278,19 @@ class ServiceModelAdapter(object):
             monitor_type = lbaas_healthmonitor["type"]
         return monitor_type
 
-    def _map_pool(self, loadbalancer, lbaas_pool, lbaas_hm):
+    def _map_pool(self, loadbalancer, lbaas_pool, lbaas_hm, lbaas_members):
         pool = self.init_pool_name(loadbalancer, lbaas_pool)
 
         pool["description"] = self.get_resource_description(pool)
 
         if "lb_algorithm" in lbaas_pool:
-            pool["loadBalancingMode"] = self._get_lb_method(
-                lbaas_pool["lb_algorithm"])
+            lbaas_lb_method = lbaas_pool['lb_algorithm'].upper()
+            pool['loadBalancingMode'] = \
+                self._set_lb_method(lbaas_lb_method, lbaas_members)
 
             # If source_ip lb method, add SOURCE_IP persistence to ensure
             # source IP loadbalancing. See issue #344 for details.
-            if lbaas_pool["lb_algorithm"].upper() == 'SOURCE_IP':
+            if lbaas_pool['lb_algorithm'].upper() == 'SOURCE_IP':
                 persist = lbaas_pool.get('session_persistence', None)
                 if not persist:
                     lbaas_pool['session_persistence'] = {'type': 'SOURCE_IP'}
@@ -298,6 +300,26 @@ class ServiceModelAdapter(object):
             pool["monitor"] = hm["name"]
 
         return pool
+
+    def _set_lb_method(self, lbaas_lb_method, lbaas_members):
+        '''Set pool lb method depending on member attributes.'''
+
+        lb_method = self._get_lb_method(lbaas_lb_method)
+
+        if lbaas_lb_method == 'SOURCE_IP':
+            return lb_method
+
+        member_has_weight = False
+        for member in lbaas_members:
+            if 'weight' in member and member['weight'] > 1 and \
+                    member['provisioning_status'] != 'PENDING_DELETE':
+                member_has_weight = True
+                break
+        if member_has_weight:
+            if lbaas_lb_method == 'LEAST_CONNECTIONS':
+                return self._get_lb_method('RATIO_LEAST_CONNECTIONS')
+            return self._get_lb_method('RATIO')
+        return lb_method
 
     def _get_lb_method(self, method):
         lb_method = method.upper()

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/conftest.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/conftest.py
@@ -1,0 +1,106 @@
+# coding=utf-8
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import pytest
+
+
+@pytest.fixture
+def pool_member_service():
+    return {
+        u'loadbalancer': {
+            u'admin_state_up': True,
+            u'description': u'',
+            u'gre_vteps': [u'201.0.162.1', u'201.0.160.1', u'201.0.165.1'],
+            u'id': u'd5a0396e-e862-4cbf-8eb9-25c7fbc4d593',
+            u'listeners': [{u'id': u'e3af03f4-d3df-4c9b-b3dd-8002f133d5bf'}],
+            u'name': u'',
+            u'network_id': u'cdf1eb6d-9b17-424a-a054-778f3d3a5490',
+            u'operating_status': u'ONLINE',
+            u'pools': [{u'id': u'2dbca6cd-30d8-4013-9c9a-df0850fabf52'}],
+            u'provider': u'f5networks',
+            u'provisioning_status': u'ACTIVE',
+            u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd',
+            u'vip_address': u'172.16.101.3',
+            u'vip_port': {
+                u'admin_state_up': True,
+                u'allowed_address_pairs': [],
+                u'binding:host_id': u'host-164.int.lineratesystems.com:16ea1e',
+                u'binding:profile': {},
+                u'binding:vif_details': {},
+                u'binding:vif_type': u'binding_failed',
+                u'binding:vnic_type': u'normal',
+                u'created_at': u'2016-10-24T21:17:30',
+                u'description': None,
+                u'device_id': u'0bd0b8ff-1c51-5061-b0c4',
+                u'device_owner': u'network:f5lbaasv2',
+                u'dns_name': None,
+                u'extra_dhcp_opts': [],
+                u'fixed_ips': [
+                    {u'ip_address': u'172.16.101.3',
+                     u'subnet_id': u'81f42a8a-fc98-4281-8de4'}],
+                u'id': u'38a13e5c-6863-4537-80a3',
+                u'mac_address': u'fa:16:3e:94:65:0c',
+                u'name': u'loadbalancer-d5a0396e-e862',
+                u'network_id': u'cdf1eb6d-9b17-424a',
+                u'security_groups': [u'df88afdb-2bc6-4621'],
+                u'status': u'DOWN',
+                u'tenant_id': u'd9ed216f67f04a84bf8fd',
+                u'updated_at': u'2016-10-24T21:17:31'},
+            u'vip_port_id': u'38a13e5c-6863-4537-80a3-c788d5f0c9ce',
+            u'vip_subnet_id': u'81f42a8a-fc98-4281-8de4-2b946e931457',
+            u'vxlan_vteps': []},
+        u'members': [
+            {
+                u'address': u'10.2.2.3',
+                u'admin_state_up': True,
+                u'id': u'1e7bfa17-a38f-4728-a3a7-aad85da69712',
+                u'name': u'',
+                u'network_id': u'cdf1eb6d-9b17-424a-a054-778f3d3a5490',
+                u'operating_status': u'ONLINE',
+                u'pool_id': u'2dbca6cd-30d8-4013-9c9a-df0850fabf52',
+                u'protocol_port': 8080,
+                u'provisioning_status': u'ACTIVE',
+                u'subnet_id': u'81f42a8a-fc98-4281-8de4-2b946e931457',
+                u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd',
+                u'weight': 1},
+            {
+                u'address': u'10.2.2.7',
+                u'admin_state_up': True,
+                u'id': u'1e7bfa17-a38f-4728-a3a7-aad85da69712',
+                u'name': u'',
+                u'network_id': u'cdf1eb6d-9b17-424a-a054-778f3d3a5490',
+                u'operating_status': u'ONLINE',
+                u'pool_id': u'2dbca6cd-30d8-4013-9c9a-df0850fabf52',
+                u'protocol_port': 8080,
+                u'provisioning_status': u'ACTIVE',
+                u'subnet_id': u'81f42a8a-fc98-4281-8de4-2b946e931457',
+                u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd',
+                u'weight': 10}],
+        u'pool': {
+            u'admin_state_up': True,
+            u'description': u'',
+            u'healthmonitor_id': u'70fed03a-efc4-460a-8a21',
+            u'id': u'2dbca6cd-30d8-4013-9c9a-df0850fabf52',
+            u'l7_policies': [],
+            u'lb_algorithm': u'LEAST_CONNECTIONS',
+            u'loadbalancer_id': u'd5a0396e-e862-4cbf-8eb9-25c7fbc4d59',
+            u'name': u'',
+            u'operating_status': u'ONLINE',
+            u'protocol': u'HTTP',
+            u'provisioning_status': u'ACTIVE',
+            u'session_persistence': None,
+            u'sessionpersistence': None,
+            u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd'}
+        }

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_lbaas_builder.py
@@ -18,6 +18,7 @@ from f5_openstack_agent.lbaasv2.drivers.bigip.lbaas_builder import \
     LBaaSBuilder
 
 
+import copy
 import mock
 import pytest
 
@@ -134,3 +135,17 @@ class TestLbaasBuilder(object):
         service['pools'][0]['provisioning_status'] = 'ACTIVE'
         builder._assure_members(service, mock.MagicMock())
         assert not delete_member_mock.called
+
+    def test__get_pool_members(self, pool_member_service):
+        '''Method will map members with their pool.'''
+
+        builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
+        service = copy.deepcopy(pool_member_service)
+        members = builder._get_pool_members(service, service['pool']['id'])
+        assert len(members) == 2
+
+        # Modify pool_id of both members, expect no members returned
+        service['members'][0]['pool_id'] = 'test'
+        service['members'][1]['pool_id'] = 'test'
+        members = builder._get_pool_members(service, service['pool']['id'])
+        assert members == []

--- a/systest/scripts/install_test_infra.sh
+++ b/systest/scripts/install_test_infra.sh
@@ -23,8 +23,8 @@ sudo -E apt-get install -y libssl-dev &&
 sudo -E apt-get install -y libffi-dev &&
 sudo -E -H pip install --upgrade pip &&
 sudo -E -H pip install tox &&
-sudo -E -H pip install git+ssh://git@bldr-git.int.lineratesystems.com/tools/testenv.git@v0.1.18 &&
-sudo -E -H pip install git+ssh://git@bldr-git.int.lineratesystems.com/velcro/systest-common.git@001c8f80f0b2fed1feed1f2a097c15c601914246 &&
-sudo -E -H pip install git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-meta.git &&
-sudo -E -H pip install git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-autolog.git &&
-sudo -E -H pip install git+ssh://git@bldr-git.int.lineratesystems.com/tools/pytest-symbols.git
+sudo -E -H pip install git+ssh://git@gitlab.pdbld.f5net.com:tools/testenv.git@v0.1.18 &&
+sudo -E -H pip install git+ssh://git@gitlab.pdbld.f5net.com:velcro/systest-common.git@001c8f80f0b2fed1feed1f2a097c15c601914246 &&
+sudo -E -H pip install git+ssh://git@gitlab.pdbld.f5net.com:tools/pytest-meta.git &&
+sudo -E -H pip install git+ssh://git@gitlab.pdbld.f5net.com:tools/pytest-autolog.git &&
+sudo -E -H pip install git+ssh://git@gitlab.pdbld.f5net.com:tools/pytest-symbols.git

--- a/test/functional/neutronless/conftest.py
+++ b/test/functional/neutronless/conftest.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016 F5 Networks Inc.
+# Copyright 2016-2017 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,6 +18,10 @@ from .testlib.bigip_client import BigIpClient
 from .testlib.fake_rpc import FakeRPCPlugin
 from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import \
     iControlDriver
+
+from copy import deepcopy
+import json
+import os
 import pytest
 
 
@@ -61,3 +65,20 @@ def icontrol_driver(icd_config, fake_plugin_rpc):
     icd.plugin_rpc = fake_plugin_rpc
 
     return icd
+
+
+@pytest.fixture()
+def icd_config():
+    oslo_config_filename = (
+        os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                     '../config/basic_agent_config.json')
+    )
+    OSLO_CONFIGS = json.load(open(oslo_config_filename))
+
+    config = deepcopy(OSLO_CONFIGS)
+    config['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
+    config['icontrol_username'] = pytest.symbols.bigip_username
+    config['icontrol_password'] = pytest.symbols.bigip_password
+    config['f5_vtep_selfip_name'] = pytest.symbols.f5_vtep_selfip_name
+
+    return config

--- a/test/functional/neutronless/pool/test_pool_lb_method_change.py
+++ b/test/functional/neutronless/pool/test_pool_lb_method_change.py
@@ -1,0 +1,164 @@
+# coding=utf-8
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import json
+import logging
+import os
+import pytest
+import requests
+
+from f5_openstack_agent.lbaasv2.drivers.bigip.resource_helper import \
+    ResourceType
+
+from ..testlib.resource_validator import ResourceValidator
+from ..testlib.service_reader import LoadbalancerReader
+
+requests.packages.urllib3.disable_warnings()
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def services():
+    neutron_services_filename = (
+        os.path.join(
+            os.path.dirname(os.path.abspath(__file__)),
+            '../../testdata/service_requests/pool_multiple_members.json')
+    )
+    return (json.load(open(neutron_services_filename)))
+
+
+def test_pool_lb_change_ratio(bigip, services, icd_config, icontrol_driver):
+    env_prefix = icd_config['environment_prefix']
+    service_iter = iter(services)
+    validator = ResourceValidator(bigip, env_prefix)
+
+    # create lb
+    service = service_iter.next()
+    lb_reader = LoadbalancerReader(service)
+    folder = '{0}_{1}'.format(env_prefix, lb_reader.tenant_id())
+    icontrol_driver._common_service_handler(service)
+    assert bigip.folder_exists(folder)
+
+    # create listener
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+
+    # create pool with round-robin, no members
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+    pool_srvc = service['pools'][0]
+    pool_name = '{0}_{1}'.format(env_prefix, pool_srvc['id'])
+    validator.assert_pool_valid(pool_srvc, folder)
+    pool = bigip.get_resource(ResourceType.pool, pool_name, partition=folder)
+    assert pool.loadBalancingMode == 'round-robin'
+
+    # create member with weight = 1
+    service = service_iter.next()
+    member = service['members'][0]
+    icontrol_driver._common_service_handler(service)
+    validator.assert_member_valid(pool_srvc, member, folder)
+    pool.refresh()
+    assert pool.loadBalancingMode == 'round-robin'
+
+    # create member with weight > 1
+    service = service_iter.next()
+    member = service['members'][1]
+    icontrol_driver._common_service_handler(service)
+    validator.assert_member_valid(pool_srvc, member, folder)
+    pool.refresh()
+    assert pool.loadBalancingMode == 'ratio-member'
+
+    # create member with weight = 1
+    service = service_iter.next()
+    member = service['members'][2]
+    icontrol_driver._common_service_handler(service)
+    validator.assert_member_valid(pool_srvc, member, folder)
+    pool.refresh()
+    assert pool.loadBalancingMode == 'ratio-member'
+
+    # delete pool member with weight > 1
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+    validator.assert_pool_valid(pool_srvc, folder)
+    pool.refresh()
+    assert pool.loadBalancingMode == 'round-robin'
+
+    # update pool to have lb method least connections
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+    validator.assert_pool_valid(pool_srvc, folder)
+    pool.refresh()
+    assert pool.loadBalancingMode == 'least-connections-member'
+
+    # create member with weight > 1
+    service = service_iter.next()
+    member = service['members'][2]
+    icontrol_driver._common_service_handler(service)
+    validator.assert_pool_valid(pool_srvc, folder)
+    validator.assert_member_valid(pool_srvc, member, folder)
+    pool.refresh()
+    assert pool.loadBalancingMode == 'ratio-least-connections-member'
+
+    # delete member with weight > 1
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+    validator.assert_pool_valid(pool_srvc, folder)
+    pool.refresh()
+    assert pool.loadBalancingMode == 'least-connections-member'
+
+    # delete second member
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+    validator.assert_pool_valid(pool_srvc, folder)
+    pool.refresh()
+    assert pool.loadBalancingMode == 'least-connections-member'
+
+    # set lb method to SOURCE_IP for pool
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+    validator.assert_pool_valid(pool_srvc, folder)
+    pool.refresh()
+    assert pool.loadBalancingMode == 'least-connections-node'
+
+    # update member to have weight > 1
+    service = service_iter.next()
+    member = service['members'][0]
+    icontrol_driver._common_service_handler(service)
+    validator.assert_pool_valid(pool_srvc, folder)
+    validator.assert_member_valid(pool_srvc, member, folder)
+    pool.refresh()
+    assert pool.loadBalancingMode == 'least-connections-node'
+
+    # delete remaining member
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+    validator.assert_pool_valid(pool_srvc, folder)
+    pool.refresh()
+    assert pool.loadBalancingMode == 'least-connections-node'
+
+    # delete pool
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+    assert not bigip.resource_exists(
+        ResourceType.pool, pool_name, partition=folder)
+
+    # delete listener
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+
+    # delete lb
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)

--- a/test/functional/testdata/service_requests/pool_multiple_members.json
+++ b/test/functional/testdata/service_requests/pool_multiple_members.json
@@ -1,0 +1,3998 @@
+[{
+  "healthmonitors": [],
+  "l7policies": [],
+  "l7policy_rules": [],
+  "listeners": [],
+  "loadbalancer": {
+    "admin_state_up": true,
+    "description": "create lb",
+    "gre_vteps": [],
+    "id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+    "listeners": [],
+    "name": "lb1",
+    "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+    "operating_status": "OFFLINE",
+    "pools": [],
+    "provider": null,
+    "provisioning_status": "PENDING_CREATE",
+    "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+    "vip_address": "10.2.1.104",
+    "vip_port": {
+      "admin_state_up": false,
+      "allowed_address_pairs": [],
+      "binding:host_id": "",
+      "binding:profile": {},
+      "binding:vif_details": {},
+      "binding:vif_type": "unbound",
+      "binding:vnic_type": "normal",
+      "created_at": "2016-12-30T15:16:53",
+      "description": null,
+      "device_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "device_owner": "neutron:LOADBALANCERV2",
+      "dns_name": null,
+      "extra_dhcp_opts": [],
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.1.104",
+          "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+        }
+      ],
+      "id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+      "mac_address": "fa:16:3e:86:f2:b3",
+      "name": "loadbalancer-85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "security_groups": [
+        "cda7d6ff-99e5-4e82-8d59-f04c5cad0a22"
+      ],
+      "status": "DOWN",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-30T15:16:53"
+    },
+    "vip_port_id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+    "vip_subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+    "vxlan_vteps": [
+      "201.0.155.1",
+      "201.0.156.1",
+      "201.0.154.1",
+      "201.0.153.10"
+    ]
+  },
+  "members": [],
+  "networks": {
+    "035acd89-e04c-45b9-8028-1ea610f192e2": {
+      "admin_state_up": true,
+      "availability_zone_hints": [],
+      "availability_zones": [
+        "nova"
+      ],
+      "created_at": "2016-12-29T22:56:41",
+      "description": "",
+      "id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "ipv4_address_scope": null,
+      "ipv6_address_scope": null,
+      "mtu": 1450,
+      "name": "testlab-mgmt-network",
+      "provider:network_type": "vxlan",
+      "provider:physical_network": null,
+      "provider:segmentation_id": 85,
+      "router:external": false,
+      "shared": false,
+      "status": "ACTIVE",
+      "subnets": [
+        "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f",
+        "fe473803-35eb-4587-983f-493753b77f7c"
+      ],
+      "tags": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:41",
+      "vlan_transparent": null
+    }
+  },
+  "pools": [],
+  "subnets": {
+    "fe473803-35eb-4587-983f-493753b77f7c": {
+      "allocation_pools": [
+        {
+          "end": "10.2.1.150",
+          "start": "10.2.1.100"
+        }
+      ],
+      "cidr": "10.2.1.0/24",
+      "created_at": "2016-12-29T22:56:43",
+      "description": "",
+      "dns_nameservers": [
+        "10.190.0.20"
+      ],
+      "enable_dhcp": true,
+      "gateway_ip": "10.2.1.1",
+      "host_routes": [],
+      "id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "ip_version": 4,
+      "ipv6_address_mode": null,
+      "ipv6_ra_mode": null,
+      "name": "testlab-mgmt-v4-subnet",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "shared": false,
+      "subnetpool_id": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:43"
+    }
+  }
+},{
+  "healthmonitors": [],
+  "l7policies": [],
+  "l7policy_rules": [],
+  "listeners": [
+    {
+      "admin_state_up": true,
+      "connection_limit": -1,
+      "default_pool_id": null,
+      "default_tls_container_id": null,
+      "description": "create listener",
+      "id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "l7_policies": [],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "name": "listener1",
+      "operating_status": "OFFLINE",
+      "protocol": "HTTP",
+      "protocol_port": 80,
+      "provisioning_status": "PENDING_CREATE",
+      "sni_containers": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "loadbalancer": {
+    "admin_state_up": true,
+    "description": "",
+    "gre_vteps": [],
+    "id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+    "listeners": [
+      {
+        "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+      }
+    ],
+    "name": "lb1",
+    "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+    "operating_status": "ONLINE",
+    "pools": [],
+    "provider": "f5networks",
+    "provisioning_status": "PENDING_UPDATE",
+    "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+    "vip_address": "10.2.1.104",
+    "vip_port": {
+      "admin_state_up": true,
+      "allowed_address_pairs": [],
+      "binding:host_id": "host-155.int.lineratesystems.com:e5fe8b6d-ba1f-578c-a2ba-c1306a529179",
+      "binding:profile": {},
+      "binding:vif_details": {},
+      "binding:vif_type": "binding_failed",
+      "binding:vnic_type": "normal",
+      "created_at": "2016-12-30T15:16:53",
+      "description": null,
+      "device_id": "1460cf50-e691-5167-8489-0d56663e906a",
+      "device_owner": "network:f5lbaasv2",
+      "dns_name": null,
+      "extra_dhcp_opts": [],
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.1.104",
+          "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+        }
+      ],
+      "id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+      "mac_address": "fa:16:3e:86:f2:b3",
+      "name": "loadbalancer-85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "security_groups": [
+        "cda7d6ff-99e5-4e82-8d59-f04c5cad0a22"
+      ],
+      "status": "DOWN",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-30T15:16:53"
+    },
+    "vip_port_id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+    "vip_subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+    "vxlan_vteps": [
+      "201.0.155.1",
+      "201.0.156.1",
+      "201.0.154.1",
+      "201.0.153.10"
+    ]
+  },
+  "members": [],
+  "networks": {
+    "035acd89-e04c-45b9-8028-1ea610f192e2": {
+      "admin_state_up": true,
+      "availability_zone_hints": [],
+      "availability_zones": [
+        "nova"
+      ],
+      "created_at": "2016-12-29T22:56:41",
+      "description": "",
+      "id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "ipv4_address_scope": null,
+      "ipv6_address_scope": null,
+      "mtu": 1450,
+      "name": "testlab-mgmt-network",
+      "provider:network_type": "vxlan",
+      "provider:physical_network": null,
+      "provider:segmentation_id": 85,
+      "router:external": false,
+      "shared": false,
+      "status": "ACTIVE",
+      "subnets": [
+        "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f",
+        "fe473803-35eb-4587-983f-493753b77f7c"
+      ],
+      "tags": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:41",
+      "vlan_transparent": null
+    }
+  },
+  "pools": [],
+  "subnets": {
+    "fe473803-35eb-4587-983f-493753b77f7c": {
+      "allocation_pools": [
+        {
+          "end": "10.2.1.150",
+          "start": "10.2.1.100"
+        }
+      ],
+      "cidr": "10.2.1.0/24",
+      "created_at": "2016-12-29T22:56:43",
+      "description": "",
+      "dns_nameservers": [
+        "10.190.0.20"
+      ],
+      "enable_dhcp": true,
+      "gateway_ip": "10.2.1.1",
+      "host_routes": [],
+      "id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "ip_version": 4,
+      "ipv6_address_mode": null,
+      "ipv6_ra_mode": null,
+      "name": "testlab-mgmt-v4-subnet",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "shared": false,
+      "subnetpool_id": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:43"
+    }
+  }
+},{
+  "healthmonitors": [],
+  "l7policies": [],
+  "l7policy_rules": [],
+  "listeners": [
+    {
+      "admin_state_up": true,
+      "connection_limit": -1,
+      "default_pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "default_tls_container_id": null,
+      "description": "",
+      "id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "l7_policies": [],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "name": "listener1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "protocol_port": 80,
+      "provisioning_status": "ACTIVE",
+      "sni_containers": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "loadbalancer": {
+    "admin_state_up": true,
+    "description": "create pool",
+    "gre_vteps": [],
+    "id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+    "listeners": [
+      {
+        "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+      }
+    ],
+    "name": "lb1",
+    "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+    "operating_status": "ONLINE",
+    "pools": [
+      {
+        "id": "75026460-addc-4edc-ba90-50bed675b54a"
+      }
+    ],
+    "provider": "f5networks",
+    "provisioning_status": "PENDING_UPDATE",
+    "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+    "vip_address": "10.2.1.104",
+    "vip_port": {
+      "admin_state_up": true,
+      "allowed_address_pairs": [],
+      "binding:host_id": "host-155.int.lineratesystems.com:e5fe8b6d-ba1f-578c-a2ba-c1306a529179",
+      "binding:profile": {},
+      "binding:vif_details": {},
+      "binding:vif_type": "binding_failed",
+      "binding:vnic_type": "normal",
+      "created_at": "2016-12-30T15:16:53",
+      "description": null,
+      "device_id": "1460cf50-e691-5167-8489-0d56663e906a",
+      "device_owner": "network:f5lbaasv2",
+      "dns_name": null,
+      "extra_dhcp_opts": [],
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.1.104",
+          "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+        }
+      ],
+      "id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+      "mac_address": "fa:16:3e:86:f2:b3",
+      "name": "loadbalancer-85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "security_groups": [
+        "cda7d6ff-99e5-4e82-8d59-f04c5cad0a22"
+      ],
+      "status": "DOWN",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-30T15:16:53"
+    },
+    "vip_port_id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+    "vip_subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+    "vxlan_vteps": [
+      "201.0.155.1",
+      "201.0.156.1",
+      "201.0.154.1",
+      "201.0.153.10"
+    ]
+  },
+  "members": [],
+  "networks": {
+    "035acd89-e04c-45b9-8028-1ea610f192e2": {
+      "admin_state_up": true,
+      "availability_zone_hints": [],
+      "availability_zones": [
+        "nova"
+      ],
+      "created_at": "2016-12-29T22:56:41",
+      "description": "",
+      "id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "ipv4_address_scope": null,
+      "ipv6_address_scope": null,
+      "mtu": 1450,
+      "name": "testlab-mgmt-network",
+      "provider:network_type": "vxlan",
+      "provider:physical_network": null,
+      "provider:segmentation_id": 85,
+      "router:external": false,
+      "shared": false,
+      "status": "ACTIVE",
+      "subnets": [
+        "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f",
+        "fe473803-35eb-4587-983f-493753b77f7c"
+      ],
+      "tags": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:41",
+      "vlan_transparent": null
+    }
+  },
+  "pools": [
+    {
+      "admin_state_up": true,
+      "description": "",
+      "healthmonitor_id": null,
+      "id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "l7_policies": [],
+      "lb_algorithm": "ROUND_ROBIN",
+      "listener_id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "listeners": [
+        {
+          "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+        }
+      ],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "members": [],
+      "name": "pool1",
+      "operating_status": "OFFLINE",
+      "protocol": "HTTP",
+      "provisioning_status": "PENDING_CREATE",
+      "sessionpersistence": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "subnets": {
+    "fe473803-35eb-4587-983f-493753b77f7c": {
+      "allocation_pools": [
+        {
+          "end": "10.2.1.150",
+          "start": "10.2.1.100"
+        }
+      ],
+      "cidr": "10.2.1.0/24",
+      "created_at": "2016-12-29T22:56:43",
+      "description": "",
+      "dns_nameservers": [
+        "10.190.0.20"
+      ],
+      "enable_dhcp": true,
+      "gateway_ip": "10.2.1.1",
+      "host_routes": [],
+      "id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "ip_version": 4,
+      "ipv6_address_mode": null,
+      "ipv6_ra_mode": null,
+      "name": "testlab-mgmt-v4-subnet",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "shared": false,
+      "subnetpool_id": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:43"
+    }
+  }
+},{
+  "healthmonitors": [],
+  "l7policies": [],
+  "l7policy_rules": [],
+  "listeners": [
+    {
+      "admin_state_up": true,
+      "connection_limit": -1,
+      "default_pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "default_tls_container_id": null,
+      "description": "",
+      "id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "l7_policies": [],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "name": "listener1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "protocol_port": 80,
+      "provisioning_status": "ACTIVE",
+      "sni_containers": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "loadbalancer": {
+    "admin_state_up": true,
+    "description": "create member with weight = 1",
+    "gre_vteps": [],
+    "id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+    "listeners": [
+      {
+        "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+      }
+    ],
+    "name": "lb1",
+    "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+    "operating_status": "ONLINE",
+    "pools": [
+      {
+        "id": "75026460-addc-4edc-ba90-50bed675b54a"
+      }
+    ],
+    "provider": "f5networks",
+    "provisioning_status": "PENDING_UPDATE",
+    "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+    "vip_address": "10.2.1.104",
+    "vip_port": {
+      "admin_state_up": true,
+      "allowed_address_pairs": [],
+      "binding:host_id": "host-155.int.lineratesystems.com:e5fe8b6d-ba1f-578c-a2ba-c1306a529179",
+      "binding:profile": {},
+      "binding:vif_details": {},
+      "binding:vif_type": "binding_failed",
+      "binding:vnic_type": "normal",
+      "created_at": "2016-12-30T15:16:53",
+      "description": null,
+      "device_id": "1460cf50-e691-5167-8489-0d56663e906a",
+      "device_owner": "network:f5lbaasv2",
+      "dns_name": null,
+      "extra_dhcp_opts": [],
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.1.104",
+          "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+        }
+      ],
+      "id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+      "mac_address": "fa:16:3e:86:f2:b3",
+      "name": "loadbalancer-85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "security_groups": [
+        "cda7d6ff-99e5-4e82-8d59-f04c5cad0a22"
+      ],
+      "status": "DOWN",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-30T15:16:53"
+    },
+    "vip_port_id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+    "vip_subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+    "vxlan_vteps": [
+      "201.0.155.1",
+      "201.0.156.1",
+      "201.0.154.1",
+      "201.0.153.10"
+    ]
+  },
+  "members": [
+    {
+      "address": "10.2.1.9",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8ff",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "OFFLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.9",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "PENDING_CREATE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 1
+    }
+  ],
+  "networks": {
+    "035acd89-e04c-45b9-8028-1ea610f192e2": {
+      "admin_state_up": true,
+      "availability_zone_hints": [],
+      "availability_zones": [
+        "nova"
+      ],
+      "created_at": "2016-12-29T22:56:41",
+      "description": "",
+      "id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "ipv4_address_scope": null,
+      "ipv6_address_scope": null,
+      "mtu": 1450,
+      "name": "testlab-mgmt-network",
+      "provider:network_type": "vxlan",
+      "provider:physical_network": null,
+      "provider:segmentation_id": 85,
+      "router:external": false,
+      "shared": false,
+      "status": "ACTIVE",
+      "subnets": [
+        "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f",
+        "fe473803-35eb-4587-983f-493753b77f7c"
+      ],
+      "tags": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:41",
+      "vlan_transparent": null
+    }
+  },
+  "pools": [
+    {
+      "admin_state_up": true,
+      "description": "",
+      "healthmonitor_id": "48237b3d-b2e0-4ed4-a8e6-4647cf67bcf2",
+      "id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "l7_policies": [],
+      "lb_algorithm": "ROUND_ROBIN",
+      "listener_id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "listeners": [
+        {
+          "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+        }
+      ],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "members": [
+        {
+          "id": "4af30627-bddc-42d4-a8f9-2f088082e8ff"
+        }
+      ],
+      "name": "pool1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "provisioning_status": "ACTIVE",
+      "sessionpersistence": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "subnets": {
+    "fe473803-35eb-4587-983f-493753b77f7c": {
+      "allocation_pools": [
+        {
+          "end": "10.2.1.150",
+          "start": "10.2.1.100"
+        }
+      ],
+      "cidr": "10.2.1.0/24",
+      "created_at": "2016-12-29T22:56:43",
+      "description": "",
+      "dns_nameservers": [
+        "10.190.0.20"
+      ],
+      "enable_dhcp": true,
+      "gateway_ip": "10.2.1.1",
+      "host_routes": [],
+      "id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "ip_version": 4,
+      "ipv6_address_mode": null,
+      "ipv6_ra_mode": null,
+      "name": "testlab-mgmt-v4-subnet",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "shared": false,
+      "subnetpool_id": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:43"
+    }
+  }
+},{
+  "healthmonitors": [],
+  "l7policies": [],
+  "l7policy_rules": [],
+  "listeners": [
+    {
+      "admin_state_up": true,
+      "connection_limit": -1,
+      "default_pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "default_tls_container_id": null,
+      "description": "",
+      "id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "l7_policies": [],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "name": "listener1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "protocol_port": 80,
+      "provisioning_status": "ACTIVE",
+      "sni_containers": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "loadbalancer": {
+    "admin_state_up": true,
+    "description": "create member with weight > 1",
+    "gre_vteps": [],
+    "id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+    "listeners": [
+      {
+        "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+      }
+    ],
+    "name": "lb1",
+    "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+    "operating_status": "ONLINE",
+    "pools": [
+      {
+        "id": "75026460-addc-4edc-ba90-50bed675b54a"
+      }
+    ],
+    "provider": "f5networks",
+    "provisioning_status": "PENDING_UPDATE",
+    "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+    "vip_address": "10.2.1.104",
+    "vip_port": {
+      "admin_state_up": true,
+      "allowed_address_pairs": [],
+      "binding:host_id": "host-155.int.lineratesystems.com:e5fe8b6d-ba1f-578c-a2ba-c1306a529179",
+      "binding:profile": {},
+      "binding:vif_details": {},
+      "binding:vif_type": "binding_failed",
+      "binding:vnic_type": "normal",
+      "created_at": "2016-12-30T15:16:53",
+      "description": null,
+      "device_id": "1460cf50-e691-5167-8489-0d56663e906a",
+      "device_owner": "network:f5lbaasv2",
+      "dns_name": null,
+      "extra_dhcp_opts": [],
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.1.104",
+          "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+        }
+      ],
+      "id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+      "mac_address": "fa:16:3e:86:f2:b3",
+      "name": "loadbalancer-85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "security_groups": [
+        "cda7d6ff-99e5-4e82-8d59-f04c5cad0a22"
+      ],
+      "status": "DOWN",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-30T15:16:53"
+    },
+    "vip_port_id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+    "vip_subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+    "vxlan_vteps": [
+      "201.0.155.1",
+      "201.0.156.1",
+      "201.0.154.1",
+      "201.0.153.10"
+    ]
+  },
+  "members": [
+    {
+      "address": "10.2.1.9",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8fa",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "ONLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.9",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "ACTIVE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 1
+    },
+    {
+      "address": "10.2.1.10",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8fb",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "OFFLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.10",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "PENDING_CREATE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 10
+    }
+  ],
+  "networks": {
+    "035acd89-e04c-45b9-8028-1ea610f192e2": {
+      "admin_state_up": true,
+      "availability_zone_hints": [],
+      "availability_zones": [
+        "nova"
+      ],
+      "created_at": "2016-12-29T22:56:41",
+      "description": "",
+      "id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "ipv4_address_scope": null,
+      "ipv6_address_scope": null,
+      "mtu": 1450,
+      "name": "testlab-mgmt-network",
+      "provider:network_type": "vxlan",
+      "provider:physical_network": null,
+      "provider:segmentation_id": 85,
+      "router:external": false,
+      "shared": false,
+      "status": "ACTIVE",
+      "subnets": [
+        "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f",
+        "fe473803-35eb-4587-983f-493753b77f7c"
+      ],
+      "tags": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:41",
+      "vlan_transparent": null
+    }
+  },
+  "pools": [
+    {
+      "admin_state_up": true,
+      "description": "",
+      "healthmonitor_id": "48237b3d-b2e0-4ed4-a8e6-4647cf67bcf2",
+      "id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "l7_policies": [],
+      "lb_algorithm": "ROUND_ROBIN",
+      "listener_id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "listeners": [
+        {
+          "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+        }
+      ],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "members": [
+        {
+          "id": "4af30627-bddc-42d4-a8f9-2f088082e8ff"
+        }
+      ],
+      "name": "pool1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "provisioning_status": "ACTIVE",
+      "sessionpersistence": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "subnets": {
+    "fe473803-35eb-4587-983f-493753b77f7c": {
+      "allocation_pools": [
+        {
+          "end": "10.2.1.150",
+          "start": "10.2.1.100"
+        }
+      ],
+      "cidr": "10.2.1.0/24",
+      "created_at": "2016-12-29T22:56:43",
+      "description": "",
+      "dns_nameservers": [
+        "10.190.0.20"
+      ],
+      "enable_dhcp": true,
+      "gateway_ip": "10.2.1.1",
+      "host_routes": [],
+      "id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "ip_version": 4,
+      "ipv6_address_mode": null,
+      "ipv6_ra_mode": null,
+      "name": "testlab-mgmt-v4-subnet",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "shared": false,
+      "subnetpool_id": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:43"
+    }
+  }
+},{
+  "healthmonitors": [],
+  "l7policies": [],
+  "l7policy_rules": [],
+  "listeners": [
+    {
+      "admin_state_up": true,
+      "connection_limit": -1,
+      "default_pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "default_tls_container_id": null,
+      "description": "",
+      "id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "l7_policies": [],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "name": "listener1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "protocol_port": 80,
+      "provisioning_status": "ACTIVE",
+      "sni_containers": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "loadbalancer": {
+    "admin_state_up": true,
+    "description": "create member with weight > 1",
+    "gre_vteps": [],
+    "id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+    "listeners": [
+      {
+        "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+      }
+    ],
+    "name": "lb1",
+    "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+    "operating_status": "ONLINE",
+    "pools": [
+      {
+        "id": "75026460-addc-4edc-ba90-50bed675b54a"
+      }
+    ],
+    "provider": "f5networks",
+    "provisioning_status": "PENDING_UPDATE",
+    "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+    "vip_address": "10.2.1.104",
+    "vip_port": {
+      "admin_state_up": true,
+      "allowed_address_pairs": [],
+      "binding:host_id": "host-155.int.lineratesystems.com:e5fe8b6d-ba1f-578c-a2ba-c1306a529179",
+      "binding:profile": {},
+      "binding:vif_details": {},
+      "binding:vif_type": "binding_failed",
+      "binding:vnic_type": "normal",
+      "created_at": "2016-12-30T15:16:53",
+      "description": null,
+      "device_id": "1460cf50-e691-5167-8489-0d56663e906a",
+      "device_owner": "network:f5lbaasv2",
+      "dns_name": null,
+      "extra_dhcp_opts": [],
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.1.104",
+          "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+        }
+      ],
+      "id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+      "mac_address": "fa:16:3e:86:f2:b3",
+      "name": "loadbalancer-85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "security_groups": [
+        "cda7d6ff-99e5-4e82-8d59-f04c5cad0a22"
+      ],
+      "status": "DOWN",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-30T15:16:53"
+    },
+    "vip_port_id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+    "vip_subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+    "vxlan_vteps": [
+      "201.0.155.1",
+      "201.0.156.1",
+      "201.0.154.1",
+      "201.0.153.10"
+    ]
+  },
+  "members": [
+    {
+      "address": "10.2.1.9",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8fa",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "ONLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.9",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "ACTIVE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 1
+    },
+    {
+      "address": "10.2.1.10",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8fb",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "ONLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.10",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "ACTIVE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 10
+    },{
+      "address": "10.2.1.11",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8fc",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "OFFLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.11",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "PENDING_CREATE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "PENDING_CREATE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 1
+    }
+  ],
+  "networks": {
+    "035acd89-e04c-45b9-8028-1ea610f192e2": {
+      "admin_state_up": true,
+      "availability_zone_hints": [],
+      "availability_zones": [
+        "nova"
+      ],
+      "created_at": "2016-12-29T22:56:41",
+      "description": "",
+      "id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "ipv4_address_scope": null,
+      "ipv6_address_scope": null,
+      "mtu": 1450,
+      "name": "testlab-mgmt-network",
+      "provider:network_type": "vxlan",
+      "provider:physical_network": null,
+      "provider:segmentation_id": 85,
+      "router:external": false,
+      "shared": false,
+      "status": "ACTIVE",
+      "subnets": [
+        "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f",
+        "fe473803-35eb-4587-983f-493753b77f7c"
+      ],
+      "tags": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:41",
+      "vlan_transparent": null
+    }
+  },
+  "pools": [
+    {
+      "admin_state_up": true,
+      "description": "",
+      "healthmonitor_id": "48237b3d-b2e0-4ed4-a8e6-4647cf67bcf2",
+      "id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "l7_policies": [],
+      "lb_algorithm": "ROUND_ROBIN",
+      "listener_id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "listeners": [
+        {
+          "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+        }
+      ],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "members": [
+        {
+          "id": "4af30627-bddc-42d4-a8f9-2f088082e8ff"
+        }
+      ],
+      "name": "pool1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "provisioning_status": "ACTIVE",
+      "sessionpersistence": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "subnets": {
+    "fe473803-35eb-4587-983f-493753b77f7c": {
+      "allocation_pools": [
+        {
+          "end": "10.2.1.150",
+          "start": "10.2.1.100"
+        }
+      ],
+      "cidr": "10.2.1.0/24",
+      "created_at": "2016-12-29T22:56:43",
+      "description": "",
+      "dns_nameservers": [
+        "10.190.0.20"
+      ],
+      "enable_dhcp": true,
+      "gateway_ip": "10.2.1.1",
+      "host_routes": [],
+      "id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "ip_version": 4,
+      "ipv6_address_mode": null,
+      "ipv6_ra_mode": null,
+      "name": "testlab-mgmt-v4-subnet",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "shared": false,
+      "subnetpool_id": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:43"
+    }
+  }
+},{
+  "healthmonitors": [],
+  "l7policies": [],
+  "l7policy_rules": [],
+  "listeners": [
+    {
+      "admin_state_up": true,
+      "connection_limit": -1,
+      "default_pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "default_tls_container_id": null,
+      "description": "",
+      "id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "l7_policies": [],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "name": "listener1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "protocol_port": 80,
+      "provisioning_status": "ACTIVE",
+      "sni_containers": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "loadbalancer": {
+    "admin_state_up": true,
+    "description": "delete member with weight > 1",
+    "gre_vteps": [],
+    "id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+    "listeners": [
+      {
+        "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+      }
+    ],
+    "name": "lb1",
+    "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+    "operating_status": "ONLINE",
+    "pools": [
+      {
+        "id": "75026460-addc-4edc-ba90-50bed675b54a"
+      }
+    ],
+    "provider": "f5networks",
+    "provisioning_status": "PENDING_UPDATE",
+    "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+    "vip_address": "10.2.1.104",
+    "vip_port": {
+      "admin_state_up": true,
+      "allowed_address_pairs": [],
+      "binding:host_id": "host-155.int.lineratesystems.com:e5fe8b6d-ba1f-578c-a2ba-c1306a529179",
+      "binding:profile": {},
+      "binding:vif_details": {},
+      "binding:vif_type": "binding_failed",
+      "binding:vnic_type": "normal",
+      "created_at": "2016-12-30T15:16:53",
+      "description": null,
+      "device_id": "1460cf50-e691-5167-8489-0d56663e906a",
+      "device_owner": "network:f5lbaasv2",
+      "dns_name": null,
+      "extra_dhcp_opts": [],
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.1.104",
+          "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+        }
+      ],
+      "id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+      "mac_address": "fa:16:3e:86:f2:b3",
+      "name": "loadbalancer-85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "security_groups": [
+        "cda7d6ff-99e5-4e82-8d59-f04c5cad0a22"
+      ],
+      "status": "DOWN",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-30T15:16:53"
+    },
+    "vip_port_id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+    "vip_subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+    "vxlan_vteps": [
+      "201.0.155.1",
+      "201.0.156.1",
+      "201.0.154.1",
+      "201.0.153.10"
+    ]
+  },
+  "members": [
+    {
+      "address": "10.2.1.9",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8fa",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "ONLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.9",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "ACTIVE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 1
+    },
+    {
+      "address": "10.2.1.10",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8fb",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "ONLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.10",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "PENDING_DELETE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 10
+    },{
+      "address": "10.2.1.11",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8fc",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "ONLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.11",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "PENDING_CREATE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 1
+    }
+  ],
+  "networks": {
+    "035acd89-e04c-45b9-8028-1ea610f192e2": {
+      "admin_state_up": true,
+      "availability_zone_hints": [],
+      "availability_zones": [
+        "nova"
+      ],
+      "created_at": "2016-12-29T22:56:41",
+      "description": "",
+      "id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "ipv4_address_scope": null,
+      "ipv6_address_scope": null,
+      "mtu": 1450,
+      "name": "testlab-mgmt-network",
+      "provider:network_type": "vxlan",
+      "provider:physical_network": null,
+      "provider:segmentation_id": 85,
+      "router:external": false,
+      "shared": false,
+      "status": "ACTIVE",
+      "subnets": [
+        "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f",
+        "fe473803-35eb-4587-983f-493753b77f7c"
+      ],
+      "tags": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:41",
+      "vlan_transparent": null
+    }
+  },
+  "pools": [
+    {
+      "admin_state_up": true,
+      "description": "",
+      "healthmonitor_id": "48237b3d-b2e0-4ed4-a8e6-4647cf67bcf2",
+      "id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "l7_policies": [],
+      "lb_algorithm": "ROUND_ROBIN",
+      "listener_id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "listeners": [
+        {
+          "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+        }
+      ],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "members": [
+        {
+          "id": "4af30627-bddc-42d4-a8f9-2f088082e8ff"
+        }
+      ],
+      "name": "pool1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "provisioning_status": "ACTIVE",
+      "sessionpersistence": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "subnets": {
+    "fe473803-35eb-4587-983f-493753b77f7c": {
+      "allocation_pools": [
+        {
+          "end": "10.2.1.150",
+          "start": "10.2.1.100"
+        }
+      ],
+      "cidr": "10.2.1.0/24",
+      "created_at": "2016-12-29T22:56:43",
+      "description": "",
+      "dns_nameservers": [
+        "10.190.0.20"
+      ],
+      "enable_dhcp": true,
+      "gateway_ip": "10.2.1.1",
+      "host_routes": [],
+      "id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "ip_version": 4,
+      "ipv6_address_mode": null,
+      "ipv6_ra_mode": null,
+      "name": "testlab-mgmt-v4-subnet",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "shared": false,
+      "subnetpool_id": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:43"
+    }
+  }
+},{
+  "healthmonitors": [],
+  "l7policies": [],
+  "l7policy_rules": [],
+  "listeners": [
+    {
+      "admin_state_up": true,
+      "connection_limit": -1,
+      "default_pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "default_tls_container_id": null,
+      "description": "",
+      "id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "l7_policies": [],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "name": "listener1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "protocol_port": 80,
+      "provisioning_status": "ACTIVE",
+      "sni_containers": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "loadbalancer": {
+    "admin_state_up": true,
+    "description": "update pool to have lb method least connections",
+    "gre_vteps": [],
+    "id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+    "listeners": [
+      {
+        "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+      }
+    ],
+    "name": "lb1",
+    "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+    "operating_status": "ONLINE",
+    "pools": [
+      {
+        "id": "75026460-addc-4edc-ba90-50bed675b54a"
+      }
+    ],
+    "provider": "f5networks",
+    "provisioning_status": "PENDING_UPDATE",
+    "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+    "vip_address": "10.2.1.104",
+    "vip_port": {
+      "admin_state_up": true,
+      "allowed_address_pairs": [],
+      "binding:host_id": "host-155.int.lineratesystems.com:e5fe8b6d-ba1f-578c-a2ba-c1306a529179",
+      "binding:profile": {},
+      "binding:vif_details": {},
+      "binding:vif_type": "binding_failed",
+      "binding:vnic_type": "normal",
+      "created_at": "2016-12-30T15:16:53",
+      "description": null,
+      "device_id": "1460cf50-e691-5167-8489-0d56663e906a",
+      "device_owner": "network:f5lbaasv2",
+      "dns_name": null,
+      "extra_dhcp_opts": [],
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.1.104",
+          "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+        }
+      ],
+      "id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+      "mac_address": "fa:16:3e:86:f2:b3",
+      "name": "loadbalancer-85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "security_groups": [
+        "cda7d6ff-99e5-4e82-8d59-f04c5cad0a22"
+      ],
+      "status": "DOWN",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-30T15:16:53"
+    },
+    "vip_port_id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+    "vip_subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+    "vxlan_vteps": [
+      "201.0.155.1",
+      "201.0.156.1",
+      "201.0.154.1",
+      "201.0.153.10"
+    ]
+  },
+  "members": [
+    {
+      "address": "10.2.1.9",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8fa",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "ONLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.9",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "ACTIVE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 1
+    },{
+      "address": "10.2.1.11",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8fc",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "ONLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.11",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "ACTIVE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 1
+    }
+  ],
+  "networks": {
+    "035acd89-e04c-45b9-8028-1ea610f192e2": {
+      "admin_state_up": true,
+      "availability_zone_hints": [],
+      "availability_zones": [
+        "nova"
+      ],
+      "created_at": "2016-12-29T22:56:41",
+      "description": "",
+      "id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "ipv4_address_scope": null,
+      "ipv6_address_scope": null,
+      "mtu": 1450,
+      "name": "testlab-mgmt-network",
+      "provider:network_type": "vxlan",
+      "provider:physical_network": null,
+      "provider:segmentation_id": 85,
+      "router:external": false,
+      "shared": false,
+      "status": "ACTIVE",
+      "subnets": [
+        "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f",
+        "fe473803-35eb-4587-983f-493753b77f7c"
+      ],
+      "tags": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:41",
+      "vlan_transparent": null
+    }
+  },
+  "pools": [
+    {
+      "admin_state_up": true,
+      "description": "",
+      "healthmonitor_id": "48237b3d-b2e0-4ed4-a8e6-4647cf67bcf2",
+      "id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "l7_policies": [],
+      "lb_algorithm": "LEAST_CONNECTIONS",
+      "listener_id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "listeners": [
+        {
+          "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+        }
+      ],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "members": [
+        {
+          "id": "4af30627-bddc-42d4-a8f9-2f088082e8ff"
+        }
+      ],
+      "name": "pool1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "provisioning_status": "PENDING_UPDATE",
+      "sessionpersistence": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "subnets": {
+    "fe473803-35eb-4587-983f-493753b77f7c": {
+      "allocation_pools": [
+        {
+          "end": "10.2.1.150",
+          "start": "10.2.1.100"
+        }
+      ],
+      "cidr": "10.2.1.0/24",
+      "created_at": "2016-12-29T22:56:43",
+      "description": "",
+      "dns_nameservers": [
+        "10.190.0.20"
+      ],
+      "enable_dhcp": true,
+      "gateway_ip": "10.2.1.1",
+      "host_routes": [],
+      "id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "ip_version": 4,
+      "ipv6_address_mode": null,
+      "ipv6_ra_mode": null,
+      "name": "testlab-mgmt-v4-subnet",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "shared": false,
+      "subnetpool_id": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:43"
+    }
+  }
+},{
+  "healthmonitors": [],
+  "l7policies": [],
+  "l7policy_rules": [],
+  "listeners": [
+    {
+      "admin_state_up": true,
+      "connection_limit": -1,
+      "default_pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "default_tls_container_id": null,
+      "description": "",
+      "id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "l7_policies": [],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "name": "listener1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "protocol_port": 80,
+      "provisioning_status": "ACTIVE",
+      "sni_containers": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "loadbalancer": {
+    "admin_state_up": true,
+    "description": "create member with weight > 1",
+    "gre_vteps": [],
+    "id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+    "listeners": [
+      {
+        "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+      }
+    ],
+    "name": "lb1",
+    "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+    "operating_status": "ONLINE",
+    "pools": [
+      {
+        "id": "75026460-addc-4edc-ba90-50bed675b54a"
+      }
+    ],
+    "provider": "f5networks",
+    "provisioning_status": "PENDING_UPDATE",
+    "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+    "vip_address": "10.2.1.104",
+    "vip_port": {
+      "admin_state_up": true,
+      "allowed_address_pairs": [],
+      "binding:host_id": "host-155.int.lineratesystems.com:e5fe8b6d-ba1f-578c-a2ba-c1306a529179",
+      "binding:profile": {},
+      "binding:vif_details": {},
+      "binding:vif_type": "binding_failed",
+      "binding:vnic_type": "normal",
+      "created_at": "2016-12-30T15:16:53",
+      "description": null,
+      "device_id": "1460cf50-e691-5167-8489-0d56663e906a",
+      "device_owner": "network:f5lbaasv2",
+      "dns_name": null,
+      "extra_dhcp_opts": [],
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.1.104",
+          "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+        }
+      ],
+      "id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+      "mac_address": "fa:16:3e:86:f2:b3",
+      "name": "loadbalancer-85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "security_groups": [
+        "cda7d6ff-99e5-4e82-8d59-f04c5cad0a22"
+      ],
+      "status": "DOWN",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-30T15:16:53"
+    },
+    "vip_port_id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+    "vip_subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+    "vxlan_vteps": [
+      "201.0.155.1",
+      "201.0.156.1",
+      "201.0.154.1",
+      "201.0.153.10"
+    ]
+  },
+  "members": [
+    {
+      "address": "10.2.1.9",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8fa",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "ONLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.9",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "ACTIVE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 1
+    },{
+      "address": "10.2.1.11",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8fc",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "ONLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.11",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "ACTIVE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 1
+    },{
+      "address": "10.2.1.12",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8fd",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "ONLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.12",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "PENDING_CREATE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 100
+    }
+  ],
+  "networks": {
+    "035acd89-e04c-45b9-8028-1ea610f192e2": {
+      "admin_state_up": true,
+      "availability_zone_hints": [],
+      "availability_zones": [
+        "nova"
+      ],
+      "created_at": "2016-12-29T22:56:41",
+      "description": "",
+      "id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "ipv4_address_scope": null,
+      "ipv6_address_scope": null,
+      "mtu": 1450,
+      "name": "testlab-mgmt-network",
+      "provider:network_type": "vxlan",
+      "provider:physical_network": null,
+      "provider:segmentation_id": 85,
+      "router:external": false,
+      "shared": false,
+      "status": "ACTIVE",
+      "subnets": [
+        "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f",
+        "fe473803-35eb-4587-983f-493753b77f7c"
+      ],
+      "tags": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:41",
+      "vlan_transparent": null
+    }
+  },
+  "pools": [
+    {
+      "admin_state_up": true,
+      "description": "",
+      "healthmonitor_id": "48237b3d-b2e0-4ed4-a8e6-4647cf67bcf2",
+      "id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "l7_policies": [],
+      "lb_algorithm": "LEAST_CONNECTIONS",
+      "listener_id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "listeners": [
+        {
+          "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+        }
+      ],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "members": [
+        {
+          "id": "4af30627-bddc-42d4-a8f9-2f088082e8ff"
+        }
+      ],
+      "name": "pool1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "provisioning_status": "ACTIVE",
+      "sessionpersistence": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "subnets": {
+    "fe473803-35eb-4587-983f-493753b77f7c": {
+      "allocation_pools": [
+        {
+          "end": "10.2.1.150",
+          "start": "10.2.1.100"
+        }
+      ],
+      "cidr": "10.2.1.0/24",
+      "created_at": "2016-12-29T22:56:43",
+      "description": "",
+      "dns_nameservers": [
+        "10.190.0.20"
+      ],
+      "enable_dhcp": true,
+      "gateway_ip": "10.2.1.1",
+      "host_routes": [],
+      "id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "ip_version": 4,
+      "ipv6_address_mode": null,
+      "ipv6_ra_mode": null,
+      "name": "testlab-mgmt-v4-subnet",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "shared": false,
+      "subnetpool_id": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:43"
+    }
+  }
+},{
+  "healthmonitors": [],
+  "l7policies": [],
+  "l7policy_rules": [],
+  "listeners": [
+    {
+      "admin_state_up": true,
+      "connection_limit": -1,
+      "default_pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "default_tls_container_id": null,
+      "description": "",
+      "id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "l7_policies": [],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "name": "listener1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "protocol_port": 80,
+      "provisioning_status": "ACTIVE",
+      "sni_containers": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "loadbalancer": {
+    "admin_state_up": true,
+    "description": "delete member with weight > 1",
+    "gre_vteps": [],
+    "id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+    "listeners": [
+      {
+        "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+      }
+    ],
+    "name": "lb1",
+    "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+    "operating_status": "ONLINE",
+    "pools": [
+      {
+        "id": "75026460-addc-4edc-ba90-50bed675b54a"
+      }
+    ],
+    "provider": "f5networks",
+    "provisioning_status": "PENDING_UPDATE",
+    "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+    "vip_address": "10.2.1.104",
+    "vip_port": {
+      "admin_state_up": true,
+      "allowed_address_pairs": [],
+      "binding:host_id": "host-155.int.lineratesystems.com:e5fe8b6d-ba1f-578c-a2ba-c1306a529179",
+      "binding:profile": {},
+      "binding:vif_details": {},
+      "binding:vif_type": "binding_failed",
+      "binding:vnic_type": "normal",
+      "created_at": "2016-12-30T15:16:53",
+      "description": null,
+      "device_id": "1460cf50-e691-5167-8489-0d56663e906a",
+      "device_owner": "network:f5lbaasv2",
+      "dns_name": null,
+      "extra_dhcp_opts": [],
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.1.104",
+          "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+        }
+      ],
+      "id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+      "mac_address": "fa:16:3e:86:f2:b3",
+      "name": "loadbalancer-85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "security_groups": [
+        "cda7d6ff-99e5-4e82-8d59-f04c5cad0a22"
+      ],
+      "status": "DOWN",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-30T15:16:53"
+    },
+    "vip_port_id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+    "vip_subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+    "vxlan_vteps": [
+      "201.0.155.1",
+      "201.0.156.1",
+      "201.0.154.1",
+      "201.0.153.10"
+    ]
+  },
+  "members": [
+    {
+      "address": "10.2.1.9",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8fa",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "ONLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.9",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "ACTIVE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 1
+    },{
+      "address": "10.2.1.11",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8fc",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "ONLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.11",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "ACTIVE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 1
+    },{
+      "address": "10.2.1.12",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8fd",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "ONLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.12",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "PENDING_DELETE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 100
+    }
+  ],
+  "networks": {
+    "035acd89-e04c-45b9-8028-1ea610f192e2": {
+      "admin_state_up": true,
+      "availability_zone_hints": [],
+      "availability_zones": [
+        "nova"
+      ],
+      "created_at": "2016-12-29T22:56:41",
+      "description": "",
+      "id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "ipv4_address_scope": null,
+      "ipv6_address_scope": null,
+      "mtu": 1450,
+      "name": "testlab-mgmt-network",
+      "provider:network_type": "vxlan",
+      "provider:physical_network": null,
+      "provider:segmentation_id": 85,
+      "router:external": false,
+      "shared": false,
+      "status": "ACTIVE",
+      "subnets": [
+        "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f",
+        "fe473803-35eb-4587-983f-493753b77f7c"
+      ],
+      "tags": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:41",
+      "vlan_transparent": null
+    }
+  },
+  "pools": [
+    {
+      "admin_state_up": true,
+      "description": "",
+      "healthmonitor_id": "48237b3d-b2e0-4ed4-a8e6-4647cf67bcf2",
+      "id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "l7_policies": [],
+      "lb_algorithm": "LEAST_CONNECTIONS",
+      "listener_id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "listeners": [
+        {
+          "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+        }
+      ],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "members": [
+        {
+          "id": "4af30627-bddc-42d4-a8f9-2f088082e8ff"
+        }
+      ],
+      "name": "pool1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "provisioning_status": "ACTIVE",
+      "sessionpersistence": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "subnets": {
+    "fe473803-35eb-4587-983f-493753b77f7c": {
+      "allocation_pools": [
+        {
+          "end": "10.2.1.150",
+          "start": "10.2.1.100"
+        }
+      ],
+      "cidr": "10.2.1.0/24",
+      "created_at": "2016-12-29T22:56:43",
+      "description": "",
+      "dns_nameservers": [
+        "10.190.0.20"
+      ],
+      "enable_dhcp": true,
+      "gateway_ip": "10.2.1.1",
+      "host_routes": [],
+      "id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "ip_version": 4,
+      "ipv6_address_mode": null,
+      "ipv6_ra_mode": null,
+      "name": "testlab-mgmt-v4-subnet",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "shared": false,
+      "subnetpool_id": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:43"
+    }
+  }
+},{
+  "healthmonitors": [],
+  "l7policies": [],
+  "l7policy_rules": [],
+  "listeners": [
+    {
+      "admin_state_up": true,
+      "connection_limit": -1,
+      "default_pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "default_tls_container_id": null,
+      "description": "",
+      "id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "l7_policies": [],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "name": "listener1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "protocol_port": 80,
+      "provisioning_status": "ACTIVE",
+      "sni_containers": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "loadbalancer": {
+    "admin_state_up": true,
+    "description": "delete second member",
+    "gre_vteps": [],
+    "id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+    "listeners": [
+      {
+        "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+      }
+    ],
+    "name": "lb1",
+    "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+    "operating_status": "ONLINE",
+    "pools": [
+      {
+        "id": "75026460-addc-4edc-ba90-50bed675b54a"
+      }
+    ],
+    "provider": "f5networks",
+    "provisioning_status": "PENDING_UPDATE",
+    "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+    "vip_address": "10.2.1.104",
+    "vip_port": {
+      "admin_state_up": true,
+      "allowed_address_pairs": [],
+      "binding:host_id": "host-155.int.lineratesystems.com:e5fe8b6d-ba1f-578c-a2ba-c1306a529179",
+      "binding:profile": {},
+      "binding:vif_details": {},
+      "binding:vif_type": "binding_failed",
+      "binding:vnic_type": "normal",
+      "created_at": "2016-12-30T15:16:53",
+      "description": null,
+      "device_id": "1460cf50-e691-5167-8489-0d56663e906a",
+      "device_owner": "network:f5lbaasv2",
+      "dns_name": null,
+      "extra_dhcp_opts": [],
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.1.104",
+          "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+        }
+      ],
+      "id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+      "mac_address": "fa:16:3e:86:f2:b3",
+      "name": "loadbalancer-85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "security_groups": [
+        "cda7d6ff-99e5-4e82-8d59-f04c5cad0a22"
+      ],
+      "status": "DOWN",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-30T15:16:53"
+    },
+    "vip_port_id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+    "vip_subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+    "vxlan_vteps": [
+      "201.0.155.1",
+      "201.0.156.1",
+      "201.0.154.1",
+      "201.0.153.10"
+    ]
+  },
+  "members": [
+    {
+      "address": "10.2.1.9",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8fa",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "ONLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.9",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "ACTIVE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 1
+    },{
+      "address": "10.2.1.11",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8fc",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "ONLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.11",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "PENDING_DELETE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 1
+    }
+  ],
+  "networks": {
+    "035acd89-e04c-45b9-8028-1ea610f192e2": {
+      "admin_state_up": true,
+      "availability_zone_hints": [],
+      "availability_zones": [
+        "nova"
+      ],
+      "created_at": "2016-12-29T22:56:41",
+      "description": "",
+      "id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "ipv4_address_scope": null,
+      "ipv6_address_scope": null,
+      "mtu": 1450,
+      "name": "testlab-mgmt-network",
+      "provider:network_type": "vxlan",
+      "provider:physical_network": null,
+      "provider:segmentation_id": 85,
+      "router:external": false,
+      "shared": false,
+      "status": "ACTIVE",
+      "subnets": [
+        "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f",
+        "fe473803-35eb-4587-983f-493753b77f7c"
+      ],
+      "tags": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:41",
+      "vlan_transparent": null
+    }
+  },
+  "pools": [
+    {
+      "admin_state_up": true,
+      "description": "",
+      "healthmonitor_id": "48237b3d-b2e0-4ed4-a8e6-4647cf67bcf2",
+      "id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "l7_policies": [],
+      "lb_algorithm": "LEAST_CONNECTIONS",
+      "listener_id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "listeners": [
+        {
+          "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+        }
+      ],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "members": [
+        {
+          "id": "4af30627-bddc-42d4-a8f9-2f088082e8ff"
+        }
+      ],
+      "name": "pool1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "provisioning_status": "ACTIVE",
+      "sessionpersistence": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "subnets": {
+    "fe473803-35eb-4587-983f-493753b77f7c": {
+      "allocation_pools": [
+        {
+          "end": "10.2.1.150",
+          "start": "10.2.1.100"
+        }
+      ],
+      "cidr": "10.2.1.0/24",
+      "created_at": "2016-12-29T22:56:43",
+      "description": "",
+      "dns_nameservers": [
+        "10.190.0.20"
+      ],
+      "enable_dhcp": true,
+      "gateway_ip": "10.2.1.1",
+      "host_routes": [],
+      "id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "ip_version": 4,
+      "ipv6_address_mode": null,
+      "ipv6_ra_mode": null,
+      "name": "testlab-mgmt-v4-subnet",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "shared": false,
+      "subnetpool_id": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:43"
+    }
+  }
+},{
+  "healthmonitors": [],
+  "l7policies": [],
+  "l7policy_rules": [],
+  "listeners": [
+    {
+      "admin_state_up": true,
+      "connection_limit": -1,
+      "default_pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "default_tls_container_id": null,
+      "description": "",
+      "id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "l7_policies": [],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "name": "listener1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "protocol_port": 80,
+      "provisioning_status": "ACTIVE",
+      "sni_containers": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "loadbalancer": {
+    "admin_state_up": true,
+    "description": "set lb method to SOURCE_IP for pool",
+    "gre_vteps": [],
+    "id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+    "listeners": [
+      {
+        "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+      }
+    ],
+    "name": "lb1",
+    "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+    "operating_status": "ONLINE",
+    "pools": [
+      {
+        "id": "75026460-addc-4edc-ba90-50bed675b54a"
+      }
+    ],
+    "provider": "f5networks",
+    "provisioning_status": "PENDING_UPDATE",
+    "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+    "vip_address": "10.2.1.104",
+    "vip_port": {
+      "admin_state_up": true,
+      "allowed_address_pairs": [],
+      "binding:host_id": "host-155.int.lineratesystems.com:e5fe8b6d-ba1f-578c-a2ba-c1306a529179",
+      "binding:profile": {},
+      "binding:vif_details": {},
+      "binding:vif_type": "binding_failed",
+      "binding:vnic_type": "normal",
+      "created_at": "2016-12-30T15:16:53",
+      "description": null,
+      "device_id": "1460cf50-e691-5167-8489-0d56663e906a",
+      "device_owner": "network:f5lbaasv2",
+      "dns_name": null,
+      "extra_dhcp_opts": [],
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.1.104",
+          "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+        }
+      ],
+      "id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+      "mac_address": "fa:16:3e:86:f2:b3",
+      "name": "loadbalancer-85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "security_groups": [
+        "cda7d6ff-99e5-4e82-8d59-f04c5cad0a22"
+      ],
+      "status": "DOWN",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-30T15:16:53"
+    },
+    "vip_port_id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+    "vip_subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+    "vxlan_vteps": [
+      "201.0.155.1",
+      "201.0.156.1",
+      "201.0.154.1",
+      "201.0.153.10"
+    ]
+  },
+  "members": [
+    {
+      "address": "10.2.1.9",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8fa",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "ONLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.9",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "ACTIVE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 1
+    }
+  ],
+  "networks": {
+    "035acd89-e04c-45b9-8028-1ea610f192e2": {
+      "admin_state_up": true,
+      "availability_zone_hints": [],
+      "availability_zones": [
+        "nova"
+      ],
+      "created_at": "2016-12-29T22:56:41",
+      "description": "",
+      "id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "ipv4_address_scope": null,
+      "ipv6_address_scope": null,
+      "mtu": 1450,
+      "name": "testlab-mgmt-network",
+      "provider:network_type": "vxlan",
+      "provider:physical_network": null,
+      "provider:segmentation_id": 85,
+      "router:external": false,
+      "shared": false,
+      "status": "ACTIVE",
+      "subnets": [
+        "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f",
+        "fe473803-35eb-4587-983f-493753b77f7c"
+      ],
+      "tags": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:41",
+      "vlan_transparent": null
+    }
+  },
+  "pools": [
+    {
+      "admin_state_up": true,
+      "description": "",
+      "healthmonitor_id": "48237b3d-b2e0-4ed4-a8e6-4647cf67bcf2",
+      "id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "l7_policies": [],
+      "lb_algorithm": "SOURCE_IP",
+      "listener_id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "listeners": [
+        {
+          "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+        }
+      ],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "members": [
+        {
+          "id": "4af30627-bddc-42d4-a8f9-2f088082e8ff"
+        }
+      ],
+      "name": "pool1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "provisioning_status": "PENDING_UPDATE",
+      "sessionpersistence": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "subnets": {
+    "fe473803-35eb-4587-983f-493753b77f7c": {
+      "allocation_pools": [
+        {
+          "end": "10.2.1.150",
+          "start": "10.2.1.100"
+        }
+      ],
+      "cidr": "10.2.1.0/24",
+      "created_at": "2016-12-29T22:56:43",
+      "description": "",
+      "dns_nameservers": [
+        "10.190.0.20"
+      ],
+      "enable_dhcp": true,
+      "gateway_ip": "10.2.1.1",
+      "host_routes": [],
+      "id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "ip_version": 4,
+      "ipv6_address_mode": null,
+      "ipv6_ra_mode": null,
+      "name": "testlab-mgmt-v4-subnet",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "shared": false,
+      "subnetpool_id": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:43"
+    }
+  }
+},{
+  "healthmonitors": [],
+  "l7policies": [],
+  "l7policy_rules": [],
+  "listeners": [
+    {
+      "admin_state_up": true,
+      "connection_limit": -1,
+      "default_pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "default_tls_container_id": null,
+      "description": "",
+      "id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "l7_policies": [],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "name": "listener1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "protocol_port": 80,
+      "provisioning_status": "ACTIVE",
+      "sni_containers": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "loadbalancer": {
+    "admin_state_up": true,
+    "description": "update member to have weight > 1",
+    "gre_vteps": [],
+    "id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+    "listeners": [
+      {
+        "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+      }
+    ],
+    "name": "lb1",
+    "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+    "operating_status": "ONLINE",
+    "pools": [
+      {
+        "id": "75026460-addc-4edc-ba90-50bed675b54a"
+      }
+    ],
+    "provider": "f5networks",
+    "provisioning_status": "PENDING_UPDATE",
+    "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+    "vip_address": "10.2.1.104",
+    "vip_port": {
+      "admin_state_up": true,
+      "allowed_address_pairs": [],
+      "binding:host_id": "host-155.int.lineratesystems.com:e5fe8b6d-ba1f-578c-a2ba-c1306a529179",
+      "binding:profile": {},
+      "binding:vif_details": {},
+      "binding:vif_type": "binding_failed",
+      "binding:vnic_type": "normal",
+      "created_at": "2016-12-30T15:16:53",
+      "description": null,
+      "device_id": "1460cf50-e691-5167-8489-0d56663e906a",
+      "device_owner": "network:f5lbaasv2",
+      "dns_name": null,
+      "extra_dhcp_opts": [],
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.1.104",
+          "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+        }
+      ],
+      "id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+      "mac_address": "fa:16:3e:86:f2:b3",
+      "name": "loadbalancer-85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "security_groups": [
+        "cda7d6ff-99e5-4e82-8d59-f04c5cad0a22"
+      ],
+      "status": "DOWN",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-30T15:16:53"
+    },
+    "vip_port_id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+    "vip_subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+    "vxlan_vteps": [
+      "201.0.155.1",
+      "201.0.156.1",
+      "201.0.154.1",
+      "201.0.153.10"
+    ]
+  },
+  "members": [{
+      "address": "10.2.1.9",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8fa",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "ONLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.9",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "PENDING_UPDATE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 13
+    }
+  ],
+  "networks": {
+    "035acd89-e04c-45b9-8028-1ea610f192e2": {
+      "admin_state_up": true,
+      "availability_zone_hints": [],
+      "availability_zones": [
+        "nova"
+      ],
+      "created_at": "2016-12-29T22:56:41",
+      "description": "",
+      "id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "ipv4_address_scope": null,
+      "ipv6_address_scope": null,
+      "mtu": 1450,
+      "name": "testlab-mgmt-network",
+      "provider:network_type": "vxlan",
+      "provider:physical_network": null,
+      "provider:segmentation_id": 85,
+      "router:external": false,
+      "shared": false,
+      "status": "ACTIVE",
+      "subnets": [
+        "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f",
+        "fe473803-35eb-4587-983f-493753b77f7c"
+      ],
+      "tags": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:41",
+      "vlan_transparent": null
+    }
+  },
+  "pools": [
+    {
+      "admin_state_up": true,
+      "description": "",
+      "healthmonitor_id": "48237b3d-b2e0-4ed4-a8e6-4647cf67bcf2",
+      "id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "l7_policies": [],
+      "lb_algorithm": "SOURCE_IP",
+      "listener_id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "listeners": [
+        {
+          "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+        }
+      ],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "members": [
+        {
+          "id": "4af30627-bddc-42d4-a8f9-2f088082e8ff"
+        }
+      ],
+      "name": "pool1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "provisioning_status": "ACTIVE",
+      "sessionpersistence": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "subnets": {
+    "fe473803-35eb-4587-983f-493753b77f7c": {
+      "allocation_pools": [
+        {
+          "end": "10.2.1.150",
+          "start": "10.2.1.100"
+        }
+      ],
+      "cidr": "10.2.1.0/24",
+      "created_at": "2016-12-29T22:56:43",
+      "description": "",
+      "dns_nameservers": [
+        "10.190.0.20"
+      ],
+      "enable_dhcp": true,
+      "gateway_ip": "10.2.1.1",
+      "host_routes": [],
+      "id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "ip_version": 4,
+      "ipv6_address_mode": null,
+      "ipv6_ra_mode": null,
+      "name": "testlab-mgmt-v4-subnet",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "shared": false,
+      "subnetpool_id": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:43"
+    }
+  }
+},{
+  "healthmonitors": [],
+  "l7policies": [],
+  "l7policy_rules": [],
+  "listeners": [
+    {
+      "admin_state_up": true,
+      "connection_limit": -1,
+      "default_pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "default_tls_container_id": null,
+      "description": "",
+      "id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "l7_policies": [],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "name": "listener1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "protocol_port": 80,
+      "provisioning_status": "ACTIVE",
+      "sni_containers": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "loadbalancer": {
+    "admin_state_up": true,
+    "description": "delete remaining member",
+    "gre_vteps": [],
+    "id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+    "listeners": [
+      {
+        "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+      }
+    ],
+    "name": "lb1",
+    "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+    "operating_status": "ONLINE",
+    "pools": [
+      {
+        "id": "75026460-addc-4edc-ba90-50bed675b54a"
+      }
+    ],
+    "provider": "f5networks",
+    "provisioning_status": "PENDING_UPDATE",
+    "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+    "vip_address": "10.2.1.104",
+    "vip_port": {
+      "admin_state_up": true,
+      "allowed_address_pairs": [],
+      "binding:host_id": "host-155.int.lineratesystems.com:e5fe8b6d-ba1f-578c-a2ba-c1306a529179",
+      "binding:profile": {},
+      "binding:vif_details": {},
+      "binding:vif_type": "binding_failed",
+      "binding:vnic_type": "normal",
+      "created_at": "2016-12-30T15:16:53",
+      "description": null,
+      "device_id": "1460cf50-e691-5167-8489-0d56663e906a",
+      "device_owner": "network:f5lbaasv2",
+      "dns_name": null,
+      "extra_dhcp_opts": [],
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.1.104",
+          "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+        }
+      ],
+      "id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+      "mac_address": "fa:16:3e:86:f2:b3",
+      "name": "loadbalancer-85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "security_groups": [
+        "cda7d6ff-99e5-4e82-8d59-f04c5cad0a22"
+      ],
+      "status": "DOWN",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-30T15:16:53"
+    },
+    "vip_port_id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+    "vip_subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+    "vxlan_vteps": [
+      "201.0.155.1",
+      "201.0.156.1",
+      "201.0.154.1",
+      "201.0.153.10"
+    ]
+  },
+  "members": [{
+      "address": "10.2.1.9",
+      "admin_state_up": true,
+      "gre_vteps": [],
+      "id": "4af30627-bddc-42d4-a8f9-2f088082e8fa",
+      "name": "",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "operating_status": "ONLINE",
+      "pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "port": {
+        "admin_state_up": true,
+        "allowed_address_pairs": [],
+        "binding:host_id": "host-153.int.lineratesystems.com",
+        "binding:profile": {},
+        "binding:vif_details": {
+          "ovs_hybrid_plug": true,
+          "port_filter": true
+        },
+        "binding:vif_type": "ovs",
+        "binding:vnic_type": "normal",
+        "created_at": "2016-12-29T22:56:50",
+        "description": "",
+        "device_id": "25412738-3d52-4eea-aa61-90d1fea3aff0",
+        "device_owner": "compute:None",
+        "dns_name": "client",
+        "extra_dhcp_opts": [],
+        "fixed_ips": [
+          {
+            "ip_address": "10.2.1.9",
+            "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+          },
+          {
+            "ip_address": "2001:f5:cafe:f5::2",
+            "subnet_id": "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f"
+          }
+        ],
+        "id": "04637731-215f-454d-817e-fa9eb2ab3495",
+        "mac_address": "fa:16:3e:1a:a3:fa",
+        "name": "client-mgmt-port",
+        "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+        "security_groups": [
+          "62b00abc-c160-4ef0-a4ae-5e63086478b0"
+        ],
+        "status": "ACTIVE",
+        "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+        "updated_at": "2016-12-29T22:58:23"
+      },
+      "protocol_port": 8080,
+      "provisioning_status": "PENDING_DELETE",
+      "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "vxlan_vteps": [
+        "201.0.154.1"
+      ],
+      "weight": 13
+    }],
+  "networks": {
+    "035acd89-e04c-45b9-8028-1ea610f192e2": {
+      "admin_state_up": true,
+      "availability_zone_hints": [],
+      "availability_zones": [
+        "nova"
+      ],
+      "created_at": "2016-12-29T22:56:41",
+      "description": "",
+      "id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "ipv4_address_scope": null,
+      "ipv6_address_scope": null,
+      "mtu": 1450,
+      "name": "testlab-mgmt-network",
+      "provider:network_type": "vxlan",
+      "provider:physical_network": null,
+      "provider:segmentation_id": 85,
+      "router:external": false,
+      "shared": false,
+      "status": "ACTIVE",
+      "subnets": [
+        "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f",
+        "fe473803-35eb-4587-983f-493753b77f7c"
+      ],
+      "tags": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:41",
+      "vlan_transparent": null
+    }
+  },
+  "pools": [
+    {
+      "admin_state_up": true,
+      "description": "",
+      "healthmonitor_id": "48237b3d-b2e0-4ed4-a8e6-4647cf67bcf2",
+      "id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "l7_policies": [],
+      "lb_algorithm": "SOURCE_IP",
+      "listener_id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "listeners": [
+        {
+          "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+        }
+      ],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "members": [
+        {
+          "id": "4af30627-bddc-42d4-a8f9-2f088082e8ff"
+        }
+      ],
+      "name": "pool1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "provisioning_status": "ACTIVE",
+      "sessionpersistence": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "subnets": {
+    "fe473803-35eb-4587-983f-493753b77f7c": {
+      "allocation_pools": [
+        {
+          "end": "10.2.1.150",
+          "start": "10.2.1.100"
+        }
+      ],
+      "cidr": "10.2.1.0/24",
+      "created_at": "2016-12-29T22:56:43",
+      "description": "",
+      "dns_nameservers": [
+        "10.190.0.20"
+      ],
+      "enable_dhcp": true,
+      "gateway_ip": "10.2.1.1",
+      "host_routes": [],
+      "id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "ip_version": 4,
+      "ipv6_address_mode": null,
+      "ipv6_ra_mode": null,
+      "name": "testlab-mgmt-v4-subnet",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "shared": false,
+      "subnetpool_id": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:43"
+    }
+  }
+},{
+  "healthmonitors": [],
+  "l7policies": [],
+  "l7policy_rules": [],
+  "listeners": [
+    {
+      "admin_state_up": true,
+      "connection_limit": -1,
+      "default_pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "default_tls_container_id": null,
+      "description": "",
+      "id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "l7_policies": [],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "name": "listener1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "protocol_port": 80,
+      "provisioning_status": "ACTIVE",
+      "sni_containers": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }
+  ],
+  "loadbalancer": {
+    "admin_state_up": true,
+    "description": "delete pool",
+    "gre_vteps": [],
+    "id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+    "listeners": [
+      {
+        "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+      }
+    ],
+    "name": "lb1",
+    "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+    "operating_status": "ONLINE",
+    "pools": [],
+    "provider": "f5networks",
+    "provisioning_status": "PENDING_UPDATE",
+    "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+    "vip_address": "10.2.1.104",
+    "vip_port": {
+      "admin_state_up": true,
+      "allowed_address_pairs": [],
+      "binding:host_id": "host-155.int.lineratesystems.com:e5fe8b6d-ba1f-578c-a2ba-c1306a529179",
+      "binding:profile": {},
+      "binding:vif_details": {},
+      "binding:vif_type": "binding_failed",
+      "binding:vnic_type": "normal",
+      "created_at": "2016-12-30T15:16:53",
+      "description": null,
+      "device_id": "1460cf50-e691-5167-8489-0d56663e906a",
+      "device_owner": "network:f5lbaasv2",
+      "dns_name": null,
+      "extra_dhcp_opts": [],
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.1.104",
+          "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+        }
+      ],
+      "id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+      "mac_address": "fa:16:3e:86:f2:b3",
+      "name": "loadbalancer-85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "security_groups": [
+        "cda7d6ff-99e5-4e82-8d59-f04c5cad0a22"
+      ],
+      "status": "DOWN",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-30T15:16:53"
+    },
+    "vip_port_id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+    "vip_subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+    "vxlan_vteps": [
+      "201.0.155.1",
+      "201.0.156.1",
+      "201.0.154.1",
+      "201.0.153.10"
+    ]
+  },
+  "members": [],
+  "networks": {
+    "035acd89-e04c-45b9-8028-1ea610f192e2": {
+      "admin_state_up": true,
+      "availability_zone_hints": [],
+      "availability_zones": [
+        "nova"
+      ],
+      "created_at": "2016-12-29T22:56:41",
+      "description": "",
+      "id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "ipv4_address_scope": null,
+      "ipv6_address_scope": null,
+      "mtu": 1450,
+      "name": "testlab-mgmt-network",
+      "provider:network_type": "vxlan",
+      "provider:physical_network": null,
+      "provider:segmentation_id": 85,
+      "router:external": false,
+      "shared": false,
+      "status": "ACTIVE",
+      "subnets": [
+        "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f",
+        "fe473803-35eb-4587-983f-493753b77f7c"
+      ],
+      "tags": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:41",
+      "vlan_transparent": null
+    }
+  },
+  "pools": [{
+      "admin_state_up": true,
+      "description": "",
+      "healthmonitor_id": "48237b3d-b2e0-4ed4-a8e6-4647cf67bcf2",
+      "id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "l7_policies": [],
+      "lb_algorithm": "SOURCE_IP",
+      "listener_id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "listeners": [
+        {
+          "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+        }
+      ],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "members": [
+        {
+          "id": "4af30627-bddc-42d4-a8f9-2f088082e8ff"
+        }
+      ],
+      "name": "pool1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "provisioning_status": "PENDING_DELETE",
+      "sessionpersistence": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }],
+  "subnets": {
+    "fe473803-35eb-4587-983f-493753b77f7c": {
+      "allocation_pools": [
+        {
+          "end": "10.2.1.150",
+          "start": "10.2.1.100"
+        }
+      ],
+      "cidr": "10.2.1.0/24",
+      "created_at": "2016-12-29T22:56:43",
+      "description": "",
+      "dns_nameservers": [
+        "10.190.0.20"
+      ],
+      "enable_dhcp": true,
+      "gateway_ip": "10.2.1.1",
+      "host_routes": [],
+      "id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "ip_version": 4,
+      "ipv6_address_mode": null,
+      "ipv6_ra_mode": null,
+      "name": "testlab-mgmt-v4-subnet",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "shared": false,
+      "subnetpool_id": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:43"
+    }
+  }
+},{
+  "healthmonitors": [],
+  "l7policies": [],
+  "l7policy_rules": [],
+  "listeners": [{
+      "admin_state_up": true,
+      "connection_limit": -1,
+      "default_pool_id": "75026460-addc-4edc-ba90-50bed675b54a",
+      "default_tls_container_id": null,
+      "description": "",
+      "id": "0acc59ab-b54b-4176-813b-c4643e115b28",
+      "l7_policies": [],
+      "loadbalancer_id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "name": "listener1",
+      "operating_status": "ONLINE",
+      "protocol": "HTTP",
+      "protocol_port": 80,
+      "provisioning_status": "PENDING_DELETE",
+      "sni_containers": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a"
+    }],
+  "loadbalancer": {
+    "admin_state_up": true,
+    "description": "delete listener",
+    "gre_vteps": [],
+    "id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+    "listeners": [
+      {
+        "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+      }
+    ],
+    "name": "lb1",
+    "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+    "operating_status": "ONLINE",
+    "pools": [],
+    "provider": "f5networks",
+    "provisioning_status": "PENDING_UPDATE",
+    "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+    "vip_address": "10.2.1.104",
+    "vip_port": {
+      "admin_state_up": true,
+      "allowed_address_pairs": [],
+      "binding:host_id": "host-155.int.lineratesystems.com:e5fe8b6d-ba1f-578c-a2ba-c1306a529179",
+      "binding:profile": {},
+      "binding:vif_details": {},
+      "binding:vif_type": "binding_failed",
+      "binding:vnic_type": "normal",
+      "created_at": "2016-12-30T15:16:53",
+      "description": null,
+      "device_id": "1460cf50-e691-5167-8489-0d56663e906a",
+      "device_owner": "network:f5lbaasv2",
+      "dns_name": null,
+      "extra_dhcp_opts": [],
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.1.104",
+          "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+        }
+      ],
+      "id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+      "mac_address": "fa:16:3e:86:f2:b3",
+      "name": "loadbalancer-85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "security_groups": [
+        "cda7d6ff-99e5-4e82-8d59-f04c5cad0a22"
+      ],
+      "status": "DOWN",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-30T15:16:53"
+    },
+    "vip_port_id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+    "vip_subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+    "vxlan_vteps": [
+      "201.0.155.1",
+      "201.0.156.1",
+      "201.0.154.1",
+      "201.0.153.10"
+    ]
+  },
+  "members": [],
+  "networks": {
+    "035acd89-e04c-45b9-8028-1ea610f192e2": {
+      "admin_state_up": true,
+      "availability_zone_hints": [],
+      "availability_zones": [
+        "nova"
+      ],
+      "created_at": "2016-12-29T22:56:41",
+      "description": "",
+      "id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "ipv4_address_scope": null,
+      "ipv6_address_scope": null,
+      "mtu": 1450,
+      "name": "testlab-mgmt-network",
+      "provider:network_type": "vxlan",
+      "provider:physical_network": null,
+      "provider:segmentation_id": 85,
+      "router:external": false,
+      "shared": false,
+      "status": "ACTIVE",
+      "subnets": [
+        "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f",
+        "fe473803-35eb-4587-983f-493753b77f7c"
+      ],
+      "tags": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:41",
+      "vlan_transparent": null
+    }
+  },
+  "pools": [],
+  "subnets": {
+    "fe473803-35eb-4587-983f-493753b77f7c": {
+      "allocation_pools": [
+        {
+          "end": "10.2.1.150",
+          "start": "10.2.1.100"
+        }
+      ],
+      "cidr": "10.2.1.0/24",
+      "created_at": "2016-12-29T22:56:43",
+      "description": "",
+      "dns_nameservers": [
+        "10.190.0.20"
+      ],
+      "enable_dhcp": true,
+      "gateway_ip": "10.2.1.1",
+      "host_routes": [],
+      "id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "ip_version": 4,
+      "ipv6_address_mode": null,
+      "ipv6_ra_mode": null,
+      "name": "testlab-mgmt-v4-subnet",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "shared": false,
+      "subnetpool_id": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:43"
+    }
+  }
+},{
+  "healthmonitors": [],
+  "l7policies": [],
+  "l7policy_rules": [],
+  "listeners": [],
+  "loadbalancer": {
+    "admin_state_up": true,
+    "description": "delete lb",
+    "gre_vteps": [],
+    "id": "85cd8749-87eb-4d28-b6a5-c613667c11eb",
+    "listeners": [
+      {
+        "id": "0acc59ab-b54b-4176-813b-c4643e115b28"
+      }
+    ],
+    "name": "lb1",
+    "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+    "operating_status": "ONLINE",
+    "pools": [],
+    "provider": "f5networks",
+    "provisioning_status": "PENDING_DELETE",
+    "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+    "vip_address": "10.2.1.104",
+    "vip_port": {
+      "admin_state_up": true,
+      "allowed_address_pairs": [],
+      "binding:host_id": "host-155.int.lineratesystems.com:e5fe8b6d-ba1f-578c-a2ba-c1306a529179",
+      "binding:profile": {},
+      "binding:vif_details": {},
+      "binding:vif_type": "binding_failed",
+      "binding:vnic_type": "normal",
+      "created_at": "2016-12-30T15:16:53",
+      "description": null,
+      "device_id": "1460cf50-e691-5167-8489-0d56663e906a",
+      "device_owner": "network:f5lbaasv2",
+      "dns_name": null,
+      "extra_dhcp_opts": [],
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.1.104",
+          "subnet_id": "fe473803-35eb-4587-983f-493753b77f7c"
+        }
+      ],
+      "id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+      "mac_address": "fa:16:3e:86:f2:b3",
+      "name": "loadbalancer-85cd8749-87eb-4d28-b6a5-c613667c11eb",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "security_groups": [
+        "cda7d6ff-99e5-4e82-8d59-f04c5cad0a22"
+      ],
+      "status": "DOWN",
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-30T15:16:53"
+    },
+    "vip_port_id": "ba4f535e-72ca-409b-ba1a-76bd386dee7b",
+    "vip_subnet_id": "fe473803-35eb-4587-983f-493753b77f7c",
+    "vxlan_vteps": [
+      "201.0.155.1",
+      "201.0.156.1",
+      "201.0.154.1",
+      "201.0.153.10"
+    ]
+  },
+  "members": [],
+  "networks": {
+    "035acd89-e04c-45b9-8028-1ea610f192e2": {
+      "admin_state_up": true,
+      "availability_zone_hints": [],
+      "availability_zones": [
+        "nova"
+      ],
+      "created_at": "2016-12-29T22:56:41",
+      "description": "",
+      "id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "ipv4_address_scope": null,
+      "ipv6_address_scope": null,
+      "mtu": 1450,
+      "name": "testlab-mgmt-network",
+      "provider:network_type": "vxlan",
+      "provider:physical_network": null,
+      "provider:segmentation_id": 85,
+      "router:external": false,
+      "shared": false,
+      "status": "ACTIVE",
+      "subnets": [
+        "2927a04c-a253-4ab3-aab1-4d85ac7f6b6f",
+        "fe473803-35eb-4587-983f-493753b77f7c"
+      ],
+      "tags": [],
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:41",
+      "vlan_transparent": null
+    }
+  },
+  "pools": [],
+  "subnets": {
+    "fe473803-35eb-4587-983f-493753b77f7c": {
+      "allocation_pools": [
+        {
+          "end": "10.2.1.150",
+          "start": "10.2.1.100"
+        }
+      ],
+      "cidr": "10.2.1.0/24",
+      "created_at": "2016-12-29T22:56:43",
+      "description": "",
+      "dns_nameservers": [
+        "10.190.0.20"
+      ],
+      "enable_dhcp": true,
+      "gateway_ip": "10.2.1.1",
+      "host_routes": [],
+      "id": "fe473803-35eb-4587-983f-493753b77f7c",
+      "ip_version": 4,
+      "ipv6_address_mode": null,
+      "ipv6_ra_mode": null,
+      "name": "testlab-mgmt-v4-subnet",
+      "network_id": "035acd89-e04c-45b9-8028-1ea610f192e2",
+      "shared": false,
+      "subnetpool_id": null,
+      "tenant_id": "980e3f914f3e40359c3c2d9470fb2e8a",
+      "updated_at": "2016-12-29T22:56:43"
+    }
+  }
+}]


### PR DESCRIPTION
@jlongstaf 

#### What issues does this address?
Fixes #659 

#### What's this change do?
Modified the service_adapter to set the pool's lb algorithm when it sees
a member specified with a weight. The lb method is changed to
'ratio-member' when the lb method is ROUND_ROBIN and a member has a
weight specified. The lb method is changed to
'ratio-least-connections-member' if the lb method is LEAST_CONNECTIONS
and a member has specified a weight. If SOURCE_IP is the lb method, no
change is made regardless of a member having a weight or not.

#### Where should the reviewer start?

#### Any background context?
Creating pool members with weights does not change the pool's lb-method
from round robin to ratio. The lb-method for pools with weighted members
should be changed to ratio. Weights (ratios) for members are correctly
set, but the pool lb-method is not changed. Note that OpenStack LBaaS
does not have a ratio lb-alogrithm, but the agent should ignore the
lb-algorithm setting when a member weight is specified.

Created a set of unit tests for the service_adapter changes, and some
neutronless tests for the functional testing of the lb method change on
a pool. The functional tests do not run currently in nightly, but they
do pass. I have created a JIRA story to track adding these and other
similar tests to the nightly tests.