### PR TITLE
L7 policy or rule provisioning status does not propagate up to the loadbalancer

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -459,6 +459,8 @@ class LBaaSBuilder(object):
                             l7policy, service, bigips)
                 except Exception as err:
                     l7policy['provisioning_status'] = plugin_const.ERROR
+                    service['loadbalancer']['provisioning_status'] = \
+                        plugin_const.ERROR
                     raise f5_ex.L7PolicyCreationException(err.message)
 
     def _assure_l7policies_deleted(self, service):
@@ -492,6 +494,8 @@ class LBaaSBuilder(object):
                             l7policy, service, bigips)
                 except Exception as err:
                     l7policy['provisioning_status'] = plugin_const.ERROR
+                    service['loadbalancer']['provisioning_status'] = \
+                        plugin_const.ERROR
                     raise f5_ex.L7PolicyDeleteException(err.message)
 
     def _assure_l7rules_created(self, service):
@@ -515,6 +519,8 @@ class LBaaSBuilder(object):
                     self.l7service.create_l7rule(l7rule, service, bigips)
                 except Exception as err:
                     l7rule['provisioning_status'] = plugin_const.ERROR
+                    service['loadbalancer']['provisioning_status'] = \
+                        plugin_const.ERROR
                     raise f5_ex.L7PolicyCreationException(err.message)
 
     def _assure_l7rules_deleted(self, service):
@@ -536,6 +542,8 @@ class LBaaSBuilder(object):
                     self.l7service.delete_l7rule(l7rule, service, bigips)
                 except Exception as err:
                     l7rule['provisioning_status'] = plugin_const.ERROR
+                    service['loadbalancer']['provisioning_status'] = \
+                        plugin_const.ERROR
                     raise f5_ex.L7PolicyDeleteException(err.message)
 
     def get_listener_stats(self, service, stats):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_lbaas_builder.py
@@ -25,6 +25,20 @@ import pytest
 from requests import HTTPError
 
 
+POL_CREATE_PATH = \
+    'f5_openstack_agent.lbaasv2.drivers.bigip.l7policy_service' \
+    '.L7PolicyService.create_l7policy'
+POL_DELETE_PATH = \
+    'f5_openstack_agent.lbaasv2.drivers.bigip.l7policy_service' \
+    '.L7PolicyService.update_l7policy'
+RULE_CREATE_PATH = \
+    'f5_openstack_agent.lbaasv2.drivers.bigip.l7policy_service' \
+    '.L7PolicyService.create_l7rule'
+RULE_DELETE_PATH = \
+    'f5_openstack_agent.lbaasv2.drivers.bigip.l7policy_service' \
+    '.L7PolicyService.delete_l7rule'
+
+
 @pytest.fixture
 def service():
     return {
@@ -104,15 +118,467 @@ def service():
     }
 
 
+@pytest.fixture
+def l7policy_create_service():
+    return {
+        u'loadbalancer': {
+            u'admin_state_up': True,
+            u'description': u'',
+            u'gre_vteps': [u'201.0.162.1',
+                           u'201.0.160.1',
+                           u'201.0.165.1'],
+            u'id': u'd5a0396e-e862-4cbf-8eb9-25c7fbc4d593',
+            u'listeners': [
+                {u'id': u'e3af03f4-d3df-4c9b-b3dd-8002f133d5bf'}],
+            u'name': u'',
+            u'network_id': u'cdf1eb6d-9b17-424a-a054-778f3d3a5490',
+            u'operating_status': u'ONLINE',
+            u'pools': [],
+            u'provider': u'f5networks',
+            u'provisioning_status': u'ACTIVE',
+            u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd',
+            u'vip_address': u'172.16.101.3',
+            u'vip_port': {u'admin_state_up': True,
+                          u'allowed_address_pairs': [],
+                          u'binding:host_id':
+                              u'host-164.int.lineratesystems.com:16ea1e',
+                          u'binding:profile': {},
+                          u'binding:vif_details': {},
+                          u'binding:vif_type': u'binding_failed',
+                          u'binding:vnic_type': u'normal',
+                          u'created_at': u'2016-10-24T21:17:30',
+                          u'description': None,
+                          u'device_id': u'0bd0b8ff-1c51-5061-b0c4',
+                          u'device_owner': u'network:f5lbaasv2',
+                          u'dns_name': None,
+                          u'extra_dhcp_opts': [],
+                          u'fixed_ips': [
+                              {u'ip_address': u'172.16.101.3',
+                               u'subnet_id': u'81f42a8a-fc98-4281-8de4'}],
+                          u'id': u'38a13e5c-6863-4537-80a3',
+                          u'mac_address': u'fa:16:3e:94:65:0c',
+                          u'name': u'loadbalancer-d5a0396e-e862',
+                          u'network_id': u'cdf1eb6d-9b17-424a',
+                          u'security_groups': [u'df88afdb-2bc6-4621'],
+                          u'status': u'DOWN',
+                          u'tenant_id': u'd9ed216f67f04a84bf8fd',
+                          u'updated_at': u'2016-10-24T21:17:31'},
+            u'vip_port_id': u'38a13e5c-6863-4537-80a3-c788d5f0c9ce',
+            u'vip_subnet_id': u'81f42a8a-fc98-4281-8de4-2b946e931457',
+            u'vxlan_vteps': []},
+        u'l7policies': [
+            {
+                u'action': u'REJECT',
+                u'admin_state_up': True,
+                u'description': u'',
+                u'id': u'23eea01d-5151-44fd-9ceb-6356bbb1ebb7',
+                u'listener_id': u'7ddad6cc-887d-49aa-b970-5820471dc6e5',
+                u'name': u'',
+                u'position': 2,
+                u'provisioning_status': u'PENDING_CREATE',
+                u'redirect_pool_id': None,
+                u'redirect_url': None,
+                u'rules': [],
+                u'tenant_id': u'5197d6a284044c72b63f2fe6ae6edc21'},
+            {
+                u'action': u'REJECT',
+                u'admin_state_up': True,
+                u'description': u'',
+                u'id': u'8935a899-706d-46d6-8376-51f013431533',
+                u'listener_id': u'7ddad6cc-887d-49aa-b970-5820471dc6e5',
+                u'name': u'',
+                u'position': 1,
+                u'provisioning_status': u'ACTIVE',
+                u'redirect_pool_id': None,
+                u'redirect_url': None,
+                u'rules': [],
+                u'tenant_id': u'5197d6a284044c72b63f2fe6ae6edc21'}],
+        u'l7policy_rules': [],
+        u'listeners': [
+            {
+                u'admin_state_up': True,
+                u'connection_limit': -1,
+                u'default_pool_id': None,
+                u'default_tls_container_id': None,
+                u'description': u'',
+                u'id': u'7ddad6cc-887d-49aa-b970-5820471dc6e5',
+                u'l7_policies': [
+                    {
+                        u'id': u'8935a899-706d-46d6-8376-51f013431533'},
+                    {
+                        u'id': u'23eea01d-5151-44fd-9ceb-6356bbb1ebb7'}],
+                u'loadbalancer_id': u'd5a0396e-e862-4cbf-8eb9-25c7fbc4d593',
+                u'name': u'vs1',
+                u'operating_status': 'ONLINE',
+                u'protocol': u'HTTP',
+                u'protocol_port': 80,
+                u'provisioning_status': u'ACTIVE',
+                'snat_pool_name': u'Project_5197d6a284044c72b63f2fe6ae6edc21',
+                u'sni_containers': [],
+                u'tenant_id': u'5197d6a284044c72b63f2fe6ae6edc21',
+                'use_snat': True}],
+        u'members': [],
+        u'pools': [],
+    }
+
+
+@pytest.fixture
+def l7policy_delete_service():
+    return {
+        u'loadbalancer': {
+            u'admin_state_up': True,
+            u'description': u'',
+            u'gre_vteps': [u'201.0.162.1',
+                           u'201.0.160.1',
+                           u'201.0.165.1'],
+            u'id': u'd5a0396e-e862-4cbf-8eb9-25c7fbc4d593',
+            u'listeners': [
+                {u'id': u'e3af03f4-d3df-4c9b-b3dd-8002f133d5bf'}],
+            u'name': u'',
+            u'network_id': u'cdf1eb6d-9b17-424a-a054-778f3d3a5490',
+            u'operating_status': u'ONLINE',
+            u'pools': [],
+            u'provider': u'f5networks',
+            u'provisioning_status': u'ACTIVE',
+            u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd',
+            u'vip_address': u'172.16.101.3',
+            u'vip_port': {u'admin_state_up': True,
+                          u'allowed_address_pairs': [],
+                          u'binding:host_id':
+                              u'host-164.int.lineratesystems.com:16ea1e',
+                          u'binding:profile': {},
+                          u'binding:vif_details': {},
+                          u'binding:vif_type': u'binding_failed',
+                          u'binding:vnic_type': u'normal',
+                          u'created_at': u'2016-10-24T21:17:30',
+                          u'description': None,
+                          u'device_id': u'0bd0b8ff-1c51-5061-b0c4',
+                          u'device_owner': u'network:f5lbaasv2',
+                          u'dns_name': None,
+                          u'extra_dhcp_opts': [],
+                          u'fixed_ips': [
+                              {u'ip_address': u'172.16.101.3',
+                               u'subnet_id': u'81f42a8a-fc98-4281-8de4'}],
+                          u'id': u'38a13e5c-6863-4537-80a3',
+                          u'mac_address': u'fa:16:3e:94:65:0c',
+                          u'name': u'loadbalancer-d5a0396e-e862',
+                          u'network_id': u'cdf1eb6d-9b17-424a',
+                          u'security_groups': [u'df88afdb-2bc6-4621'],
+                          u'status': u'DOWN',
+                          u'tenant_id': u'd9ed216f67f04a84bf8fd',
+                          u'updated_at': u'2016-10-24T21:17:31'},
+            u'vip_port_id': u'38a13e5c-6863-4537-80a3-c788d5f0c9ce',
+            u'vip_subnet_id': u'81f42a8a-fc98-4281-8de4-2b946e931457',
+            u'vxlan_vteps': []},
+        u'l7policies': [
+            {
+                u'action': u'REJECT',
+                u'admin_state_up': True,
+                u'description': u'',
+                u'id': u'23eea01d-5151-44fd-9ceb-6356bbb1ebb7',
+                u'listener_id': u'7ddad6cc-887d-49aa-b970-5820471dc6e5',
+                u'name': u'',
+                u'position': 2,
+                u'provisioning_status': u'PENDING_DELETE',
+                u'redirect_pool_id': None,
+                u'redirect_url': None,
+                u'rules': [],
+                u'tenant_id': u'5197d6a284044c72b63f2fe6ae6edc21'},
+            {
+                u'action': u'REJECT',
+                u'admin_state_up': True,
+                u'description': u'',
+                u'id': u'8935a899-706d-46d6-8376-51f013431533',
+                u'listener_id': u'7ddad6cc-887d-49aa-b970-5820471dc6e5',
+                u'name': u'',
+                u'position': 1,
+                u'provisioning_status': u'ACTIVE',
+                u'redirect_pool_id': None,
+                u'redirect_url': None,
+                u'rules': [],
+                u'tenant_id': u'5197d6a284044c72b63f2fe6ae6edc21'}],
+        u'l7policy_rules': [],
+        u'listeners': [
+            {
+                u'admin_state_up': True,
+                u'connection_limit': -1,
+                u'default_pool_id': None,
+                u'default_tls_container_id': None,
+                u'description': u'',
+                u'id': u'7ddad6cc-887d-49aa-b970-5820471dc6e5',
+                u'l7_policies': [
+                    {
+                        u'id': u'8935a899-706d-46d6-8376-51f013431533'},
+                    {
+                        u'id': u'23eea01d-5151-44fd-9ceb-6356bbb1ebb7'}],
+                u'loadbalancer_id': u'd5a0396e-e862-4cbf-8eb9-25c7fbc4d593',
+                u'name': u'vs1',
+                u'operating_status': 'ONLINE',
+                u'protocol': u'HTTP',
+                u'protocol_port': 80,
+                u'provisioning_status': u'ACTIVE',
+                'snat_pool_name': u'Project_5197d6a284044c72b63f2fe6ae6edc21',
+                u'sni_containers': [],
+                u'tenant_id': u'5197d6a284044c72b63f2fe6ae6edc21',
+                'use_snat': True}],
+        u'members': [],
+        u'pools': [],
+    }
+
+
+@pytest.fixture
+def l7rule_create_service():
+    return {
+        u'loadbalancer': {
+            u'admin_state_up': True,
+            u'description': u'',
+            u'gre_vteps': [u'201.0.162.1',
+                           u'201.0.160.1',
+                           u'201.0.165.1'],
+            u'id': u'd5a0396e-e862-4cbf-8eb9-25c7fbc4d593',
+            u'listeners': [
+                {u'id': u'e3af03f4-d3df-4c9b-b3dd-8002f133d5bf'}],
+            u'name': u'',
+            u'network_id': u'cdf1eb6d-9b17-424a-a054-778f3d3a5490',
+            u'operating_status': u'ONLINE',
+            u'pools': [],
+            u'provider': u'f5networks',
+            u'provisioning_status': u'ACTIVE',
+            u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd',
+            u'vip_address': u'172.16.101.3',
+            u'vip_port': {u'admin_state_up': True,
+                          u'allowed_address_pairs': [],
+                          u'binding:host_id':
+                              u'host-164.int.lineratesystems.com:16ea1e',
+                          u'binding:profile': {},
+                          u'binding:vif_details': {},
+                          u'binding:vif_type': u'binding_failed',
+                          u'binding:vnic_type': u'normal',
+                          u'created_at': u'2016-10-24T21:17:30',
+                          u'description': None,
+                          u'device_id': u'0bd0b8ff-1c51-5061-b0c4',
+                          u'device_owner': u'network:f5lbaasv2',
+                          u'dns_name': None,
+                          u'extra_dhcp_opts': [],
+                          u'fixed_ips': [
+                              {u'ip_address': u'172.16.101.3',
+                               u'subnet_id': u'81f42a8a-fc98-4281-8de4'}],
+                          u'id': u'38a13e5c-6863-4537-80a3',
+                          u'mac_address': u'fa:16:3e:94:65:0c',
+                          u'name': u'loadbalancer-d5a0396e-e862',
+                          u'network_id': u'cdf1eb6d-9b17-424a',
+                          u'security_groups': [u'df88afdb-2bc6-4621'],
+                          u'status': u'DOWN',
+                          u'tenant_id': u'd9ed216f67f04a84bf8fd',
+                          u'updated_at': u'2016-10-24T21:17:31'},
+            u'vip_port_id': u'38a13e5c-6863-4537-80a3-c788d5f0c9ce',
+            u'vip_subnet_id': u'81f42a8a-fc98-4281-8de4-2b946e931457',
+            u'vxlan_vteps': []
+        },
+        u'l7policies': [
+            {
+                u'action': u'REJECT',
+                u'admin_state_up': True,
+                u'description': u'',
+                u'id': u'23eea01d-5151-44fd-9ceb-6356bbb1ebb7',
+                u'listener_id': u'7ddad6cc-887d-49aa-b970-5820471dc6e5',
+                u'name': u'',
+                u'position': 2,
+                u'provisioning_status': u'ACTIVE',
+                u'redirect_pool_id': None,
+                u'redirect_url': None,
+                u'rules': [{u'id': u'40e06ae9-3297-435d-be23-f3f6ff465e22'}],
+                u'tenant_id': u'5197d6a284044c72b63f2fe6ae6edc21'},
+            {
+                u'action': u'REJECT',
+                u'admin_state_up': True,
+                u'description': u'',
+                u'id': u'8935a899-706d-46d6-8376-51f013431533',
+                u'listener_id': u'7ddad6cc-887d-49aa-b970-5820471dc6e5',
+                u'name': u'',
+                u'position': 1,
+                u'provisioning_status': u'ACTIVE',
+                u'redirect_pool_id': None,
+                u'redirect_url': None,
+                u'rules': [],
+                u'tenant_id': u'5197d6a284044c72b63f2fe6ae6edc21'
+            }],
+        u'l7policy_rules': [
+            {
+                u'admin_state_up': True,
+                u'compare_type': u'EQUAL_TO',
+                u'id': u'40e06ae9-3297-435d-be23-f3f6ff465e22',
+                u'invert': False,
+                u'key': None,
+                u'policies': [
+                    {u'id': u'23eea01d-5151-44fd-9ceb-6356bbb1ebb7'}],
+                u'policy_id': u'23eea01d-5151-44fd-9ceb-6356bbb1ebb7',
+                u'provisioning_status': u'PENDING_CREATE',
+                u'tenant_id': u'5197d6a284044c72b63f2fe6ae6edc21',
+                u'type': u'FILE_TYPE',
+                u'value': u'txt'}],
+        u'listeners': [
+            {
+                u'admin_state_up': True,
+                u'connection_limit': -1,
+                u'default_pool_id': None,
+                u'default_tls_container_id': None,
+                u'description': u'',
+                u'id': u'7ddad6cc-887d-49aa-b970-5820471dc6e5',
+                u'l7_policies': [
+                    {u'id': u'8935a899-706d-46d6-8376-51f013431533'},
+                    {u'id': u'23eea01d-5151-44fd-9ceb-6356bbb1ebb7'}],
+                u'loadbalancer_id': u'd5a0396e-e862-4cbf-8eb9-25c7fbc4d593',
+                u'name': u'vs1',
+                u'operating_status': 'ONLINE',
+                u'protocol': u'HTTP',
+                u'protocol_port': 80,
+                u'provisioning_status': u'ACTIVE',
+                'snat_pool_name': u'Project_5197d6a284044c72b63f2fe6ae6edc21',
+                u'sni_containers': [],
+                u'tenant_id': u'5197d6a284044c72b63f2fe6ae6edc21',
+                'use_snat': True}],
+        u'members': [],
+        u'pools': [],
+    }
+
+
+@pytest.fixture
+def l7rule_delete_service():
+    return {
+        u'loadbalancer': {
+            u'admin_state_up': True,
+            u'description': u'',
+            u'gre_vteps': [u'201.0.162.1',
+                           u'201.0.160.1',
+                           u'201.0.165.1'],
+            u'id': u'd5a0396e-e862-4cbf-8eb9-25c7fbc4d593',
+            u'listeners': [
+                {u'id': u'e3af03f4-d3df-4c9b-b3dd-8002f133d5bf'}],
+            u'name': u'',
+            u'network_id': u'cdf1eb6d-9b17-424a-a054-778f3d3a5490',
+            u'operating_status': u'ONLINE',
+            u'pools': [],
+            u'provider': u'f5networks',
+            u'provisioning_status': u'ACTIVE',
+            u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd',
+            u'vip_address': u'172.16.101.3',
+            u'vip_port': {u'admin_state_up': True,
+                          u'allowed_address_pairs': [],
+                          u'binding:host_id':
+                              u'host-164.int.lineratesystems.com:16ea1e',
+                          u'binding:profile': {},
+                          u'binding:vif_details': {},
+                          u'binding:vif_type': u'binding_failed',
+                          u'binding:vnic_type': u'normal',
+                          u'created_at': u'2016-10-24T21:17:30',
+                          u'description': None,
+                          u'device_id': u'0bd0b8ff-1c51-5061-b0c4',
+                          u'device_owner': u'network:f5lbaasv2',
+                          u'dns_name': None,
+                          u'extra_dhcp_opts': [],
+                          u'fixed_ips': [
+                              {u'ip_address': u'172.16.101.3',
+                               u'subnet_id': u'81f42a8a-fc98-4281-8de4'}],
+                          u'id': u'38a13e5c-6863-4537-80a3',
+                          u'mac_address': u'fa:16:3e:94:65:0c',
+                          u'name': u'loadbalancer-d5a0396e-e862',
+                          u'network_id': u'cdf1eb6d-9b17-424a',
+                          u'security_groups': [u'df88afdb-2bc6-4621'],
+                          u'status': u'DOWN',
+                          u'tenant_id': u'd9ed216f67f04a84bf8fd',
+                          u'updated_at': u'2016-10-24T21:17:31'},
+            u'vip_port_id': u'38a13e5c-6863-4537-80a3-c788d5f0c9ce',
+            u'vip_subnet_id': u'81f42a8a-fc98-4281-8de4-2b946e931457',
+            u'vxlan_vteps': []},
+        u'l7policies': [
+            {
+                u'action': u'REJECT',
+                u'admin_state_up': True,
+                u'description': u'',
+                u'id': u'23eea01d-5151-44fd-9ceb-6356bbb1ebb7',
+                u'listener_id': u'7ddad6cc-887d-49aa-b970-5820471dc6e5',
+                u'name': u'',
+                u'position': 2,
+                u'provisioning_status': u'ACTIVE',
+                u'redirect_pool_id': None,
+                u'redirect_url': None,
+                u'rules': [
+                    {u'id': u'40e06ae9-3297-435d-be23-f3f6ff465e22'}],
+                u'tenant_id': u'5197d6a284044c72b63f2fe6ae6edc21'},
+            {
+                u'action': u'REJECT',
+                u'admin_state_up': True,
+                u'description': u'',
+                u'id': u'8935a899-706d-46d6-8376-51f013431533',
+                u'listener_id': u'7ddad6cc-887d-49aa-b970-5820471dc6e5',
+                u'name': u'',
+                u'position': 1,
+                u'provisioning_status': u'ACTIVE',
+                u'redirect_pool_id': None,
+                u'redirect_url': None,
+                u'rules': [],
+                u'tenant_id': u'5197d6a284044c72b63f2fe6ae6edc21'}],
+        u'l7policy_rules': [
+            {
+                u'admin_state_up': True,
+                u'compare_type': u'EQUAL_TO',
+                u'id': u'40e06ae9-3297-435d-be23-f3f6ff465e22',
+                u'invert': False,
+                u'key': None,
+                u'policies': [
+                    {u'id': u'23eea01d-5151-44fd-9ceb-6356bbb1ebb7'}],
+                u'policy_id': u'23eea01d-5151-44fd-9ceb-6356bbb1ebb7',
+                u'provisioning_status': u'PENDING_DELETE',
+                u'tenant_id': u'5197d6a284044c72b63f2fe6ae6edc21',
+                u'type': u'FILE_TYPE',
+                u'value': u'txt'
+            }],
+        u'listeners': [
+            {
+                u'admin_state_up': True,
+                u'connection_limit': -1,
+                u'default_pool_id': None,
+                u'default_tls_container_id': None,
+                u'description': u'',
+                u'id': u'7ddad6cc-887d-49aa-b970-5820471dc6e5',
+                u'l7_policies': [
+                    {u'id': u'8935a899-706d-46d6-8376-51f013431533'},
+                    {u'id': u'23eea01d-5151-44fd-9ceb-6356bbb1ebb7'}],
+                u'loadbalancer_id': u'd5a0396e-e862-4cbf-8eb9-25c7fbc4d593',
+                u'name': u'vs1',
+                u'operating_status': 'ONLINE',
+                u'protocol': u'HTTP',
+                u'protocol_port': 80,
+                u'provisioning_status': u'ACTIVE',
+                'snat_pool_name': u'Project_5197d6a284044c72b63f2fe6ae6edc21',
+                u'sni_containers': [],
+                u'tenant_id': u'5197d6a284044c72b63f2fe6ae6edc21',
+                'use_snat': True}],
+        u'members': [],
+        u'pools': [],
+    }
+
+
 class MockHTTPError(HTTPError):
-    def __init__(self, response_obj):
+    def __init__(self, response_obj, message=''):
         self.response = response_obj
+        self.message = message
+
+
+class MockHTTPErrorResponse404(HTTPError):
+    def __init__(self):
+        self.status_code = 404
 
 
 class MockHTTPErrorResponse409(HTTPError):
     def __init__(self):
-        self.text = 'Conflict.'
         self.status_code = 409
+
+
+class MockHTTPErrorResponse500(HTTPError):
+    def __init__(self):
+        self.status_code = 500
 
 
 class TestLbaasBuilder(object):
@@ -190,3 +656,97 @@ class TestLbaasBuilder(object):
                     builder._assure_members(service, mock.MagicMock())
                     assert service['members'][0]['provisioning_status'] ==\
                         'ERROR'
+
+    def test_create_policy_active_status(self, l7policy_create_service):
+        """provisioning_status is ACTIVE after successful policy creation."""
+
+        svc = l7policy_create_service
+        builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
+        builder._assure_l7policies_created(svc)
+        assert svc['l7policies'][0]['provisioning_status'] == 'PENDING_CREATE'
+        assert svc['loadbalancer']['provisioning_status'] == 'ACTIVE'
+
+    def test_create_policy_error_status(self, l7policy_create_service):
+        """provisioning_status is ERROR after policy creation fails."""
+
+        svc = l7policy_create_service
+        with mock.patch(POL_CREATE_PATH) as mock_pol_create:
+            mock_pol_create.side_effect = \
+                MockHTTPError(MockHTTPErrorResponse500(), 'Server failure.')
+            builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
+            with pytest.raises(f5_ex.L7PolicyCreationException) as ex:
+                builder._assure_l7policies_created(svc)
+            assert svc['l7policies'][0]['provisioning_status'] == 'ERROR'
+            assert svc['loadbalancer']['provisioning_status'] == 'ERROR'
+            assert ex.value.message == 'Server failure.'
+
+    def test_delete_policy(self, l7policy_delete_service):
+        """provisioning_status is PENDING_DELETE when deleteing policy."""
+
+        svc = l7policy_delete_service
+        builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
+        builder._assure_l7policies_deleted(svc)
+        assert svc['l7policies'][0]['provisioning_status'] == 'PENDING_DELETE'
+        assert svc['loadbalancer']['provisioning_status'] == 'ACTIVE'
+
+    def test_delete_policy_error_status(self, l7policy_delete_service):
+        """provisioning_status is ERROR when policy fails to delete."""
+
+        svc = l7policy_delete_service
+        with mock.patch(POL_DELETE_PATH) as mock_pol_delete:
+            mock_pol_delete.side_effect = \
+                MockHTTPError(MockHTTPErrorResponse409(), 'Not found.')
+            builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
+            with pytest.raises(f5_ex.L7PolicyDeleteException) as ex:
+                builder._assure_l7policies_deleted(svc)
+            assert svc['l7policies'][0]['provisioning_status'] == 'ERROR'
+            assert svc['loadbalancer']['provisioning_status'] == 'ERROR'
+            assert ex.value.message == 'Not found.'
+
+    def test_create_rule_active_status(self, l7rule_create_service):
+        """provisioning_status is ACTIVE after successful rule creation."""
+
+        svc = l7rule_create_service
+        builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
+        builder._assure_l7rules_created(svc)
+        assert svc['l7policy_rules'][0]['provisioning_status'] == \
+            'PENDING_CREATE'
+        assert svc['loadbalancer']['provisioning_status'] == 'ACTIVE'
+
+    def test_create_rule_error_status(self, l7rule_create_service):
+        """provisioning_status is ERROR after rule creation fails."""
+
+        svc = l7rule_create_service
+        with mock.patch(RULE_CREATE_PATH) as mock_pol_create:
+            mock_pol_create.side_effect = \
+                MockHTTPError(MockHTTPErrorResponse500(), 'Server failure.')
+            builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
+            with pytest.raises(f5_ex.L7PolicyCreationException) as ex:
+                builder._assure_l7rules_created(svc)
+            assert svc['l7policy_rules'][0]['provisioning_status'] == 'ERROR'
+            assert svc['loadbalancer']['provisioning_status'] == 'ERROR'
+            assert ex.value.message == 'Server failure.'
+
+    def test_delete_rule(self, l7rule_delete_service):
+        """provisioning_status is PENDING_DELETE when deleteing rule."""
+
+        svc = l7rule_delete_service
+        builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
+        builder._assure_l7rules_deleted(svc)
+        assert svc['l7policy_rules'][0]['provisioning_status'] == \
+            'PENDING_DELETE'
+        assert svc['loadbalancer']['provisioning_status'] == 'ACTIVE'
+
+    def test_delete_rule_error_status(self, l7rule_delete_service):
+        """provisioning_status is ERROR when rule fails to delete."""
+
+        svc = l7rule_delete_service
+        with mock.patch(RULE_DELETE_PATH) as mock_pol_delete:
+            mock_pol_delete.side_effect = \
+                MockHTTPError(MockHTTPErrorResponse409(), 'Not found.')
+            builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
+            with pytest.raises(f5_ex.L7PolicyDeleteException) as ex:
+                builder._assure_l7rules_deleted(svc)
+            assert svc['l7policy_rules'][0]['provisioning_status'] == 'ERROR'
+            assert svc['loadbalancer']['provisioning_status'] == 'ERROR'
+            assert ex.value.message == 'Not found.'


### PR DESCRIPTION
@jlongstaf 

#### What issues does this address?
#577

#### What's this change do?
In the except clause for policy and rule assurances (create/delete), we
now set the loadbalancer provisioning status to ERROR if the policy or
rule fails to deploy for any reason. This is predicated on the notion
that only one loadbalancer is handled at this level.

#### Where should the reviewer start?


#### Any background context?
If the agent detects a failure (an exception) during deployment of an L7
policy, we currently only update the provisioning status of the policy
object. To fully communicate the problem, I believe we should also
update the provisioning status of the loadbalancer as well. This is
primarily because a neutron lbaas-l7policy-show command does not show
you this status, but if you get into the database, you can see the
status there. So a user may never know something went wrong with a
policy until they try to use it to direct traffic. The loadbalancer
status should also be updated and likely the listener as well.

Ran driver tempest tests against 12.1.1 deployment. Tested my new unit
tests in a docker container.

Driver tests:

The single failure is attached to a known issue.

```
api/test_esd.py::ESDTestJSON::test_create_esd FAILED
api/test_l7policy.py::L7PolicyTestJSON::test_create_l7_redirect_to_pool_policy PASSED
api/test_l7policy.py::L7PolicyTestJSON::test_create_l7_redirect_to_url_policy PASSED
api/test_l7policy.py::L7PolicyTestJSON::test_create_l7_reject_policy PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_create_l7_reject_policy PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_policy_reject_header_contains PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_policy_reject_header_ends_with PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_policy_reject_many_rules PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_policy_reject_multi_policy_multi_rules PASSED
api/test_l7policy_rules.py::L7PolicyJSONReject::test_policy_reject_three_rules PASSED
api/test_l7policy_rules.py::TestL7PolicyTestJSONRedirectToUrl::test_create_l7_redirect_to_url_policy PASSED
api/test_l7policy_rules.py::TestL7PolicyTestJSONRedirectToUrl::test_policy_redirect_url_contains PASSED
api/test_l7policy_rules.py::L7PolicyJSONRedirectToPool::test_create_l7_redirect_to_pool_policy_file_type_contains PASSED
api/test_l7policy_rules.py::L7PolicyJSONRedirectToPool::test_create_l7_redirect_to_pool_policy_not_file_type PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_create_policy_no_rule PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_create_policy_one_rule PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_create_two_policies PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_delete_all_rules PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_delete_one_rule PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_delete_policy PASSED
api/test_l7policy_update.py::L7PolicyRulesTestJSON::test_reorder_policies PASSED
api/test_load_balancers_admin.py::LoadBalancersTestJSON::test_create_load_balancer_with_tenant_id_field_for_admin PASSED
api/test_load_balancers_admin.py::LoadBalancersTestJSON::test_create_load_balancer_without_tenant_id PASSED
api/test_member_status.py::MemberStatusTestJSON::test_disabled <- .tox/tempest/local/lib/python2.7/site-packages/tempest/lib/decorators.py SKIPPED
api/test_member_status.py::MemberStatusTestJSON::test_no_monitor PASSED
api/test_member_status.py::MemberStatusTestJSON::test_offline PASSED
api/test_member_status.py::MemberStatusTestJSON::test_online PASSED
api/test_pools.py::PoolTestJSON::test_create_shared_pools PASSED
api/test_service_builder.py::ServiceBuilderTestJSON::test_service_builder PASSED
scenario/test_esd.py::TestEsdBasic::test_policy_abort_deployment PASSED
scenario/test_esd.py::TestEsdBasic::test_policy_deployment PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToPool::test_policy_deployment PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToPool::test_policy_redirect_pool_cookie_contains PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToPool::test_policy_redirect_pool_cookie_not_contains PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToPool::test_policy_redirect_pool_header_equal_to PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToPool::test_policy_redirect_pool_hostname_starts_with PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToUrl::test_policy_redirect_url_file_type_fails_bad_compare_type PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToUrl::test_policy_redirect_url_file_type_not_contains PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToUrl::test_policy_redirect_url_hostname_ends_with PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicRedirectToUrl::test_policy_redirect_url_path_starts_with PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicReject::test_policy_reject_file_type_equal_to PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicReject::test_policy_reject_header_starts_with PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicUpdate::test_policy_deployment_operand_match PASSED
scenario/test_l7policies_and_rules.py::TestL7BasicUpdate::test_policy_reorder_and_rule_update PASSED
scenario/test_stats.py::TestLoadBalancerStats::test_stats PASSED
```