### PR TITLE
Makefile needs to be prepared for newton running in nightly

### DIFF
--- a/systest/Makefile
+++ b/systest/Makefile
@@ -72,12 +72,18 @@ PROJDIR := $(shell dirname $(realpath $(MAKEFILE_DIR)))
 TAGINFO := $(shell git describe --long --tags --first-parent)
 
 # git branch
-BRANCH := liberty
+BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+
+# The branch may contain the text 'stable/' before the OpenStack release name
+# To allow this type of branch name and any other to work with the cloud deployment
+# and with Jenkins, we should strip out the forward slash, leaving something like:
+# stable/newton -> stablenewton
+SANITIZED_BRANCH := $(subst /,,$(BRANCH))
 
 # /ASB/PATH/systest/test_results: This is where the CI system will look
 # for test reuslts.
 RESULTS_DIR := $(MAKEFILE_DIR)/test_results
-TESTENVLOGDIR := $(RESULTS_DIR)/f5-openstack-agent_$(BRANCH)/testenv
+TESTENVLOGDIR := $(RESULTS_DIR)/f5-openstack-agent_$(SANITIZED_BRANCH)/testenv
 
 #### INITIALIZATION SECTION
 #    Since all tests will run on the same CI worker, and we do not (yet)
@@ -92,7 +98,7 @@ setup:
 #### UNITTEST SECTION:
 unit-tests: setup
 	-@echo executing $@
-	export GP_SUFFIX=f5-openstack-agent_$(BRANCH)-unit &&
+	export GP_SUFFIX=f5-openstack-agent_$(SANITIZED_BRANCH)-unit &&
 	export GUMBALLS_PROJECT=$(RESULTS_DIR)/$${GP_SUFFIX} &&
 	tox -e unit --sitepackages -- \
 		--cov $(PROJDIR)/f5_openstack_agent \
@@ -115,12 +121,12 @@ $(DEPLOYS): setup
 	. $(MAKEFILE_DIR)/device_version_maps.sh &&
 	export BIGIP_VER=`python -c 'print("$@".split("-")[0].replace(".", "_"))'` &&
 	export DEVICEVERSION=BIGIP_$${BIGIP_VER} &&
-	export TESTENV_NAME=agent_$(BRANCH)_v$${BIGIP_VER}_bigip &&
+	export TESTENV_NAME=agent_$(SANITIZED_BRANCH)_v$${BIGIP_VER}_bigip &&
 	export TESTENV_CONF=bigip.testenv.yaml &&
 	export CLOUD=`python -c 'print("$@".split("-")[1])'` &&
 	export TIMESTAMP=`date +"%Y%m%d-%H%M%S"` &&
 	export GUMBALLS_SESSION=$(TAGINFO)_$${TIMESTAMP} &&
-	export GP_SUFFIX=f5-openstack-agent_$(BRANCH)-$@ &&
+	export GP_SUFFIX=f5-openstack-agent_$(SANITIZED_BRANCH)-$@ &&
 	$(MAKE) -C . run_$${CLOUD}_tests
 
 # Currently does nothing in f5-openstack-agent


### PR DESCRIPTION
@zancas 
#### What issues does this address?
Fixes #747 

#### What's this change do?
Created a SANITIZED_BRANCH variable in the makefile. This represents the
branch name without any forward slashes. That variable is used in path
names wherever necessary.

#### Where should the reviewer start?

#### Any background context?
The systest Makefile needs to be able to handle a branch name of
stable/newton. That means we need to sanitize the name to strip out the
forward slash. This is necessary because forward slashes can and will
introduce all sorts of fun issues when that branch name is used in say,
a directory path. Also, jenkins will not allow a job named with a
forward slash. So, we will sanitize that name, then to get the OpenStack
distro, we can strip the 'stable' string out of that sanitized branch
name. This allows us to match the branch name as closely as possible for
internal test reporting.

Tested on local jenkins container. The project names appear to have not changed. Here's my result-set compared to trtl's project names:

My test container:
`pytest-autolog: outputdir is /home/testlab/f5-openstack-agent/systest/test_results/singlebigip_f5-openstack-agent_liberty-12.1.1-overcloud/v8.3.1.b1-10-g0b2a5a9_20170531-093037`
Latest jenkins build:
`pytest-autolog: outputdir is /home-local/jenkins/workspace/openstack/agent/liberty/12.1.1-overcloud/systest/test_results/singlebigip_f5-openstack-agent_liberty-12.1.1-overcloud/v8.3.1.b1-9-g7631255_20170531-003154`

My test container:
`pytest-autolog: outputdir is /home/testlab/f5-openstack-agent/systest/test_results/disconnected_singlebigip_f5-openstack-agent_liberty-12.1.1-overcloud/v8.3.1.b1-10-g0b2a5a9_20170531-093037`
`pytest-autolog: outputdir is /home-local/jenkins/workspace/openstack/agent/liberty/12.1.1-overcloud/systest/test_results/disconnected_singlebigip_f5-openstack-agent_liberty-12.1.1-overcloud/v8.3.1.b1-9-g7631255_20170531-003154`