### PR TITLE
pin eventlet to 0.19.0

### DIFF
--- a/requirements.unittest.txt
+++ b/requirements.unittest.txt
@@ -13,3 +13,4 @@ pytest-cov==2.3.1
 responses==0.5.1
 coverage==4.2
 python-coveralls==2.8.0
+eventlet==0.19.0


### PR DESCRIPTION
eventlet==0.21.0 is not compatible with python 2.7.13