### PR TITLE
Reactivate disconnected service tests

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -217,7 +217,7 @@ run_disconnected_service_tests:
 		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
 		--autolog-outputdir $${GUMBALLS_PROJECT} \
 		--autolog-session $${GUMBALLS_SESSION} \
-	    $${RUNTARGETS}
+	    ../test/functional/neutronless/disconnected_service/
 
 cleanup_singlebigip:
 	@echo executing $@


### PR DESCRIPTION
Issues:
Fixes #647

Problem: disconnected service tests were not running

Analysis: The makefile target had a stale path.

Tests: These tests were confirmed to pass in my local bbot sandbox.
I also verified that test results were written in the expected location.
