### PR TITLE
changing port creation error to warning for member

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -249,8 +249,7 @@ class LBaaSBuilder(object):
 
             if 'port' not in member and \
                member['provisioning_status'] != plugin_const.PENDING_DELETE:
-                LOG.error("Member definition does not include Neutron port")
-                continue
+                LOG.warning("Member definition does not include Neutron port")
 
             # delete member if pool is being deleted
             if member['provisioning_status'] == plugin_const.PENDING_DELETE or\

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/conftest.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/conftest.py
@@ -71,6 +71,7 @@ def pool_member_service():
                 u'operating_status': u'ONLINE',
                 u'pool_id': u'2dbca6cd-30d8-4013-9c9a-df0850fabf52',
                 u'protocol_port': 8080,
+                u'port': u'port',
                 u'provisioning_status': u'ACTIVE',
                 u'subnet_id': u'81f42a8a-fc98-4281-8de4-2b946e931457',
                 u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd',
@@ -84,11 +85,13 @@ def pool_member_service():
                 u'operating_status': u'ONLINE',
                 u'pool_id': u'2dbca6cd-30d8-4013-9c9a-df0850fabf52',
                 u'protocol_port': 8080,
+                u'port': u'port',
                 u'provisioning_status': u'ACTIVE',
                 u'subnet_id': u'81f42a8a-fc98-4281-8de4-2b946e931457',
                 u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd',
                 u'weight': 10}],
-        u'pool': {
+        u'pools': [
+            {
             u'admin_state_up': True,
             u'description': u'',
             u'healthmonitor_id': u'70fed03a-efc4-460a-8a21',
@@ -102,5 +105,5 @@ def pool_member_service():
             u'provisioning_status': u'ACTIVE',
             u'session_persistence': None,
             u'sessionpersistence': None,
-            u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd'}
-        }
+            u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd'}]
+    }

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/conftest.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/conftest.py
@@ -71,7 +71,6 @@ def pool_member_service():
                 u'operating_status': u'ONLINE',
                 u'pool_id': u'2dbca6cd-30d8-4013-9c9a-df0850fabf52',
                 u'protocol_port': 8080,
-                u'port': u'port',
                 u'provisioning_status': u'ACTIVE',
                 u'subnet_id': u'81f42a8a-fc98-4281-8de4-2b946e931457',
                 u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd',
@@ -85,13 +84,11 @@ def pool_member_service():
                 u'operating_status': u'ONLINE',
                 u'pool_id': u'2dbca6cd-30d8-4013-9c9a-df0850fabf52',
                 u'protocol_port': 8080,
-                u'port': u'port',
                 u'provisioning_status': u'ACTIVE',
                 u'subnet_id': u'81f42a8a-fc98-4281-8de4-2b946e931457',
                 u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd',
                 u'weight': 10}],
-        u'pools': [
-            {
+        u'pool': {
             u'admin_state_up': True,
             u'description': u'',
             u'healthmonitor_id': u'70fed03a-efc4-460a-8a21',
@@ -105,5 +102,5 @@ def pool_member_service():
             u'provisioning_status': u'ACTIVE',
             u'session_persistence': None,
             u'sessionpersistence': None,
-            u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd'}]
-    }
+            u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd'}
+        }

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_lbaas_builder.py
@@ -86,6 +86,19 @@ def service():
                       u'subnet_id': u'81f42a8a-fc98-4281-8de4-2b946e931457',
                       u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd',
                       u'port': 'port',
+                      u'weight': 1},
+                     {u'address': u'10.2.2.4',
+                      u'admin_state_up': True,
+                      u'id': u'1e7bfa17-a38f-4728-a3a7-aad85da69712',
+                      u'name': u'',
+                      u'network_id': u'cdf1eb6d-9b17-424a-a054-778f3d3a5490',
+                      u'operating_status': u'ONLINE',
+                      u'pool_id': u'2dbca6cd-30d8-4013-9c9a-df0850fabf52',
+                      u'protocol_port': 8080,
+                      u'provisioning_status': u'ACTIVE',
+                      u'subnet_id': u'81f42a8a-fc98-4281-8de4-2b946e931457',
+                      u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd',
+                      u'port': 'port',
                       u'weight': 1}],
         u'pools': [{u'admin_state_up': True,
                     u'description': u'',
@@ -155,13 +168,13 @@ class TestLbaasBuilder(object):
 
         builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
         service = copy.deepcopy(pool_member_service)
-        members = builder._get_pool_members(service, service['pools'][0]['id'])
+        members = builder._get_pool_members(service, service['pool']['id'])
         assert len(members) == 2
 
         # Modify pool_id of both members, expect no members returned
         service['members'][0]['pool_id'] = 'test'
         service['members'][1]['pool_id'] = 'test'
-        members = builder._get_pool_members(service, service['pools'][0]['id'])
+        members = builder._get_pool_members(service, service['pool']['id'])
         assert members == []
 
     def test_assure_members_update_exception(self, service):
@@ -203,36 +216,26 @@ class TestLbaasBuilder(object):
                         'lbaas_builder.LOG') as mock_log:
             builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
             service['members'][0].pop('port', None)
-            builder._assure_members(service, mock.MagicMock())
-            assert mock_log.warning.call_args_list == \
-                    [mock.call('Member definition does not include Neutron port')]
-
-
-    def test_assure_member_has_two_port_poolmember(self, pool_member_service):
-        with mock.patch('f5_openstack_agent.lbaasv2.drivers.bigip.'
-                        'lbaas_builder.LOG') as mock_log:
-            builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
-            builder._assure_members(pool_member_service, mock.MagicMock())
-            assert mock_log.warning.call_args_list == []
-
-    def test_assure_member_has_no_port_poolmember(self, pool_member_service):
-        with mock.patch('f5_openstack_agent.lbaasv2.drivers.bigip.'
-                        'lbaas_builder.LOG') as mock_log:
-            builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
-            service = pool_member_service
-            service['members'][0].pop('port', None)
             service['members'][1].pop('port', None)
             builder._assure_members(service, mock.MagicMock())
-            assert mock_log.warning.call_args_list == \
-                    [mock.call('Member definition does not include Neutron port'),
-                     mock.call('Member definition does not include Neutron port')]
+            assert \
+                mock_log.warning.call_args_list == \
+                [mock.call('Member definition does not include Neutron port'),
+                 mock.call('Member definition does not include Neutron port')]
 
-    def test_assure_member_has_one_port_poolmember(self, pool_member_service):
+    def test_assure_member_has_one_port(self, service):
         with mock.patch('f5_openstack_agent.lbaasv2.drivers.bigip.'
                         'lbaas_builder.LOG') as mock_log:
             builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
-            service = pool_member_service
             service['members'][0].pop('port', None)
             builder._assure_members(service, mock.MagicMock())
-            assert mock_log.warning.call_args_list == \
-                    [mock.call('Member definition does not include Neutron port')]
+            assert \
+                mock_log.warning.call_args_list == \
+                [mock.call('Member definition does not include Neutron port')]
+
+    def test_assure_member_has_two_ports(self, service):
+        with mock.patch('f5_openstack_agent.lbaasv2.drivers.bigip.'
+                        'lbaas_builder.LOG') as mock_log:
+            builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
+            builder._assure_members(service, mock.MagicMock())
+            assert mock_log.warning.call_args_list == []


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
Fixes #749 

#### What's this change do?
This change will address the appropriate code modification that needs to be made to the agent because we no longer support member port creation in the driver. It also includes unit tests for the change.

#### Where should the reviewer start?
code change: lbaas_builder.py
new unit-tests: test_lbaas_builder.py

#### Any background context?
Previously driver handled port creation in case it couldn't find a member port and if agent couldn't find a member port it throws error. We don't support this functionality in the driver anymore and as a result agent needs to change to print a warning in case no port is found.