### PR TITLE
Activate neutronless tests except vcmp

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -33,7 +33,7 @@
 #     the states "overcloud" and "undercloud", therefore elements of DEPLOYS
 #     look like the following: '12_1_1_overcloud' '11_5_4_undercloud'.
 # 
-DEVICES := 11_5_4 11_6_0 11_6_1 12_1_1
+DEVICES := 12_1_1
 DEPLOYS := $(foreach v, $(DEVICES), $(v)-overcloud $(v)-undercloud)
 
 # Tell make that targets don't map to files
@@ -44,8 +44,12 @@ DEPLOYS := $(foreach v, $(DEVICES), $(v)-overcloud $(v)-undercloud)
         singlebigip \
         setup_singlebigip_tests \
         run_singlebigip_tests \
-        cleanup_singelbigip \
+        cleanup_singlebigip \
         run_disconnected_service_tests \
+        run_neutronless_loadbalancer_tests \
+        run_neutronless_listener_tests \
+        run_neutronless_member_tests \
+        run_neutronless_pool_tests \
         clean
 
 # Don't launch seperate shell proceses on new recipe lines.
@@ -133,22 +137,62 @@ run_overcloud_tests:
 #    against all tested DEPLOYS.
 #    NOTE: GUMBALLS PROJECTS are complete here, e.g.:
 #    singlebigip_f5-openstack-agent_liberty-12_1_1-overcloud
+setup_singlebigip_tests:
+	@echo executing $@
+	echo running testenv create with stack name $${!DEVICEVERSION} &&
+	testenv --debug create --name $${!DEVICEVERSION} \
+	        --config $${TESTENV_CONF} \
+	        --params bigip_img:$${!DEVICEVERSION} &> $(TESTENVLOGDIR)/$@_$${OSTACK_NAME}.log
+
 singlebigip:
 	@echo executing $@
 	export TESTENV_CONF=bigip.testenv.yaml
 	export GP_SUFFIX=$@_$${GP_SUFFIX} &&
 	export GUMBALLS_PROJECT=$(RESULTS_DIR)/$${GP_SUFFIX} &&
-	$(MAKE) -C . setup_singlebigip_tests &&
-	$(MAKE) -C . run_singlebigip_tests || \
-	$(MAKE) -C . run_disconnected_service_tests || \
+	$(MAKE) -C . setup_singlebigip_tests &&\
+	$(MAKE) -C . run_neutronless_loadbalancer_tests ;\
+	$(MAKE) -C . run_neutronless_listener_tests ;\
+	$(MAKE) -C . run_neutronless_member_tests ;\
+	$(MAKE) -C . run_neutronless_pool_tests ;\
+	$(MAKE) -C . run_disconnected_service_tests ;\
+	$(MAKE) -C . run_singlebigip_tests ;\
 	$(MAKE) -C . cleanup_singlebigip
 
-setup_singlebigip_tests: 
+run_neutronless_loadbalancer_tests:
 	@echo executing $@
-	echo running testenv create with stack name $${OSTACK_NAME} &&
-	testenv --debug create --name $${OSTACK_NAME} \
-	        --config $${TESTENV_CONF} \
-	        --params bigip_img:$${!DEVICEVERSION} &> $(TESTENVLOGDIR)/$@_$${OSTACK_NAME}.log
+	tox -e singlebigip --sitepackage -- \
+	    --cov $(PROJDIR)/f5_openstack_agent \
+		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
+		--autolog-outputdir $${GUMBALLS_PROJECT} \
+		--autolog-session $${GUMBALLS_SESSION} \
+	    ../test/functional/neutronless/loadbalancer/
+
+run_neutronless_listener_tests:
+	@echo executing $@
+	tox -e singlebigip --sitepackage -- \
+	    --cov $(PROJDIR)/f5_openstack_agent \
+		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
+		--autolog-outputdir $${GUMBALLS_PROJECT} \
+		--autolog-session $${GUMBALLS_SESSION} \
+	    ../test/functional/neutronless/listener/
+
+run_neutronless_member_tests:
+	@echo executing $@
+	tox -e singlebigip --sitepackage -- \
+	    --cov $(PROJDIR)/f5_openstack_agent \
+		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
+		--autolog-outputdir $${GUMBALLS_PROJECT} \
+		--autolog-session $${GUMBALLS_SESSION} \
+	    ../test/functional/neutronless/member/
+
+run_neutronless_pool_tests:
+	@echo executing $@
+	tox -e singlebigip --sitepackage -- \
+	    --cov $(PROJDIR)/f5_openstack_agent \
+		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
+		--autolog-outputdir $${GUMBALLS_PROJECT} \
+		--autolog-session $${GUMBALLS_SESSION} \
+	    ../test/functional/neutronless/pool/
 
 run_singlebigip_tests: 
 	@echo executing $@

--- a/test/functional/neutronless/conftest.py
+++ b/test/functional/neutronless/conftest.py
@@ -79,6 +79,8 @@ def icd_config():
     config['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
     config['icontrol_username'] = pytest.symbols.bigip_username
     config['icontrol_password'] = pytest.symbols.bigip_password
-    config['f5_vtep_selfip_name'] = pytest.symbols.f5_vtep_selfip_name
-
+    try:
+        config['f5_vtep_selfip_name'] = pytest.symbols.f5_vtep_selfip_name
+    except AttributeError:
+        config['f5_vtep_selfip_name'] = "selfip.external"
     return config

--- a/test/functional/neutronless/listener/test_listener_update.py
+++ b/test/functional/neutronless/listener/test_listener_update.py
@@ -38,24 +38,6 @@ def services():
     return (json.load(open(neutron_services_filename)))
 
 
-@pytest.fixture()
-def icd_config():
-    oslo_config_filename = (
-        os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                     '../../config/basic_agent_config.json')
-    )
-    OSLO_CONFIGS = json.load(open(oslo_config_filename))
-
-    config = deepcopy(OSLO_CONFIGS)
-    config['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
-    config['icontrol_username'] = pytest.symbols.bigip_username
-    config['icontrol_password'] = pytest.symbols.bigip_password
-    config['f5_vtep_selfip_name'] = pytest.symbols.f5_vtep_selfip_name
-    config['environment_prefix'] = 'Project'
-
-    return config
-
-
 def get_next_listener(service_iterator, icontrol_driver, bigip, env_prefix):
 
     service = service_iterator.next()
@@ -78,7 +60,7 @@ def test_listener_update(
         icd_config,
         icontrol_driver):
 
-    env_prefix = icd_config['environment_prefix']
+    env_prefix = 'Project'
     service_iter = iter(services)
 
     # Create loadbalancer

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer.py
@@ -40,23 +40,6 @@ def services():
     return (json.load(open(neutron_services_filename)))
 
 
-@pytest.fixture(scope="module")
-def icd_config():
-    oslo_config_filename = (
-        os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                     '../../config/basic_agent_config.json')
-    )
-    OSLO_CONFIGS = json.load(open(oslo_config_filename))
-
-    config = deepcopy(OSLO_CONFIGS)
-    config['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
-    config['icontrol_username'] = pytest.symbols.bigip_username
-    config['icontrol_password'] = pytest.symbols.bigip_password
-    config['f5_vtep_selfip_name'] = pytest.symbols.f5_vtep_selfip_name
-
-    return config
-
-
 def test_create_delete_basic_lb(bigip, services, icd_config, icontrol_driver):
 
     service_iter = iter(services)
@@ -64,7 +47,7 @@ def test_create_delete_basic_lb(bigip, services, icd_config, icontrol_driver):
     lb_reader = LoadbalancerReader(service)
     env_prefix = icd_config['environment_prefix']
     fake_rpc = icontrol_driver.plugin_rpc
-    hostname = pytest.symbols.bigip_hostname
+    hostname = pytest.symbols.bigip_mgmt_ip_public
 
     folder = '%s_%s' % (env_prefix, lb_reader.tenant_id())
 
@@ -169,7 +152,7 @@ def test_create_delete_basic_lb_nodisconnected(bigip, services, icd_config, icon
     lb_reader = LoadbalancerReader(service)
     env_prefix = icd_config['environment_prefix']
     fake_rpc = icontrol_driver.plugin_rpc
-    hostname = pytest.symbols.bigip_hostname
+    hostname = pytest.symbols.bigip_mgmt_ip_public
     icd_config['f5_network_segment_physical_network'] = None
 
     folder = '%s_%s' % (env_prefix, lb_reader.tenant_id())

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer_disconnected.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer_disconnected.py
@@ -47,22 +47,6 @@ def disconnected_service_no_seg():
     )
     return (json.load(open(neutron_services_filename)))
 
-@pytest.fixture(scope="module")
-def icd_config():
-    oslo_config_filename = (
-        os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                     '../../config/basic_agent_config.json')
-    )
-    OSLO_CONFIGS = json.load(open(oslo_config_filename))
-
-    config = deepcopy(OSLO_CONFIGS)
-    config['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
-    config['icontrol_username'] = pytest.symbols.bigip_username
-    config['icontrol_password'] = pytest.symbols.bigip_password
-    config['f5_vtep_selfip_name'] = pytest.symbols.f5_vtep_selfip_name
-
-    return config
-
 
 def test_featureoff_nosegid_lb(bigip, disconnected_service_no_seg,
                                icd_config, icontrol_driver):
@@ -72,7 +56,7 @@ def test_featureoff_nosegid_lb(bigip, disconnected_service_no_seg,
     lb_reader = LoadbalancerReader(service)
     env_prefix = icd_config['environment_prefix']
     fake_rpc = icontrol_driver.plugin_rpc
-    hostname = pytest.symbols.bigip_hostname
+    hostname = pytest.symbols.bigip_mgmt_ip_public
     icd_config['f5_network_segment_physical_network'] = None
 
     folder = '%s_%s' % (env_prefix, lb_reader.tenant_id())
@@ -138,7 +122,7 @@ def test_featureon_nosegid_to_segid_lb(bigip, services, icd_config, icontrol_dri
     lb_reader = LoadbalancerReader(service)
     env_prefix = icd_config['environment_prefix']
     fake_rpc = icontrol_driver.plugin_rpc
-    hostname = pytest.symbols.bigip_hostname
+    hostname = pytest.symbols.bigip_mgmt_ip_public
     icd_config['f5_network_segment_physical_network'] = \
         "physnet1"
 

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer_opflex.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer_opflex.py
@@ -40,23 +40,6 @@ def services():
     return (json.load(open(neutron_services_filename)))
 
 
-@pytest.fixture(scope="module")
-def icd_config():
-    oslo_config_filename = (
-        os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                     '../../config/basic_agent_config.json')
-    )
-    OSLO_CONFIGS = json.load(open(oslo_config_filename))
-
-    config = deepcopy(OSLO_CONFIGS)
-    config['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
-    config['icontrol_username'] = pytest.symbols.bigip_username
-    config['icontrol_password'] = pytest.symbols.bigip_password
-    config['f5_vtep_selfip_name'] = pytest.symbols.f5_vtep_selfip_name
-
-    return config
-
-
 def test_create_delete_basic_lb(bigip, services, icd_config, icontrol_driver):
 
     service_iter = iter(services)
@@ -64,7 +47,7 @@ def test_create_delete_basic_lb(bigip, services, icd_config, icontrol_driver):
     lb_reader = LoadbalancerReader(service)
     env_prefix = icd_config['environment_prefix']
     fake_rpc = icontrol_driver.plugin_rpc
-    hostname = pytest.symbols.bigip_hostname
+    hostname = pytest.symbols.bigip_mgmt_ip_public
 
     folder = '%s_%s' % (env_prefix, lb_reader.tenant_id())
 
@@ -166,7 +149,7 @@ def test_featureoff_create_delete_basic_lb(bigip, services, icd_config, icontrol
     lb_reader = LoadbalancerReader(service)
     env_prefix = icd_config['environment_prefix']
     fake_rpc = icontrol_driver.plugin_rpc
-    hostname = pytest.symbols.bigip_hostname
+    hostname = pytest.symbols.bigip_mgmt_ip_public
     icd_config['f5_network_segment_physical_network'] = None
 
     folder = '%s_%s' % (env_prefix, lb_reader.tenant_id())

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer_rd.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer_rd.py
@@ -64,7 +64,7 @@ def my_test_create_delete_basic_lb_no_namespace(bigip, services, icd_config, ico
     lb_reader = LoadbalancerReader(service)
     env_prefix = icd_config['environment_prefix']
     fake_rpc = icontrol_driver.plugin_rpc
-    hostname = pytest.symbols.bigip_hostname
+    hostname = pytest.symbols.bigip_mgmt_ip_public
     icd_config['use_namespaces'] = False
 
     folder = '%s_%s' % (env_prefix, lb_reader.tenant_id())

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer_snat.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer_snat.py
@@ -40,23 +40,6 @@ def services():
     return (json.load(open(neutron_services_filename)))
 
 
-@pytest.fixture(scope="module")
-def icd_config():
-    oslo_config_filename = (
-        os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                     '../../config/basic_agent_config.json')
-    )
-    OSLO_CONFIGS = json.load(open(oslo_config_filename))
-
-    config = deepcopy(OSLO_CONFIGS)
-    config['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
-    config['icontrol_username'] = pytest.symbols.bigip_username
-    config['icontrol_password'] = pytest.symbols.bigip_password
-    config['f5_vtep_selfip_name'] = pytest.symbols.f5_vtep_selfip_name
-
-    return config
-
-
 def test_create_delete_lb_autosnat(bigip, services, icd_config, icontrol_driver):
 
     service_iter = iter(services)
@@ -64,7 +47,7 @@ def test_create_delete_lb_autosnat(bigip, services, icd_config, icontrol_driver)
     lb_reader = LoadbalancerReader(service)
     env_prefix = icd_config['environment_prefix']
     fake_rpc = icontrol_driver.plugin_rpc
-    hostname = pytest.symbols.bigip_hostname
+    hostname = pytest.symbols.bigip_mgmt_ip_public
 
     # Change the configuration so that Auto SNAT is used.
     icd_config['f5_snat_addresses_per_subnet'] = 0
@@ -154,7 +137,7 @@ def test_create_delete_lb_multisnat(bigip, services, icd_config, icontrol_driver
     fake_rpc = icontrol_driver.plugin_rpc
     icd_config['f5_snat_addresses_per_subnet'] = 5
     folder = '%s_%s' % (env_prefix, lb_reader.tenant_id())
-    hostname = pytest.symbols.bigip_hostname
+    hostname = pytest.symbols.bigip_mgmt_ip_public
 
     # Make sure we are starting clean.
     assert not bigip.folder_exists(folder)
@@ -257,7 +240,7 @@ def test_create_delete_lb_snatoff(bigip, services, icd_config, icontrol_driver):
     lb_reader = LoadbalancerReader(service)
     env_prefix = icd_config['environment_prefix']
     fake_rpc = icontrol_driver.plugin_rpc
-    hostname = pytest.symbols.bigip_hostname
+    hostname = pytest.symbols.bigip_mgmt_ip_public
 
     # Change the configuration so that Auto SNAT is used.
     icd_config['f5_snat_mode'] = "false"

--- a/test/functional/neutronless/loadbalancer/test_snat_common_network.py
+++ b/test/functional/neutronless/loadbalancer/test_snat_common_network.py
@@ -41,23 +41,6 @@ def services():
     return (json.load(open(neutron_services_filename)))
 
 
-@pytest.fixture()
-def icd_config():
-    oslo_config_filename = (
-        os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                     '../../config/basic_agent_config.json')
-    )
-    OSLO_CONFIGS = json.load(open(oslo_config_filename))
-
-    config = deepcopy(OSLO_CONFIGS)
-    config['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
-    config['icontrol_username'] = pytest.symbols.bigip_username
-    config['icontrol_password'] = pytest.symbols.bigip_password
-    config['f5_vtep_selfip_name'] = pytest.symbols.f5_vtep_selfip_name
-
-    return config
-
-
 @pytest.fixture(scope="module")
 def bigip():
 

--- a/test/functional/neutronless/member/test_single_member.py
+++ b/test/functional/neutronless/member/test_single_member.py
@@ -61,23 +61,6 @@ def service_create_member_down_up():
     return (json.load(open(neutron_services_filename)))
 
 
-@pytest.fixture()
-def icd_config():
-    oslo_config_filename = (
-        os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                     '../../config/basic_agent_config.json')
-    )
-    OSLO_CONFIGS = json.load(open(oslo_config_filename))
-
-    config = deepcopy(OSLO_CONFIGS)
-    config['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
-    config['icontrol_username'] = pytest.symbols.bigip_username
-    config['icontrol_password'] = pytest.symbols.bigip_password
-    config['f5_vtep_selfip_name'] = pytest.symbols.f5_vtep_selfip_name
-
-    return config
-
-
 def lbaas_service_one_member(request,
                              bigip,
                              services,

--- a/test/functional/neutronless/member/test_single_member_opflex.py
+++ b/test/functional/neutronless/member/test_single_member_opflex.py
@@ -41,23 +41,6 @@ def services():
     return (json.load(open(neutron_services_filename)))
 
 
-@pytest.fixture()
-def icd_config():
-    oslo_config_filename = (
-        os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                     '../../config/basic_agent_config.json')
-    )
-    OSLO_CONFIGS = json.load(open(oslo_config_filename))
-
-    config = deepcopy(OSLO_CONFIGS)
-    config['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
-    config['icontrol_username'] = pytest.symbols.bigip_username
-    config['icontrol_password'] = pytest.symbols.bigip_password
-    config['f5_vtep_selfip_name'] = pytest.symbols.f5_vtep_selfip_name
-
-    return config
-
-
 def test_lbaas_service_one_opflex_member(request,
                                     bigip,
                                     services,

--- a/test/functional/neutronless/member/test_single_member_weight_updates.py
+++ b/test/functional/neutronless/member/test_single_member_weight_updates.py
@@ -76,23 +76,6 @@ def services():
     return (json.load(open(neutron_services_filename)))
 
 
-@pytest.fixture()
-def icd_config():
-    oslo_config_filename = (
-        os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                     '../../config/basic_agent_config.json')
-    )
-    OSLO_CONFIGS = json.load(open(oslo_config_filename))
-
-    config = deepcopy(OSLO_CONFIGS)
-    config['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
-    config['icontrol_username'] = pytest.symbols.bigip_username
-    config['icontrol_password'] = pytest.symbols.bigip_password
-    config['f5_vtep_selfip_name'] = pytest.symbols.f5_vtep_selfip_name
-    config['environment_prefix'] = "Project"
-
-    return config
-
 def get_next_member(service_iterator, icontrol_driver, bigip, env_prefix):
 
     service = service_iterator.next()

--- a/test/functional/neutronless/pool/test_session_persistence.py
+++ b/test/functional/neutronless/pool/test_session_persistence.py
@@ -42,23 +42,6 @@ def services():
     return (json.load(open(neutron_services_filename)))
 
 
-@pytest.fixture()
-def icd_config():
-    oslo_config_filename = (
-        os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                     '../../config/basic_agent_config.json')
-    )
-    OSLO_CONFIGS = json.load(open(oslo_config_filename))
-
-    config = deepcopy(OSLO_CONFIGS)
-    config['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
-    config['icontrol_username'] = pytest.symbols.bigip_username
-    config['icontrol_password'] = pytest.symbols.bigip_password
-    config['f5_vtep_selfip_name'] = pytest.symbols.f5_vtep_selfip_name
-
-    return config
-
-
 @pytest.fixture(scope="module")
 def bigip():
 

--- a/test/functional/neutronless/pool/test_single_pool.py
+++ b/test/functional/neutronless/pool/test_single_pool.py
@@ -41,23 +41,6 @@ def services():
     return (json.load(open(neutron_services_filename)))
 
 
-@pytest.fixture()
-def icd_config():
-    oslo_config_filename = (
-        os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                     '../../config/basic_agent_config.json')
-    )
-    OSLO_CONFIGS = json.load(open(oslo_config_filename))
-
-    config = deepcopy(OSLO_CONFIGS)
-    config['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
-    config['icontrol_username'] = pytest.symbols.bigip_username
-    config['icontrol_password'] = pytest.symbols.bigip_password
-    config['f5_vtep_selfip_name'] = pytest.symbols.f5_vtep_selfip_name
-
-    return config
-
-
 @pytest.fixture(scope="module")
 def bigip():
 


### PR DESCRIPTION
Issues:
Fixes #699

Problem: Many of our tests are not yet incorporated into the automated
build infrastructure.  This change adds 4 types of "neutronless" tests
'member', 'pool', 'loadbalancer', and 'listener'

Analysis:  We delayed incorporation of these tests into the nightly
infrastructure because we are seeking to establish sources of test error.
We are incorporating these tests now, because we are (for the moment)
focusing on the driver tests to establish stability.

Tests:  I ran these tests in a builbot sandbox environment.