### PR TITLE
Agent expects to add fdb entries for each pool member port that exists

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
@@ -703,7 +703,9 @@ class NetworkServiceBuilder(object):
                 self.l2_service.add_bigip_fdbs(
                     bigip, net_folder, fdb_info, member)
             else:
-                member['provisioning_status'] = plugin_const.ERROR
+                LOG.warning('LBaaS member, %s, is not associated with Neutron '
+                            'port. No fdb entries will be created for this '
+                            'member.' % member['address'])
 
     def delete_bigip_member_l2(self, bigip, loadbalancer, member):
         # Delete pool member l2 records
@@ -722,11 +724,11 @@ class NetworkServiceBuilder(object):
                 self.l2_service.delete_bigip_fdbs(
                     bigip, net_folder, fdb_info, member)
             else:
-                LOG.error('Member on SDN has no port. Manual '
-                          'removal on the BIG-IP will be '
-                          'required. Was the vm instance '
-                          'deleted before the pool member '
-                          'was deleted?')
+                LOG.warning('LBaaS member, %s, is not assoicated with '
+                            'Neutron port. If any fdb entries were '
+                            'created for this member, they may need to be '
+                            'removed from the BIG-IP device.'
+                            % member['address'])
 
     def update_bigip_vip_l2(self, bigip, loadbalancer):
         # Update vip l2 records


### PR DESCRIPTION
@jlongstaf @szakeri 

#### What issues does this address?
Fixes #754 

#### What's this change do?
Removed the code in the update and delete member in network_service
module and put in a LOG.warning message to inform the user that no port
was associated with the member and no fdb entries were created/removed.

#### Where should the reviewer start?

#### Any background context?
The agent will add forwarding database entries for each pool member
added to a pool. This means that it is expecting information from the
member's port to create those fdb entries. With the new change to ignore
port existence, we allow that member to get to the network_service.py
without a port. If no port is found, the member's provisioning status is
set to ERROR. Note that this is also the case when we are deleting a
member as well.

Ran the test_member_status.py tests against this change. These were the
tests that failed and uncovered this issue.