### PR TITLE
Store Jenkins build info alongside systest results.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,14 +11,11 @@ pipeline {
         stage("systest") {
             steps {
                 sh '''
-                    # - source this job's environment variables
-                    export ENV_FILE=systest/${JOB_BASE_NAME}.env
-                    if [ -e $ENV_FILE ]; then
-                        . $ENV_FILE
-                    fi
+                    # - initialize env vars
+                    . systest/scripts/init_env.sh
 
-                    # - print build properties
-                    printenv | sort | grep -v OS_PASSWORD
+                    # - record start of build
+                    systest/scripts/record_build_start.sh
 
                     # - setup ssh agent
                     eval $(ssh-agent -s)
@@ -27,10 +24,8 @@ pipeline {
                     # - run tests
                     make -C systest $JOB_BASE_NAME
 
-                    # - copy results files to nfs
-                    #   (note that the nfs results directory is mounted inside
-                    #   the CI worker's home directory)
-                    cp -r $WORKSPACE/systest/test_results/* ~/results/
+                    # - record results
+                    systest/scripts/record_results.sh
                 '''
             }
         }

--- a/systest/scripts/init_env.sh
+++ b/systest/scripts/init_env.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# - JOB_NAME is provided by Jenkins (eg. "openstack/agent/liberty/unit-tests")
+export CI_PROGRAM=$(echo $JOB_NAME | cut -d "/" -f 1)
+export CI_PROJECT=$(echo $JOB_NAME | cut -d "/" -f 2)
+export CI_BRANCH=$(echo $JOB_NAME | cut -d "/" -f 3)
+
+job_dirname="${CI_PROGRAM}.${CI_PROJECT}.${CI_BRANCH}.${JOB_BASE_NAME}"
+build_dirname="${JOB_BASE_NAME}-${BUILD_ID}"
+export CI_RESULTS_DIR="/home/jenkins/results/${job_dirname}/${build_dirname}"
+export CI_BUILD_SUMMARY="${CI_RESULTS_DIR}/ci-build.yaml"
+
+# - source this job's environment variables
+export CI_ENV_FILE=systest/${JOB_BASE_NAME}.env
+if [ -e $CI_ENV_FILE ]; then
+    . $CI_ENV_FILE
+fi
+
+# - print env vars
+printenv | sort | grep -v OS_PASSWORD

--- a/systest/scripts/record_build_start.sh
+++ b/systest/scripts/record_build_start.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# - write Jenkins build info to disk
+mkdir -p $CI_RESULTS_DIR
+echo "id: $BUILD_ID" > $CI_BUILD_SUMMARY
+echo "url: ${BUILD_URL}consoleFull" >> $CI_BUILD_SUMMARY
+echo "commit: $(git rev-parse HEAD)" >> $CI_BUILD_SUMMARY
+echo "start_dt: $(date +"%Y%m%d-%H%M%S")" >> $CI_BUILD_SUMMARY

--- a/systest/scripts/record_results.sh
+++ b/systest/scripts/record_results.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -ex
+
+# - copy results files to nfs (note that the nfs results directory is mounted
+#    inside the CI worker's home directory)
+cp -r $WORKSPACE/systest/test_results/* $CI_RESULTS_DIR/


### PR DESCRIPTION
Issues:
Fixes #771

Problem:
- We want to link systest results in trtl to their corresponding builds
  in Jenkins.

Analysis:
- Update the Jenkinsfile to capture information about the Jenkins build
  that is executing it.

Tests:
Ran the liberty unit-tests and 12.1.1-overcloud-vxlan Jenkins jobs and
verified the Jenkinsfile executed as expected.

@<reviewer_id>
#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?
