### PR TITLE
Add ESD to a listener with a default pool with existing session persistence

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -60,10 +60,6 @@ class LBaaSBuilder(object):
 
         self._assure_listeners_created(service)
 
-        self._assure_l7policies_created(service)
-
-        self._assure_l7rules_created(service)
-
         self._assure_pools_created(service)
 
         self._assure_monitors(service)
@@ -71,6 +67,10 @@ class LBaaSBuilder(object):
         self._assure_members(service, all_subnet_hints)
 
         self._assure_pools_deleted(service)
+
+        self._assure_l7policies_created(service)
+
+        self._assure_l7rules_created(service)
 
         self._assure_l7rules_deleted(service)
 

--- a/test/functional/neutronless/esd/test_esd_pools.py
+++ b/test/functional/neutronless/esd/test_esd_pools.py
@@ -1,0 +1,201 @@
+# coding=utf-8
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from copy import deepcopy
+from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import \
+    iControlDriver
+from f5_openstack_agent.lbaasv2.drivers.bigip.esd_filehandler import \
+    EsdTagProcessor
+import json
+import logging
+import os
+import pytest
+import requests
+
+from ..testlib.bigip_client import BigIpClient
+from ..testlib.fake_rpc import FakeRPCPlugin
+from ..testlib.service_reader import LoadbalancerReader
+from ..testlib.resource_validator import ResourceValidator
+
+requests.packages.urllib3.disable_warnings()
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def services():
+    neutron_services_filename = (
+        os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                     '../../testdata/service_requests/l7_esd_pools.json')
+    )
+    return (json.load(open(neutron_services_filename)))
+
+
+@pytest.fixture()
+def icd_config():
+    oslo_config_filename = (
+        os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                     '../../config/basic_agent_config.json')
+    )
+    OSLO_CONFIGS = json.load(open(oslo_config_filename))
+
+    config = deepcopy(OSLO_CONFIGS)
+    config['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
+    config['icontrol_username'] = pytest.symbols.bigip_username
+    config['icontrol_password'] = pytest.symbols.bigip_password
+    config['f5_vtep_selfip_name'] = pytest.symbols.f5_vtep_selfip_name
+
+    return config
+
+
+@pytest.fixture(scope="module")
+def bigip():
+
+    return BigIpClient(pytest.symbols.bigip_mgmt_ip_public,
+                       pytest.symbols.bigip_username,
+                       pytest.symbols.bigip_password)
+
+
+@pytest.fixture
+def fake_plugin_rpc(services):
+
+    rpcObj = FakeRPCPlugin(services)
+
+    return rpcObj
+
+
+@pytest.fixture
+def icontrol_driver(icd_config, fake_plugin_rpc):
+    class ConfFake(object):
+        def __init__(self, params):
+            self.__dict__ = params
+            for k, v in self.__dict__.items():
+                if isinstance(v, unicode):
+                    self.__dict__[k] = v.encode('utf-8')
+
+        def __repr__(self):
+            return repr(self.__dict__)
+
+    icd = iControlDriver(ConfFake(icd_config),
+                         registerOpts=False)
+
+    icd.plugin_rpc = fake_plugin_rpc
+
+    return icd
+
+@pytest.fixture
+def esd():
+    esd_file = (
+        os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                     '../../../../etc/neutron/services/f5/esd/demo.json')
+    )
+    return (json.load(open(esd_file)))
+
+
+def test_esd_pools(bigip, services, icd_config, icontrol_driver, esd):
+    env_prefix = icd_config['environment_prefix']
+    service_iter = iter(services)
+    validator = ResourceValidator(bigip, env_prefix)
+
+    esd_processor = EsdTagProcessor(
+        '../../../../etc/neutron/services/f5/esd/')
+    esd_processor.process_esd([bigip.bigip])
+    icontrol_driver.lbaas_builder.esd = esd_processor
+
+    # create loadbalancer
+    # lbaas-loadbalancer-create --name lb1 mgmt_v4_subnet
+    service = service_iter.next()
+    lb_reader = LoadbalancerReader(service)
+    folder = '{0}_{1}'.format(env_prefix, lb_reader.tenant_id())
+    icontrol_driver._common_service_handler(service)
+    assert bigip.folder_exists(folder)
+
+    # create listener
+    # lbaas-listener-create --name l1 --loadbalancer lb1 --protocol HTTP
+    # --protocol-port 80
+    service = service_iter.next()
+    listener = service['listeners'][0]
+    icontrol_driver._common_service_handler(service)
+    validator.assert_virtual_valid(listener, folder)
+
+    # create pool with session persistence
+    # lbaas-pool-create --name p1 --listener l1 --protocol HTTP
+    # --lb-algorithm ROUND_ROBIN --session-persistence type=SOURCE_IP
+    service = service_iter.next()
+    pool = service['pools'][0]
+    icontrol_driver._common_service_handler(service)
+    validator.assert_pool_valid(pool, folder)
+
+    # apply ESD
+    # lbaas-l7policy-create --name esd_demo_1 --listener l1 --action REJECT
+    # --description "Override pool session persistence"
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+    validator.assert_esd_applied(esd['esd_demo_1'], listener, folder)
+
+    # delete pool
+    # lbaas-pool-delete p1
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+    validator.assert_pool_deleted(pool, None, folder)
+    # deleting pool should NOT remove ESD
+    validator.assert_esd_applied(esd['esd_demo_1'], listener, folder)
+
+    # delete ESD
+    # lbaas-l7policy-delete esd_demo_1
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+    validator.assert_esd_removed(esd['esd_demo_1'], listener, folder)
+
+    # create new ESD
+    # lbaas-l7policy-create --name esd_demo_1 --listener l1 --action REJECT
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+    validator.assert_esd_applied(esd['esd_demo_1'], listener, folder)
+
+    # create pool with session persistence
+    # lbaas-pool-create --name p1 --listener l1 --protocol HTTP
+    # --lb-algorithm ROUND_ROBIN --session-persistence type=SOURCE_IP
+    # --description "Should not override ESD session persistence"
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+    pool = service['pools'][0]
+    validator.assert_pool_valid(pool, folder)
+    # creating pool should NOT remove ESD
+    validator.assert_esd_applied(esd['esd_demo_1'], listener, folder)
+
+    # delete pool
+    # lbaas-pool-delete p1
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+    validator.assert_pool_deleted(pool, None, folder)
+
+    # delete ESD
+    # lbaas-l7policy-delete esd_demo_1
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+    validator.assert_esd_removed(esd['esd_demo_1'], listener, folder)
+
+    # delete listener
+    # lbaas-listener-delete l1
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+    validator.assert_virtual_deleted(listener, folder)
+
+    # delete loadbalancer
+    # neutron lbaas-loadbalancer-delete lb1
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service, delete_partition=True)
+    assert not bigip.folder_exists(folder)

--- a/test/functional/neutronless/testlib/resource_validator.py
+++ b/test/functional/neutronless/testlib/resource_validator.py
@@ -180,7 +180,7 @@ class ResourceValidator(object):
 
         if 'lbaas_persist' in esd:
             persist = getattr(vs, 'persist', None)
-            if not persist:
+            if persist:
                 assert vs.persist[0]['name'] != esd['lbaas_persist']
 
         if 'lbaas_fallback_persist' in esd:

--- a/test/functional/testdata/service_requests/l7_esd_pools.json
+++ b/test/functional/testdata/service_requests/l7_esd_pools.json
@@ -1,0 +1,1949 @@
+[{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+    "listeners": [], 
+    "name": "lb1", 
+    "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+    "operating_status": "OFFLINE", 
+    "pools": [], 
+    "provider": null, 
+    "provisioning_status": "PENDING_CREATE", 
+    "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": false, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "unbound", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-05-30T20:09:50", 
+      "description": null, 
+      "device_id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "device_owner": "neutron:LOADBALANCERV2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+        }
+      ], 
+      "id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+      "mac_address": "fa:16:3e:25:01:f6", 
+      "name": "loadbalancer-e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "security_groups": [
+        "28d1dd36-36bf-423e-9927-ece66845a6f4"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T20:09:50"
+    }, 
+    "vip_port_id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+    "vip_subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+    "vxlan_vteps": [
+      "201.0.168.1", 
+      "201.0.162.1", 
+      "201.0.150.10", 
+      "201.0.169.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "0b9235cc-608f-4c82-90b7-aaaa1376be8d": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-05-30T16:30:52", 
+      "description": "", 
+      "id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 48, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+      ], 
+      "tags": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:52", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "b4323537-d2e4-4ed9-a165-65ca5f7271b7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "created_at": "2017-05-30T16:30:54", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:54"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": null, 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "l7_policies": [], 
+      "loadbalancer_id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "name": "l1", 
+      "operating_status": "OFFLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "PENDING_CREATE", 
+      "sni_containers": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+    "listeners": [
+      {
+        "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+    "operating_status": "ONLINE", 
+    "pools": [], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:0d1449d4-e8a5-5f10-be72-8a568cc3a46c", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-05-30T20:09:50", 
+      "description": null, 
+      "device_id": "8d5bd554-47f7-5a53-a69e-8bf783eed8ef", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+        }
+      ], 
+      "id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+      "mac_address": "fa:16:3e:25:01:f6", 
+      "name": "loadbalancer-e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "security_groups": [
+        "28d1dd36-36bf-423e-9927-ece66845a6f4"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T20:09:51"
+    }, 
+    "vip_port_id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+    "vip_subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+    "vxlan_vteps": [
+      "201.0.168.1", 
+      "201.0.162.1", 
+      "201.0.150.10", 
+      "201.0.169.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "0b9235cc-608f-4c82-90b7-aaaa1376be8d": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-05-30T16:30:52", 
+      "description": "", 
+      "id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 48, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+      ], 
+      "tags": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:52", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "b4323537-d2e4-4ed9-a165-65ca5f7271b7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "created_at": "2017-05-30T16:30:54", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:54"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "553cc063-8313-40b3-a279-9baf71973a9d", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "l7_policies": [], 
+      "loadbalancer_id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "name": "l1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+    "listeners": [
+      {
+        "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+    "operating_status": "ONLINE", 
+    "pools": [
+      {
+        "id": "553cc063-8313-40b3-a279-9baf71973a9d"
+      }
+    ], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:0d1449d4-e8a5-5f10-be72-8a568cc3a46c", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-05-30T20:09:50", 
+      "description": null, 
+      "device_id": "8d5bd554-47f7-5a53-a69e-8bf783eed8ef", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+        }
+      ], 
+      "id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+      "mac_address": "fa:16:3e:25:01:f6", 
+      "name": "loadbalancer-e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "security_groups": [
+        "28d1dd36-36bf-423e-9927-ece66845a6f4"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T20:09:51"
+    }, 
+    "vip_port_id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+    "vip_subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+    "vxlan_vteps": [
+      "201.0.168.1", 
+      "201.0.162.1", 
+      "201.0.150.10", 
+      "201.0.169.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "0b9235cc-608f-4c82-90b7-aaaa1376be8d": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-05-30T16:30:52", 
+      "description": "", 
+      "id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 48, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+      ], 
+      "tags": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:52", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "553cc063-8313-40b3-a279-9baf71973a9d", 
+      "l7_policies": [], 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listener_id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "listeners": [
+        {
+          "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9"
+        }
+      ], 
+      "loadbalancer_id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "members": [], 
+      "name": "p1", 
+      "operating_status": "OFFLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "PENDING_CREATE", 
+      "session_persistence": {
+        "cookie_name": null, 
+        "type": "SOURCE_IP"
+      }, 
+      "sessionpersistence": null, 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "subnets": {
+    "b4323537-d2e4-4ed9-a165-65ca5f7271b7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "created_at": "2017-05-30T16:30:54", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:54"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [
+    {
+      "action": "REJECT", 
+      "admin_state_up": true, 
+      "description": "Override pool session persistence", 
+      "id": "c213e589-1ab3-43e9-bf65-0d24494fae7c", 
+      "listener_id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "name": "esd_demo_1", 
+      "position": 1, 
+      "provisioning_status": "PENDING_CREATE", 
+      "redirect_pool_id": null, 
+      "redirect_url": null, 
+      "rules": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "553cc063-8313-40b3-a279-9baf71973a9d", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "l7_policies": [
+        {
+          "id": "c213e589-1ab3-43e9-bf65-0d24494fae7c"
+        }
+      ], 
+      "loadbalancer_id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "name": "l1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+    "listeners": [
+      {
+        "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+    "operating_status": "ONLINE", 
+    "pools": [
+      {
+        "id": "553cc063-8313-40b3-a279-9baf71973a9d"
+      }
+    ], 
+    "provider": "f5networks", 
+    "provisioning_status": "ACTIVE", 
+    "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:0d1449d4-e8a5-5f10-be72-8a568cc3a46c", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-05-30T20:09:50", 
+      "description": null, 
+      "device_id": "8d5bd554-47f7-5a53-a69e-8bf783eed8ef", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+        }
+      ], 
+      "id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+      "mac_address": "fa:16:3e:25:01:f6", 
+      "name": "loadbalancer-e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "security_groups": [
+        "28d1dd36-36bf-423e-9927-ece66845a6f4"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T20:09:51"
+    }, 
+    "vip_port_id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+    "vip_subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+    "vxlan_vteps": [
+      "201.0.168.1", 
+      "201.0.162.1", 
+      "201.0.150.10", 
+      "201.0.169.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "0b9235cc-608f-4c82-90b7-aaaa1376be8d": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-05-30T16:30:52", 
+      "description": "", 
+      "id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 48, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+      ], 
+      "tags": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:52", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "553cc063-8313-40b3-a279-9baf71973a9d", 
+      "l7_policies": [], 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listener_id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "listeners": [
+        {
+          "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9"
+        }
+      ], 
+      "loadbalancer_id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "members": [], 
+      "name": "p1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "ACTIVE", 
+      "session_persistence": {
+        "cookie_name": null, 
+        "type": "SOURCE_IP"
+      }, 
+      "sessionpersistence": null, 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "subnets": {
+    "b4323537-d2e4-4ed9-a165-65ca5f7271b7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "created_at": "2017-05-30T16:30:54", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:54"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [
+    {
+      "action": "REJECT", 
+      "admin_state_up": true, 
+      "description": "Override pool session persistence", 
+      "id": "c213e589-1ab3-43e9-bf65-0d24494fae7c", 
+      "listener_id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "name": "esd_demo_1", 
+      "position": 1, 
+      "provisioning_status": "ACTIVE", 
+      "redirect_pool_id": null, 
+      "redirect_url": null, 
+      "rules": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "553cc063-8313-40b3-a279-9baf71973a9d", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "l7_policies": [
+        {
+          "id": "c213e589-1ab3-43e9-bf65-0d24494fae7c"
+        }
+      ], 
+      "loadbalancer_id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "name": "l1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+    "listeners": [
+      {
+        "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+    "operating_status": "ONLINE", 
+    "pools": [
+      {
+        "id": "553cc063-8313-40b3-a279-9baf71973a9d"
+      }
+    ], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:0d1449d4-e8a5-5f10-be72-8a568cc3a46c", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-05-30T20:09:50", 
+      "description": null, 
+      "device_id": "8d5bd554-47f7-5a53-a69e-8bf783eed8ef", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+        }
+      ], 
+      "id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+      "mac_address": "fa:16:3e:25:01:f6", 
+      "name": "loadbalancer-e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "security_groups": [
+        "28d1dd36-36bf-423e-9927-ece66845a6f4"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T20:09:51"
+    }, 
+    "vip_port_id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+    "vip_subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+    "vxlan_vteps": [
+      "201.0.168.1", 
+      "201.0.162.1", 
+      "201.0.150.10", 
+      "201.0.169.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "0b9235cc-608f-4c82-90b7-aaaa1376be8d": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-05-30T16:30:52", 
+      "description": "", 
+      "id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 48, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+      ], 
+      "tags": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:52", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "553cc063-8313-40b3-a279-9baf71973a9d", 
+      "l7_policies": [], 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listener_id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "listeners": [
+        {
+          "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9"
+        }
+      ], 
+      "loadbalancer_id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "members": [], 
+      "name": "p1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "PENDING_DELETE", 
+      "session_persistence": {
+        "cookie_name": null, 
+        "type": "SOURCE_IP"
+      }, 
+      "sessionpersistence": null, 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "subnets": {
+    "b4323537-d2e4-4ed9-a165-65ca5f7271b7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "created_at": "2017-05-30T16:30:54", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:54"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [
+    {
+      "action": "REJECT", 
+      "admin_state_up": true, 
+      "description": "Override pool session persistence", 
+      "id": "c213e589-1ab3-43e9-bf65-0d24494fae7c", 
+      "listener_id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "name": "esd_demo_1", 
+      "position": 1, 
+      "provisioning_status": "PENDING_DELETE", 
+      "redirect_pool_id": null, 
+      "redirect_url": null, 
+      "rules": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": null, 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "l7_policies": [
+        {
+          "id": "c213e589-1ab3-43e9-bf65-0d24494fae7c"
+        }
+      ], 
+      "loadbalancer_id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "name": "l1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+    "listeners": [
+      {
+        "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+    "operating_status": "ONLINE", 
+    "pools": [], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:0d1449d4-e8a5-5f10-be72-8a568cc3a46c", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-05-30T20:09:50", 
+      "description": null, 
+      "device_id": "8d5bd554-47f7-5a53-a69e-8bf783eed8ef", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+        }
+      ], 
+      "id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+      "mac_address": "fa:16:3e:25:01:f6", 
+      "name": "loadbalancer-e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "security_groups": [
+        "28d1dd36-36bf-423e-9927-ece66845a6f4"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T20:09:51"
+    }, 
+    "vip_port_id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+    "vip_subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+    "vxlan_vteps": [
+      "201.0.168.1", 
+      "201.0.162.1", 
+      "201.0.150.10", 
+      "201.0.169.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "0b9235cc-608f-4c82-90b7-aaaa1376be8d": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-05-30T16:30:52", 
+      "description": "", 
+      "id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 48, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+      ], 
+      "tags": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:52", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "b4323537-d2e4-4ed9-a165-65ca5f7271b7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "created_at": "2017-05-30T16:30:54", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:54"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [
+    {
+      "action": "REJECT", 
+      "admin_state_up": true, 
+      "description": "", 
+      "id": "01215b54-0c1c-48c7-b5a0-1ac109d61a6e", 
+      "listener_id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "name": "esd_demo_1", 
+      "position": 1, 
+      "provisioning_status": "PENDING_CREATE", 
+      "redirect_pool_id": null, 
+      "redirect_url": null, 
+      "rules": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": null, 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "l7_policies": [
+        {
+          "id": "01215b54-0c1c-48c7-b5a0-1ac109d61a6e"
+        }
+      ], 
+      "loadbalancer_id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "name": "l1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+    "listeners": [
+      {
+        "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+    "operating_status": "ONLINE", 
+    "pools": [], 
+    "provider": "f5networks", 
+    "provisioning_status": "ACTIVE", 
+    "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:0d1449d4-e8a5-5f10-be72-8a568cc3a46c", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-05-30T20:09:50", 
+      "description": null, 
+      "device_id": "8d5bd554-47f7-5a53-a69e-8bf783eed8ef", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+        }
+      ], 
+      "id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+      "mac_address": "fa:16:3e:25:01:f6", 
+      "name": "loadbalancer-e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "security_groups": [
+        "28d1dd36-36bf-423e-9927-ece66845a6f4"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T20:09:51"
+    }, 
+    "vip_port_id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+    "vip_subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+    "vxlan_vteps": [
+      "201.0.168.1", 
+      "201.0.162.1", 
+      "201.0.150.10", 
+      "201.0.169.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "0b9235cc-608f-4c82-90b7-aaaa1376be8d": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-05-30T16:30:52", 
+      "description": "", 
+      "id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 48, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+      ], 
+      "tags": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:52", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "b4323537-d2e4-4ed9-a165-65ca5f7271b7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "created_at": "2017-05-30T16:30:54", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:54"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [
+    {
+      "action": "REJECT", 
+      "admin_state_up": true, 
+      "description": "", 
+      "id": "01215b54-0c1c-48c7-b5a0-1ac109d61a6e", 
+      "listener_id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "name": "esd_demo_1", 
+      "position": 1, 
+      "provisioning_status": "ACTIVE", 
+      "redirect_pool_id": null, 
+      "redirect_url": null, 
+      "rules": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "1462dab7-1644-4b99-9fde-bec6aca83cd4", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "l7_policies": [
+        {
+          "id": "01215b54-0c1c-48c7-b5a0-1ac109d61a6e"
+        }
+      ], 
+      "loadbalancer_id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "name": "l1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+    "listeners": [
+      {
+        "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+    "operating_status": "ONLINE", 
+    "pools": [
+      {
+        "id": "1462dab7-1644-4b99-9fde-bec6aca83cd4"
+      }
+    ], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:0d1449d4-e8a5-5f10-be72-8a568cc3a46c", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-05-30T20:09:50", 
+      "description": null, 
+      "device_id": "8d5bd554-47f7-5a53-a69e-8bf783eed8ef", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+        }
+      ], 
+      "id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+      "mac_address": "fa:16:3e:25:01:f6", 
+      "name": "loadbalancer-e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "security_groups": [
+        "28d1dd36-36bf-423e-9927-ece66845a6f4"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T20:09:51"
+    }, 
+    "vip_port_id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+    "vip_subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+    "vxlan_vteps": [
+      "201.0.168.1", 
+      "201.0.162.1", 
+      "201.0.150.10", 
+      "201.0.169.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "0b9235cc-608f-4c82-90b7-aaaa1376be8d": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-05-30T16:30:52", 
+      "description": "", 
+      "id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 48, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+      ], 
+      "tags": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:52", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "Should not override ESD session persistence", 
+      "healthmonitor_id": null, 
+      "id": "1462dab7-1644-4b99-9fde-bec6aca83cd4", 
+      "l7_policies": [], 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listener_id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "listeners": [
+        {
+          "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9"
+        }
+      ], 
+      "loadbalancer_id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "members": [], 
+      "name": "p1", 
+      "operating_status": "OFFLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "PENDING_CREATE", 
+      "session_persistence": {
+        "cookie_name": null, 
+        "type": "SOURCE_IP"
+      }, 
+      "sessionpersistence": null, 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "subnets": {
+    "b4323537-d2e4-4ed9-a165-65ca5f7271b7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "created_at": "2017-05-30T16:30:54", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:54"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [
+    {
+      "action": "REJECT", 
+      "admin_state_up": true, 
+      "description": "", 
+      "id": "01215b54-0c1c-48c7-b5a0-1ac109d61a6e", 
+      "listener_id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "name": "esd_demo_1", 
+      "position": 1, 
+      "provisioning_status": "ACTIVE", 
+      "redirect_pool_id": null, 
+      "redirect_url": null, 
+      "rules": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "1462dab7-1644-4b99-9fde-bec6aca83cd4", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "l7_policies": [
+        {
+          "id": "01215b54-0c1c-48c7-b5a0-1ac109d61a6e"
+        }
+      ], 
+      "loadbalancer_id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "name": "l1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+    "listeners": [
+      {
+        "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+    "operating_status": "ONLINE", 
+    "pools": [
+      {
+        "id": "1462dab7-1644-4b99-9fde-bec6aca83cd4"
+      }
+    ], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:0d1449d4-e8a5-5f10-be72-8a568cc3a46c", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-05-30T20:09:50", 
+      "description": null, 
+      "device_id": "8d5bd554-47f7-5a53-a69e-8bf783eed8ef", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+        }
+      ], 
+      "id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+      "mac_address": "fa:16:3e:25:01:f6", 
+      "name": "loadbalancer-e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "security_groups": [
+        "28d1dd36-36bf-423e-9927-ece66845a6f4"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T20:09:51"
+    }, 
+    "vip_port_id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+    "vip_subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+    "vxlan_vteps": [
+      "201.0.168.1", 
+      "201.0.162.1", 
+      "201.0.150.10", 
+      "201.0.169.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "0b9235cc-608f-4c82-90b7-aaaa1376be8d": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-05-30T16:30:52", 
+      "description": "", 
+      "id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 48, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+      ], 
+      "tags": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:52", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "Should not override ESD session persistence", 
+      "healthmonitor_id": null, 
+      "id": "1462dab7-1644-4b99-9fde-bec6aca83cd4", 
+      "l7_policies": [], 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listener_id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "listeners": [
+        {
+          "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9"
+        }
+      ], 
+      "loadbalancer_id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "members": [], 
+      "name": "p1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "PENDING_DELETE", 
+      "session_persistence": {
+        "cookie_name": null, 
+        "type": "SOURCE_IP"
+      }, 
+      "sessionpersistence": null, 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "subnets": {
+    "b4323537-d2e4-4ed9-a165-65ca5f7271b7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "created_at": "2017-05-30T16:30:54", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:54"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [
+    {
+      "action": "REJECT", 
+      "admin_state_up": true, 
+      "description": "", 
+      "id": "01215b54-0c1c-48c7-b5a0-1ac109d61a6e", 
+      "listener_id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "name": "esd_demo_1", 
+      "position": 1, 
+      "provisioning_status": "PENDING_DELETE", 
+      "redirect_pool_id": null, 
+      "redirect_url": null, 
+      "rules": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": null, 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "l7_policies": [
+        {
+          "id": "01215b54-0c1c-48c7-b5a0-1ac109d61a6e"
+        }
+      ], 
+      "loadbalancer_id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "name": "l1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+    "listeners": [
+      {
+        "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+    "operating_status": "ONLINE", 
+    "pools": [], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:0d1449d4-e8a5-5f10-be72-8a568cc3a46c", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-05-30T20:09:50", 
+      "description": null, 
+      "device_id": "8d5bd554-47f7-5a53-a69e-8bf783eed8ef", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+        }
+      ], 
+      "id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+      "mac_address": "fa:16:3e:25:01:f6", 
+      "name": "loadbalancer-e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "security_groups": [
+        "28d1dd36-36bf-423e-9927-ece66845a6f4"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T20:09:51"
+    }, 
+    "vip_port_id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+    "vip_subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+    "vxlan_vteps": [
+      "201.0.168.1", 
+      "201.0.162.1", 
+      "201.0.150.10", 
+      "201.0.169.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "0b9235cc-608f-4c82-90b7-aaaa1376be8d": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-05-30T16:30:52", 
+      "description": "", 
+      "id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 48, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+      ], 
+      "tags": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:52", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "b4323537-d2e4-4ed9-a165-65ca5f7271b7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "created_at": "2017-05-30T16:30:54", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:54"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": null, 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9", 
+      "l7_policies": [], 
+      "loadbalancer_id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "name": "l1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "PENDING_DELETE", 
+      "sni_containers": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+    "listeners": [
+      {
+        "id": "0014ccd2-b047-4708-a3ff-18cd77d465d9"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+    "operating_status": "ONLINE", 
+    "pools": [], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:0d1449d4-e8a5-5f10-be72-8a568cc3a46c", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-05-30T20:09:50", 
+      "description": null, 
+      "device_id": "8d5bd554-47f7-5a53-a69e-8bf783eed8ef", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+        }
+      ], 
+      "id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+      "mac_address": "fa:16:3e:25:01:f6", 
+      "name": "loadbalancer-e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "security_groups": [
+        "28d1dd36-36bf-423e-9927-ece66845a6f4"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T20:09:51"
+    }, 
+    "vip_port_id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+    "vip_subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+    "vxlan_vteps": [
+      "201.0.168.1", 
+      "201.0.162.1", 
+      "201.0.150.10", 
+      "201.0.169.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "0b9235cc-608f-4c82-90b7-aaaa1376be8d": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-05-30T16:30:52", 
+      "description": "", 
+      "id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 48, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+      ], 
+      "tags": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:52", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "b4323537-d2e4-4ed9-a165-65ca5f7271b7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "created_at": "2017-05-30T16:30:54", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:54"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+    "listeners": [], 
+    "name": "lb1", 
+    "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+    "operating_status": "ONLINE", 
+    "pools": [], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_DELETE", 
+    "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:0d1449d4-e8a5-5f10-be72-8a568cc3a46c", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-05-30T20:09:50", 
+      "description": null, 
+      "device_id": "8d5bd554-47f7-5a53-a69e-8bf783eed8ef", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+        }
+      ], 
+      "id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+      "mac_address": "fa:16:3e:25:01:f6", 
+      "name": "loadbalancer-e00ee8a6-f22d-428c-b896-c3ffcd34c9ae", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "security_groups": [
+        "28d1dd36-36bf-423e-9927-ece66845a6f4"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T20:09:51"
+    }, 
+    "vip_port_id": "03161354-f688-4261-b61e-36dfca5d03b4", 
+    "vip_subnet_id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+    "vxlan_vteps": [
+      "201.0.168.1", 
+      "201.0.162.1", 
+      "201.0.150.10", 
+      "201.0.169.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "0b9235cc-608f-4c82-90b7-aaaa1376be8d": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-05-30T16:30:52", 
+      "description": "", 
+      "id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 48, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "b4323537-d2e4-4ed9-a165-65ca5f7271b7"
+      ], 
+      "tags": [], 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:52", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "b4323537-d2e4-4ed9-a165-65ca5f7271b7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "created_at": "2017-05-30T16:30:54", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "b4323537-d2e4-4ed9-a165-65ca5f7271b7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "0b9235cc-608f-4c82-90b7-aaaa1376be8d", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "041f8b2e7cf04496bf31775419d77394", 
+      "updated_at": "2017-05-30T16:30:54"
+    }
+  }
+}]


### PR DESCRIPTION
@szakeri 
#### What issues does this address?
Fixes #723

#### What's this change do?
Problem: Persistence profiles applied by an ESD can be overwritten by
pool session persistence. ESDs should take precedence.

Analysis: Assure method operations have pools following l7policies, so
that pools with session persistence end up replacing persistence set
in L7 polcies ESDs. Change order so that L7 policies follow both
pool create and delete assure methods.

Tests: existing tests: tempest test_esd.py and agent test_esd.py.
Also, create new test, test_esd_pools.py.

#### Where should the reviewer start?
lbaas_builder.py

#### Any background context?
Session persistence in LBaaS is a pool attribute. In BIG-IP/ESD it is a listener/virtual server attribute. Pool operations (create/delete) can set session persistence on a virtual server so we need to make sure the ESD operations happen after both pool create and delete.
