### PR TITLE
Fixes: issue #760 - docs build is broken

### DIFF
--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -1,3 +1,2 @@
-Sphinx>=1.5.3
-six>=1.10.0
+Sphinx>=1.5.5
 git+https://github.com/f5devcentral/f5-sphinx-theme@master


### PR DESCRIPTION
@jlongstaf @richbrowne 

#### What issues does this address?
Fixes #760 

#### What's this change do?
Bumps the minimum required version number for sphinx in requirements.docs.txt to address a build failure on Read the Docs.

I built the docs locally to make sure it worked, but we won't really know until the fix is in and we try to build docs on RTD.

#### Where should the reviewer start?

#### Any background context?
N/A