### PR TITLE
Pool references to multiple listeners can be incorrect

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -170,9 +170,9 @@ class LBaaSBuilder(object):
                         loadbalancer, pool)
 
                     # get associated listeners for pool
-                    for listener in pool['listeners']:
-                        svc['listener'] = \
-                            self.get_listener_by_id(service, listener['id'])
+                    listeners = self._get_pool_listeners(service, pool['id'])
+                    for listener in listeners:
+                        svc['listener'] = listener
                         self.listener_builder.update_listener_pool(
                             svc, pool_name["name"], bigips)
 
@@ -190,6 +190,13 @@ class LBaaSBuilder(object):
                     pool['provisioning_status'] = plugin_const.ERROR
                     loadbalancer['provisioning_status'] = plugin_const.ERROR
                     raise f5_ex.PoolCreationException(err.message)
+
+    def _get_pool_listeners(self, service, pool_id):
+        pools_listeners = []
+        for listener in service['listeners']:
+            if listener['default_pool_id'] == pool_id:
+                pools_listeners.append(listener)
+        return pools_listeners
 
     def _get_pool_members(self, service, pool_id):
         '''Return a list of members associated with given pool.'''
@@ -337,13 +344,12 @@ class LBaaSBuilder(object):
                 try:
 
                     # update listeners for pool
-                    for listener in pool['listeners']:
-                        svc['listener'] = \
-                            self.get_listener_by_id(service, listener['id'])
-
+                    listeners = self._get_pool_listeners(service, pool['id'])
+                    for listener in listeners:
+                        svc['listener'] = listener
                         # remove pool name from virtual before deleting pool
                         self.listener_builder.update_listener_pool(
-                            svc, "", bigips)
+                            svc, '', bigips)
 
                         self.listener_builder.remove_session_persistence(
                             svc, bigips)


### PR DESCRIPTION
@jlongstaf 

#### What issues does this address?
Fixes #770

#### What's this change do?
Updated the _assure_pools_created and _assure_pools_deleted methods to
use the listener's pools instead of the pool's list of listeners.

#### Where should the reviewer start?

#### Any background context?
The assure_pools_created/deleted methods in lbaas_builder.py should rely
upon the top-level listeners for references to which pool each listener
is attached to. This means changing those methods to filter listeners
based upon the current pool being processed. If the current pool is not
referenced by any listeners, then it is a detached pool. If it is being
referenced by one or more listeners, then the listeners will then be
updated with that pool. This change is related to
F5Networks/f5-openstack-lbaasv2-driver#611 in the driver, which aims to
cleanup the service object in order to avoid confusion when inspecting
the object.

Created a couple of unit tests to ensure the iteration works as
expected. We are relying on one existing test in the driver and a new
test in the driver to perform the functional testing.