### PR TITLE
Creating or changing loadbalancer admin state does not change virtual…

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_virtual_address.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_virtual_address.py
@@ -44,7 +44,8 @@ class TestVirtualAddress(object):
                         "tenant_id": "123456789",
                         "id": "loadbalancer_id",
                         "traffic_group": "traffic-group-local-only",
-                        "vip_address": "192.168.100.5"}
+                        "vip_address": "192.168.100.5",
+                        "admin_state_up": True}
 
         return loadbalancer
 
@@ -57,3 +58,4 @@ class TestVirtualAddress(object):
         assert(va.address == "192.168.100.5")
         assert(va.traffic_group == "traffic-group-local-only")
         assert(va.description == "lb1:")
+        assert(va.enabled == "yes")

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/virtual_address.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/virtual_address.py
@@ -47,13 +47,20 @@ class VirtualAddress(object):
 
         self.auto_delete = False
 
+        if loadbalancer.get('admin_state_up', True):
+            self.enabled = 'yes'
+        else:
+            self.enabled = 'no'
+
     def model(self):
         model = {"name": self.name,
                  "partition": self.partition,
                  "address": self.address,
                  "description": self.description,
                  "trafficGroup": self.traffic_group,
-                 "autoDelete": self.auto_delete}
+                 "autoDelete": self.auto_delete,
+                 "enabled": self.enabled}
+
         return model
 
     def create(self, bigip, model=None):

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer_admin_state.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer_admin_state.py
@@ -62,7 +62,7 @@ def test_create_update_lb_state(bigip, services, icd_config, icontrol_driver):
     enabled value.
 
     Also, admin-state-down (no value allowed) is permitted only in create
-    commands. admin-state-up (with True/False values) is permitted only updtae
+    commands. admin-state-up (with True/False values) is permitted only update
     commands.
 
     :param bigip: BIG-IP under test

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer_admin_state.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer_admin_state.py
@@ -1,0 +1,149 @@
+# coding=utf-8
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+from ..testlib.service_reader import LoadbalancerReader
+import json
+import logging
+import os
+import pytest
+import requests
+
+
+from f5_openstack_agent.lbaasv2.drivers.bigip.resource_helper import \
+    ResourceType
+
+requests.packages.urllib3.disable_warnings()
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.fixture
+def services():
+    neutron_services_filename = (
+        os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                     '../../testdata/service_requests/'
+                     'create_update_lb_state.json')
+    )
+    return (json.load(open(neutron_services_filename)))
+
+
+def test_create_update_lb_state(bigip, services, icd_config, icontrol_driver):
+    """Test creating and updating loadbalancer with differing admin states.
+
+    Create loadbalancer using admin-state-down and eval virtual address
+    enabled value.
+
+    Update loadbalancer using admin-state-up and eval virtual address
+    enabled value.
+
+    Create loadbalancer without admin-state-down and eval virtual address
+    enabled value.
+
+    Update loadbalancer using admin-state-up and eval virtual address
+    enabled value.
+
+
+    :param bigip: BIG-IP under test
+    :param services: list of service objects
+    :param icd_config: agent configuration
+    :param icontrol_driver: icontrol driver instance
+    """
+
+    service_iter = iter(services)
+    service = service_iter.next()
+    lb_reader = LoadbalancerReader(service)
+    env_prefix = icd_config['environment_prefix']
+
+    folder = '%s_%s' % (env_prefix, lb_reader.tenant_id())
+
+    # Make sure we are starting clean.
+    assert not bigip.folder_exists(folder)
+
+    # Create loadbalancer, admin_state_down
+    lb_pending = icontrol_driver._common_service_handler(service)
+    assert not lb_pending
+
+    virtual_addr_name = "%s_%s" % (env_prefix, lb_reader.id())
+    assert bigip.resource_exists(ResourceType.virtual_address,
+                                 virtual_addr_name)
+    virtual_addr = bigip.get_resource(ResourceType.virtual_address,
+                                      virtual_addr_name,
+                                      partition=folder)
+    assert virtual_addr.enabled == 'yes'
+
+    # Update loadbalancer, admin_state_up=False
+    service = service_iter.next()
+    lb_pending = icontrol_driver._common_service_handler(service)
+    assert not lb_pending
+    virtual_addr = bigip.get_resource(ResourceType.virtual_address,
+                                      virtual_addr_name,
+                                      partition=folder)
+    assert virtual_addr.enabled == 'no'
+
+    # Update loadbalancer, admin_state_up=True
+    service = service_iter.next()
+    lb_pending = icontrol_driver._common_service_handler(service)
+    assert not lb_pending
+    virtual_addr = bigip.get_resource(ResourceType.virtual_address,
+                                      virtual_addr_name,
+                                      partition=folder)
+    assert virtual_addr.enabled == 'yes'
+
+    # Delete loadbalancer
+    service = service_iter.next()
+    lb_pending = icontrol_driver._common_service_handler(service, delete_partition=True,
+                                                         delete_event=True)
+    assert not lb_pending
+    assert not bigip.resource_exists(ResourceType.virtual_address,
+                                     virtual_addr_name)
+
+    # Create loadbalancer, admin_state_down
+    service = service_iter.next()
+    lb_reader = LoadbalancerReader(service)
+    virtual_addr_name = "%s_%s" % (env_prefix, lb_reader.id())
+    lb_pending = icontrol_driver._common_service_handler(service)
+    assert not lb_pending
+    assert bigip.resource_exists(ResourceType.virtual_address,
+                                 virtual_addr_name)
+    virtual_addr = bigip.get_resource(ResourceType.virtual_address,
+                                      virtual_addr_name,
+                                      partition=folder)
+    assert virtual_addr.enabled == 'no'
+
+    # Update loadbalancer, admin_state_up=True
+    service = service_iter.next()
+    lb_pending = icontrol_driver._common_service_handler(service)
+    assert not lb_pending
+    virtual_addr = bigip.get_resource(ResourceType.virtual_address,
+                                      virtual_addr_name,
+                                      partition=folder)
+    assert virtual_addr.enabled == 'yes'
+
+    # Update loadbalancer, admin_state_up=False
+    service = service_iter.next()
+    lb_pending = icontrol_driver._common_service_handler(service)
+    assert not lb_pending
+    virtual_addr = bigip.get_resource(ResourceType.virtual_address,
+                                      virtual_addr_name,
+                                      partition=folder)
+    assert virtual_addr.enabled == 'no'
+
+    # Delete loadbalancer
+    service = service_iter.next()
+    lb_pending = icontrol_driver._common_service_handler(service, delete_partition=True,
+                                                         delete_event=True)
+    assert not lb_pending
+    assert not bigip.folder_exists(folder)

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer_admin_state.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer_admin_state.py
@@ -43,17 +43,19 @@ def services():
 def test_create_update_lb_state(bigip, services, icd_config, icontrol_driver):
     """Test creating and updating loadbalancer with differing admin states.
 
-    Create loadbalancer using admin-state-down and eval virtual address
-    enabled value.
-
-    Update loadbalancer using admin-state-up and eval virtual address
-    enabled value.
 
     Create loadbalancer without admin-state-down and eval virtual address
     enabled value.
 
     Update loadbalancer using admin-state-up and eval virtual address
     enabled value.
+
+    Create loadbalancer using admin-state-down and eval virtual address
+    enabled value.
+
+    Update loadbalancer using admin-state-up and eval virtual address
+    enabled value.
+
 
     Note: this tests loadbalancer admin_state_up and how those values
     are translated to the BIG-IP virtual address. The vip_port data in the

--- a/test/functional/testdata/service_requests/create_update_lb_state.json
+++ b/test/functional/testdata/service_requests/create_update_lb_state.json
@@ -1,0 +1,961 @@
+[{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "60ac05e5-e35e-499b-bda0-cb56eadd8e75", 
+    "listeners": [], 
+    "name": "lb1", 
+    "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+    "operating_status": "OFFLINE", 
+    "pools": [], 
+    "provider": null, 
+    "provisioning_status": "PENDING_CREATE", 
+    "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+    "vip_address": "10.2.4.111", 
+    "vip_port": {
+      "admin_state_up": false, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "unbound", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-05-24T20:22:52", 
+      "description": null, 
+      "device_id": "60ac05e5-e35e-499b-bda0-cb56eadd8e75", 
+      "device_owner": "neutron:LOADBALANCERV2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.111", 
+          "subnet_id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6"
+        }
+      ], 
+      "id": "eeacc678-4531-4a15-99ed-55e4b3dba8b4", 
+      "mac_address": "fa:16:3e:fa:10:13", 
+      "name": "loadbalancer-60ac05e5-e35e-499b-bda0-cb56eadd8e75", 
+      "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "security_groups": [
+        "b492a432-ed4a-4982-b0a7-2c8da91f6484"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T20:22:52"
+    }, 
+    "vip_port_id": "eeacc678-4531-4a15-99ed-55e4b3dba8b4", 
+    "vip_subnet_id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6", 
+    "vxlan_vteps": [
+      "201.0.145.10", 
+      "201.0.149.1", 
+      "201.0.147.1", 
+      "201.0.146.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-05-24T15:57:02", 
+      "description": "", 
+      "id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 29, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "d0fcc646-24b4-4a9a-9b8b-346245fecac6"
+      ], 
+      "tags": [], 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T15:57:02", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "d0fcc646-24b4-4a9a-9b8b-346245fecac6": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "created_at": "2017-05-24T15:57:05", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T15:57:05"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [], 
+  "loadbalancer": {
+    "admin_state_up": false, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "60ac05e5-e35e-499b-bda0-cb56eadd8e75", 
+    "listeners": [], 
+    "name": "lb1", 
+    "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+    "operating_status": "ONLINE", 
+    "pools": [], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+    "vip_address": "10.2.4.111", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-148.int.lineratesystems.com:09b30cab-8674-526f-9521-865c995db139", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-05-24T20:22:52", 
+      "description": null, 
+      "device_id": "f1b826b5-8c9d-5989-92a5-7e6fd4b039d7", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.111", 
+          "subnet_id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6"
+        }
+      ], 
+      "id": "eeacc678-4531-4a15-99ed-55e4b3dba8b4", 
+      "mac_address": "fa:16:3e:fa:10:13", 
+      "name": "loadbalancer-60ac05e5-e35e-499b-bda0-cb56eadd8e75", 
+      "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "security_groups": [
+        "b492a432-ed4a-4982-b0a7-2c8da91f6484"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T20:22:53"
+    }, 
+    "vip_port_id": "eeacc678-4531-4a15-99ed-55e4b3dba8b4", 
+    "vip_subnet_id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6", 
+    "vxlan_vteps": [
+      "201.0.145.10", 
+      "201.0.149.1", 
+      "201.0.147.1", 
+      "201.0.146.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-05-24T15:57:02", 
+      "description": "", 
+      "id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 29, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "d0fcc646-24b4-4a9a-9b8b-346245fecac6"
+      ], 
+      "tags": [], 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T15:57:02", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "d0fcc646-24b4-4a9a-9b8b-346245fecac6": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "created_at": "2017-05-24T15:57:05", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T15:57:05"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "60ac05e5-e35e-499b-bda0-cb56eadd8e75", 
+    "listeners": [], 
+    "name": "lb1", 
+    "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+    "operating_status": "ONLINE", 
+    "pools": [], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+    "vip_address": "10.2.4.111", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-148.int.lineratesystems.com:09b30cab-8674-526f-9521-865c995db139", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-05-24T20:22:52", 
+      "description": null, 
+      "device_id": "f1b826b5-8c9d-5989-92a5-7e6fd4b039d7", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.111", 
+          "subnet_id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6"
+        }
+      ], 
+      "id": "eeacc678-4531-4a15-99ed-55e4b3dba8b4", 
+      "mac_address": "fa:16:3e:fa:10:13", 
+      "name": "loadbalancer-60ac05e5-e35e-499b-bda0-cb56eadd8e75", 
+      "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "security_groups": [
+        "b492a432-ed4a-4982-b0a7-2c8da91f6484"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T20:22:53"
+    }, 
+    "vip_port_id": "eeacc678-4531-4a15-99ed-55e4b3dba8b4", 
+    "vip_subnet_id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6", 
+    "vxlan_vteps": [
+      "201.0.145.10", 
+      "201.0.149.1", 
+      "201.0.147.1", 
+      "201.0.146.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-05-24T15:57:02", 
+      "description": "", 
+      "id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 29, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "d0fcc646-24b4-4a9a-9b8b-346245fecac6"
+      ], 
+      "tags": [], 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T15:57:02", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "d0fcc646-24b4-4a9a-9b8b-346245fecac6": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "created_at": "2017-05-24T15:57:05", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T15:57:05"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "60ac05e5-e35e-499b-bda0-cb56eadd8e75", 
+    "listeners": [], 
+    "name": "lb1", 
+    "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+    "operating_status": "ONLINE", 
+    "pools": [], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_DELETE", 
+    "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+    "vip_address": "10.2.4.111", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-148.int.lineratesystems.com:09b30cab-8674-526f-9521-865c995db139", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-05-24T20:22:52", 
+      "description": null, 
+      "device_id": "f1b826b5-8c9d-5989-92a5-7e6fd4b039d7", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.111", 
+          "subnet_id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6"
+        }
+      ], 
+      "id": "eeacc678-4531-4a15-99ed-55e4b3dba8b4", 
+      "mac_address": "fa:16:3e:fa:10:13", 
+      "name": "loadbalancer-60ac05e5-e35e-499b-bda0-cb56eadd8e75", 
+      "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "security_groups": [
+        "b492a432-ed4a-4982-b0a7-2c8da91f6484"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T20:22:53"
+    }, 
+    "vip_port_id": "eeacc678-4531-4a15-99ed-55e4b3dba8b4", 
+    "vip_subnet_id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6", 
+    "vxlan_vteps": [
+      "201.0.145.10", 
+      "201.0.149.1", 
+      "201.0.147.1", 
+      "201.0.146.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-05-24T15:57:02", 
+      "description": "", 
+      "id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 29, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "d0fcc646-24b4-4a9a-9b8b-346245fecac6"
+      ], 
+      "tags": [], 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T15:57:02", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "d0fcc646-24b4-4a9a-9b8b-346245fecac6": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "created_at": "2017-05-24T15:57:05", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T15:57:05"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [], 
+  "loadbalancer": {
+    "admin_state_up": false, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8ff41d15-03d0-4449-86b0-e150a5f0827a", 
+    "listeners": [], 
+    "name": "lb1", 
+    "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+    "operating_status": "OFFLINE", 
+    "pools": [], 
+    "provider": null, 
+    "provisioning_status": "PENDING_CREATE", 
+    "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+    "vip_address": "10.2.4.114", 
+    "vip_port": {
+      "admin_state_up": false, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "unbound", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-05-24T20:24:12", 
+      "description": null, 
+      "device_id": "8ff41d15-03d0-4449-86b0-e150a5f0827a", 
+      "device_owner": "neutron:LOADBALANCERV2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.114", 
+          "subnet_id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6"
+        }
+      ], 
+      "id": "80289652-9a77-4e0a-8f33-1a687d41247a", 
+      "mac_address": "fa:16:3e:61:8d:ef", 
+      "name": "loadbalancer-8ff41d15-03d0-4449-86b0-e150a5f0827a", 
+      "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "security_groups": [
+        "b492a432-ed4a-4982-b0a7-2c8da91f6484"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T20:24:12"
+    }, 
+    "vip_port_id": "80289652-9a77-4e0a-8f33-1a687d41247a", 
+    "vip_subnet_id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6", 
+    "vxlan_vteps": [
+      "201.0.145.10", 
+      "201.0.149.1", 
+      "201.0.147.1", 
+      "201.0.146.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-05-24T15:57:02", 
+      "description": "", 
+      "id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 29, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "d0fcc646-24b4-4a9a-9b8b-346245fecac6"
+      ], 
+      "tags": [], 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T15:57:02", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "d0fcc646-24b4-4a9a-9b8b-346245fecac6": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "created_at": "2017-05-24T15:57:05", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T15:57:05"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8ff41d15-03d0-4449-86b0-e150a5f0827a", 
+    "listeners": [], 
+    "name": "lb1", 
+    "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+    "operating_status": "ONLINE", 
+    "pools": [], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+    "vip_address": "10.2.4.114", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-148.int.lineratesystems.com:09b30cab-8674-526f-9521-865c995db139", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-05-24T20:24:12", 
+      "description": null, 
+      "device_id": "f1b826b5-8c9d-5989-92a5-7e6fd4b039d7", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.114", 
+          "subnet_id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6"
+        }
+      ], 
+      "id": "80289652-9a77-4e0a-8f33-1a687d41247a", 
+      "mac_address": "fa:16:3e:61:8d:ef", 
+      "name": "loadbalancer-8ff41d15-03d0-4449-86b0-e150a5f0827a", 
+      "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "security_groups": [
+        "b492a432-ed4a-4982-b0a7-2c8da91f6484"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T20:24:13"
+    }, 
+    "vip_port_id": "80289652-9a77-4e0a-8f33-1a687d41247a", 
+    "vip_subnet_id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6", 
+    "vxlan_vteps": [
+      "201.0.145.10", 
+      "201.0.149.1", 
+      "201.0.147.1", 
+      "201.0.146.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-05-24T15:57:02", 
+      "description": "", 
+      "id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 29, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "d0fcc646-24b4-4a9a-9b8b-346245fecac6"
+      ], 
+      "tags": [], 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T15:57:02", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "d0fcc646-24b4-4a9a-9b8b-346245fecac6": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "created_at": "2017-05-24T15:57:05", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T15:57:05"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [], 
+  "loadbalancer": {
+    "admin_state_up": false, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8ff41d15-03d0-4449-86b0-e150a5f0827a", 
+    "listeners": [], 
+    "name": "lb1", 
+    "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+    "operating_status": "ONLINE", 
+    "pools": [], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+    "vip_address": "10.2.4.114", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-148.int.lineratesystems.com:09b30cab-8674-526f-9521-865c995db139", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-05-24T20:24:12", 
+      "description": null, 
+      "device_id": "f1b826b5-8c9d-5989-92a5-7e6fd4b039d7", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.114", 
+          "subnet_id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6"
+        }
+      ], 
+      "id": "80289652-9a77-4e0a-8f33-1a687d41247a", 
+      "mac_address": "fa:16:3e:61:8d:ef", 
+      "name": "loadbalancer-8ff41d15-03d0-4449-86b0-e150a5f0827a", 
+      "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "security_groups": [
+        "b492a432-ed4a-4982-b0a7-2c8da91f6484"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T20:24:13"
+    }, 
+    "vip_port_id": "80289652-9a77-4e0a-8f33-1a687d41247a", 
+    "vip_subnet_id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6", 
+    "vxlan_vteps": [
+      "201.0.145.10", 
+      "201.0.149.1", 
+      "201.0.147.1", 
+      "201.0.146.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-05-24T15:57:02", 
+      "description": "", 
+      "id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 29, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "d0fcc646-24b4-4a9a-9b8b-346245fecac6"
+      ], 
+      "tags": [], 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T15:57:02", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "d0fcc646-24b4-4a9a-9b8b-346245fecac6": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "created_at": "2017-05-24T15:57:05", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T15:57:05"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [], 
+  "loadbalancer": {
+    "admin_state_up": false, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8ff41d15-03d0-4449-86b0-e150a5f0827a", 
+    "listeners": [], 
+    "name": "lb1", 
+    "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+    "operating_status": "ONLINE", 
+    "pools": [], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_DELETE", 
+    "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+    "vip_address": "10.2.4.114", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-148.int.lineratesystems.com:09b30cab-8674-526f-9521-865c995db139", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-05-24T20:24:12", 
+      "description": null, 
+      "device_id": "f1b826b5-8c9d-5989-92a5-7e6fd4b039d7", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.114", 
+          "subnet_id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6"
+        }
+      ], 
+      "id": "80289652-9a77-4e0a-8f33-1a687d41247a", 
+      "mac_address": "fa:16:3e:61:8d:ef", 
+      "name": "loadbalancer-8ff41d15-03d0-4449-86b0-e150a5f0827a", 
+      "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "security_groups": [
+        "b492a432-ed4a-4982-b0a7-2c8da91f6484"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T20:24:13"
+    }, 
+    "vip_port_id": "80289652-9a77-4e0a-8f33-1a687d41247a", 
+    "vip_subnet_id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6", 
+    "vxlan_vteps": [
+      "201.0.145.10", 
+      "201.0.149.1", 
+      "201.0.147.1", 
+      "201.0.146.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-05-24T15:57:02", 
+      "description": "", 
+      "id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 29, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "d0fcc646-24b4-4a9a-9b8b-346245fecac6"
+      ], 
+      "tags": [], 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T15:57:02", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "d0fcc646-24b4-4a9a-9b8b-346245fecac6": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "created_at": "2017-05-24T15:57:05", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "d0fcc646-24b4-4a9a-9b8b-346245fecac6", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "a9238aa6-7e34-4e8c-a8bf-c18217e9b3d2", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "0ce5baeeabfb4dafac32594f285e41bc", 
+      "updated_at": "2017-05-24T15:57:05"
+    }
+  }
+}]


### PR DESCRIPTION

@pjbreaux 
#### What issues does this address?
Fixes  #704 

#### What's this change do?
Creating a Load Balancer with Admin State False should create a virtual
address which is disabled and changing a loadbalancer admin state should alter
the enable / disable status of the virtual address.

Added enabled attribue to VirtualAddress class, setting value
to yes/no based on service object attribute admin_state_up true/false.

#### Where should the reviewer start?
virtual_address.py

#### Any background context?
No.