### PR TITLE
Fix get_subnets_to_assure()

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
@@ -961,7 +961,6 @@ class NetworkServiceBuilder(object):
         networks = dict()
         loadbalancer = service['loadbalancer']
         service_adapter = self.service_adapter
-
         lb_status = loadbalancer['provisioning_status']
         if lb_status != plugin_const.PENDING_DELETE:
             if 'network_id' in loadbalancer:
@@ -973,9 +972,9 @@ class NetworkServiceBuilder(object):
                     service,
                     loadbalancer['vip_subnet_id']
                 )
-                networks[network['id']] = {'network': network,
-                                           'subnet': subnet,
-                                           'is_for_member': False}
+                networks[subnet['id']] = {'network': network,
+                                          'subnet': subnet,
+                                          'is_for_member': False}
 
         for member in service['members']:
             if member['provisioning_status'] != plugin_const.PENDING_DELETE:
@@ -988,7 +987,8 @@ class NetworkServiceBuilder(object):
                         service,
                         member['subnet_id']
                     )
-                    networks[network['id']] = {'network': network,
-                                               'subnet': subnet,
-                                               'is_for_member': True}
+                    networks[subnet['id']] = {'network': network,
+                                              'subnet': subnet,
+                                              'is_for_member': True}
+
         return networks.values()

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_network_service.py
@@ -18,6 +18,8 @@ from collections import namedtuple
 from f5_openstack_agent.lbaasv2.drivers.bigip import exceptions as f5_ex
 from f5_openstack_agent.lbaasv2.drivers.bigip.network_service import \
     NetworkServiceBuilder
+from f5_openstack_agent.lbaasv2.drivers.bigip.service_adapter import \
+    ServiceModelAdapter
 
 import mock
 import netaddr
@@ -119,12 +121,213 @@ def subnet():
 
 
 @pytest.fixture
+def service():
+    return {
+        'subnets': {
+            '2c2deedd-9a4e-47c6-aeb3-148c6042707d': {
+                'name': 'sub1',
+                'enable_dhcp': True,
+                'network_id': '8f398b94-635e-4a58-9f70-bf4d93f206a6',
+                'tenant_id': 'b95f6e974471433eb9f482303a5da291',
+                'dns_nameservers': [],
+                'gateway_ip': '10.2.5.1',
+                'ipv6_ra_mode': None,
+                'allocation_pools': [{
+                    'start': '10.2.5.2',
+                    'end': '10.2.5.254'
+                }],
+                'host_routes': [],
+                'shared': True,
+                'ip_version': 4,
+                'ipv6_address_mode': None,
+                'cidr': '10.2.5.0/24',
+                'id': '2c2deedd-9a4e-47c6-aeb3-148c6042707d',
+                'subnetpool_id': None
+            },
+            '30715508-bdde-4aed-90d9-7aa86adb2214': {
+                'name': 'mgmt_v4_subnet',
+                'enable_dhcp': True,
+                'network_id': '8f398b94-635e-4a58-9f70-bf4d93f206a6',
+                'tenant_id': 'b95f6e974471433eb9f482303a5da291',
+                'dns_nameservers': ['10.190.20.5', '10.190.0.20'],
+                'gateway_ip': '10.2.4.1',
+                'ipv6_ra_mode': None,
+                'allocation_pools': [{
+                    'start': '10.2.4.100',
+                    'end': '10.2.4.150'
+                }],
+                'host_routes': [],
+                'shared': True,
+                'ip_version': 4,
+                'ipv6_address_mode': None,
+                'cidr': '10.2.4.0/24',
+                'id': '30715508-bdde-4aed-90d9-7aa86adb2214',
+                'subnetpool_id': None
+            },
+            '237dc7ae-d56d-4c64-a4c3-ea984ff6de0b': {
+                'name': 'sub2',
+                'enable_dhcp': True,
+                'network_id': '8f398b94-635e-4a58-9f70-bf4d93f206a6',
+                'tenant_id': 'b95f6e974471433eb9f482303a5da291',
+                'dns_nameservers': [],
+                'gateway_ip': '10.2.6.1',
+                'ipv6_ra_mode': None,
+                'allocation_pools': [{
+                    'start': '10.2.6.2',
+                    'end': '10.2.6.254'
+                }],
+                'host_routes': [],
+                'shared': True,
+                'ip_version': 4,
+                'ipv6_address_mode': None,
+                'cidr': '10.2.6.0/24',
+                'id': '237dc7ae-d56d-4c64-a4c3-ea984ff6de0b',
+                'subnetpool_id': None
+            }
+        },
+        'listeners': [{
+            'protocol_port': 80,
+            'protocol': 'HTTP',
+            'description': '',
+            'default_tls_container_id': None,
+            'tenant_id': 'b95f6e974471433eb9f482303a5da291',
+            'admin_state_up': True,
+            'connection_limit': -1,
+            'id': '6aa36094-5ecd-422c-a3d3-723476ef6ab2',
+            'sni_containers': [],
+            'provisioning_status': 'ACTIVE',
+            'default_pool_id': 'b0fa36ef-c125-460b-b94c-174139915af7',
+            'loadbalancer_id': 'b0ac477a-a334-4bc9-8071-13692eee2d4e',
+            'operating_status': 'ONLINE',
+            'name': 'l1'
+        }],
+        'healthmonitors': [],
+        'members': [{
+            'weight': 1,
+            'admin_state_up': True,
+            'subnet_id': '2c2deedd-9a4e-47c6-aeb3-148c6042707d',
+            'tenant_id': 'b95f6e974471433eb9f482303a5da291',
+            'provisioning_status': 'ACTIVE',
+            'pool_id': 'b0fa36ef-c125-460b-b94c-174139915af7',
+            'network_id': '8f398b94-635e-4a58-9f70-bf4d93f206a6',
+            'address': '10.2.5.10',
+            'protocol_port': 8080,
+            'id': 'dd1e0ccc-6bc9-4c8e-abe5-f5789f0a3e70',
+            'operating_status': 'NO_MONITOR'
+        }, {
+            'weight': 1,
+            'admin_state_up': True,
+            'subnet_id': '237dc7ae-d56d-4c64-a4c3-ea984ff6de0b',
+            'tenant_id': 'b95f6e974471433eb9f482303a5da291',
+            'provisioning_status': 'PENDING_CREATE',
+            'pool_id': 'b0fa36ef-c125-460b-b94c-174139915af7',
+            'network_id': '8f398b94-635e-4a58-9f70-bf4d93f206a6',
+            'address': '10.2.6.10',
+            'protocol_port': 8080,
+            'id': 'e4bbd6bd-d4e0-4737-8c31-02cd1935f08c',
+            'operating_status': 'OFFLINE'
+        }],
+        'pools': [{
+            'lb_algorithm': 'ROUND_ROBIN',
+            'protocol': 'HTTP',
+            'description': '',
+            'provisioning_status': 'ACTIVE',
+            'tenant_id': 'b95f6e974471433eb9f482303a5da291',
+            'admin_state_up': True,
+            'session_persistence': None,
+            'healthmonitor_id': None,
+            'listeners': [{
+                'id': '6aa36094-5ecd-422c-a3d3-723476ef6ab2'
+            }],
+            'members': [{
+                'id': 'dd1e0ccc-6bc9-4c8e-abe5-f5789f0a3e70'
+            }, {
+                'id': 'e4bbd6bd-d4e0-4737-8c31-02cd1935f08c'
+            }],
+            'sessionpersistence': None,
+            'id': 'b0fa36ef-c125-460b-b94c-174139915af7',
+            'operating_status': 'ONLINE',
+            'name': 'p1'
+        }],
+        'networks': {
+            '8f398b94-635e-4a58-9f70-bf4d93f206a6': {
+                'status': 'ACTIVE',
+                'subnets': ['2c2deedd-9a4e-47c6-aeb3-148c6042707d',
+                            '237dc7ae-d56d-4c64-a4c3-ea984ff6de0b',
+                            '30715508-bdde-4aed-90d9-7aa86adb2214'],
+                'name': 'tempest-mgmt-network',
+                'provider:physical_network': None,
+                'admin_state_up': True,
+                'tenant_id': 'b95f6e974471433eb9f482303a5da291',
+                'mtu': 0,
+                'router:external': False,
+                'vlan_transparent': None,
+                'shared': True,
+                'provider:network_type': 'vxlan',
+                'id': '8f398b94-635e-4a58-9f70-bf4d93f206a6',
+                'provider:segmentation_id': 22
+            }
+        },
+        'loadbalancer': {
+            'vxlan_vteps': ['201.0.156.1', '201.0.160.1', '201.0.157.10',
+                            '201.0.159.1'],
+            'name': 'lb1',
+            'provisioning_status': 'PENDING_UPDATE',
+            'network_id': '8f398b94-635e-4a58-9f70-bf4d93f206a6',
+            'tenant_id': 'b95f6e974471433eb9f482303a5da291',
+            'admin_state_up': True,
+            'provider': 'f5networks',
+            'id': 'b0ac477a-a334-4bc9-8071-13692eee2d4e',
+            'gre_vteps': [],
+            'listeners': [{
+                'id': '6aa36094-5ecd-422c-a3d3-723476ef6ab2'
+            }],
+            'vip_port_id': '56eff2ad-ede0-49fd-bf37-aa34c4f76e6e',
+            'vip_address': '10.2.4.104',
+            'vip_subnet_id': '30715508-bdde-4aed-90d9-7aa86adb2214',
+            'vip_port': {
+                'status': 'DOWN',
+                'binding:host_id': 'host-155.int.lineratesystems.com:e4d04069-3d8b-555c-a154-3e2486f7c92e',
+                'name': 'loadbalancer-b0ac477a-a334-4bc9-8071-13692eee2d4e',
+                'allowed_address_pairs': [],
+                'admin_state_up': True,
+                'network_id': '8f398b94-635e-4a58-9f70-bf4d93f206a6',
+                'dns_name': '',
+                'extra_dhcp_opts': [],
+                'mac_address': 'fa:16:3e:8d:ca:54',
+                'dns_assignment': [{
+                    'hostname': 'host-10-2-4-104',
+                    'ip_address': '10.2.4.104',
+                    'fqdn': 'host-10-2-4-104.openstacklocal.'
+                }],
+                'binding:vif_details': {},
+                'binding:vif_type': 'binding_failed',
+                'device_owner': 'network:f5lbaasv2',
+                'tenant_id': 'b95f6e974471433eb9f482303a5da291',
+                'binding:profile': {},
+                'binding:vnic_type': 'normal',
+                'fixed_ips': [{
+                    'subnet_id': '30715508-bdde-4aed-90d9-7aa86adb2214',
+                    'ip_address': '10.2.4.104'
+                }],
+                'id': '56eff2ad-ede0-49fd-bf37-aa34c4f76e6e',
+                'security_groups': ['b1d95c23-bdb8-4b5f-99c5-83ea4bdd08ee'],
+                'device_id': '1d69cdd3-e560-530a-b615-15bb7a18ba68'
+            },
+            'operating_status': 'ONLINE',
+            'description': ''
+        }
+    }
+
+
+@pytest.fixture
 def network_service(rds_cache):
     conf = mock.MagicMock()
     conf.vlan_binding_driver = None
     driver = mock.MagicMock()
     driver.conf = conf
     service = NetworkServiceBuilder(False, conf, driver)
+    service.service_adapter = ServiceModelAdapter(conf)
 
     # add a 'real' RD cache
     service.rds_cache = rds_cache
@@ -219,19 +422,39 @@ class TestNetworkServiceBuilder(object):
             network_service.assign_route_domain(tenant_id, network, subnet)
             assert network['route_domain_id'] == 1234
             assert mock.call('No route domain cache entry for vlan-600') in \
-                mock_log.debug.call_args_list
+                   mock_log.debug.call_args_list
             assert mock.call('max namespaces: 1') in \
-                mock_log.debug.call_args_list
+                   mock_log.debug.call_args_list
 
             # no cache entry, multiple namespaces
             network_service.conf.max_namespaces_per_tenant = 3
             network_service.assign_route_domain(tenant_id, network, subnet)
             assert network['route_domain_id'] == 2
             assert mock.call('max namespaces: 3') in \
-                mock_log.debug.call_args_list
+                   mock_log.debug.call_args_list
 
         # invalid network data
         with pytest.raises(f5_ex.InvalidNetworkType):
             network['provider:segmentation_id'] = 604
             network['provider:network_type'] = ''
             network_service.assign_route_domain(tenant_id, network, subnet)
+
+    def test_get_subnets_to_assure(self, network_service, service):
+        subnets = network_service._get_subnets_to_assure(service)
+        assert len(subnets) == 3
+
+        service['loadbalancer']['provisioning_status'] = 'PENDING_DELETE'
+        subnets = network_service._get_subnets_to_assure(service)
+        assert len(subnets) == 2
+
+        service['loadbalancer']['provisioning_status'] = 'ACTIVE'
+        subnets = network_service._get_subnets_to_assure(service)
+        assert len(subnets) == 3
+
+        service['members'].pop()
+        subnets = network_service._get_subnets_to_assure(service)
+        assert len(subnets) == 2
+
+        service['members'].pop()
+        subnets = network_service._get_subnets_to_assure(service)
+        assert len(subnets) == 1

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_network_service.py
@@ -287,7 +287,9 @@ def service():
             'vip_subnet_id': '30715508-bdde-4aed-90d9-7aa86adb2214',
             'vip_port': {
                 'status': 'DOWN',
-                'binding:host_id': 'host-155.int.lineratesystems.com:e4d04069-3d8b-555c-a154-3e2486f7c92e',
+                'binding:host_id':
+                    'host-155.int.lineratesystems.com:'
+                    'e4d04069-3d8b-555c-a154-3e2486f7c92e',
                 'name': 'loadbalancer-b0ac477a-a334-4bc9-8071-13692eee2d4e',
                 'allowed_address_pairs': [],
                 'admin_state_up': True,
@@ -422,16 +424,16 @@ class TestNetworkServiceBuilder(object):
             network_service.assign_route_domain(tenant_id, network, subnet)
             assert network['route_domain_id'] == 1234
             assert mock.call('No route domain cache entry for vlan-600') in \
-                   mock_log.debug.call_args_list
+                mock_log.debug.call_args_list
             assert mock.call('max namespaces: 1') in \
-                   mock_log.debug.call_args_list
+                mock_log.debug.call_args_list
 
             # no cache entry, multiple namespaces
             network_service.conf.max_namespaces_per_tenant = 3
             network_service.assign_route_domain(tenant_id, network, subnet)
             assert network['route_domain_id'] == 2
             assert mock.call('max namespaces: 3') in \
-                   mock_log.debug.call_args_list
+                mock_log.debug.call_args_list
 
         # invalid network data
         with pytest.raises(f5_ex.InvalidNetworkType):

--- a/requirements.unittest.txt
+++ b/requirements.unittest.txt
@@ -13,3 +13,4 @@ pytest-cov==2.3.1
 responses==0.5.1
 coverage==4.2
 python-coveralls==2.8.0
+eventlet==0.19.0


### PR DESCRIPTION

Problem: The use case of pool members allocated on different subnets but the same
network is not working.

Analysis: method _get_subnets_to_assure() assumes that a network only
has one subnet. Each subnet found that shares a network with another
then overrides the previous subnet. Modified return data to save
subnets by subnet ID, not network ID.


@pjbreaux 
#### What's this change do?
Fixes a bug in the network_service.py module that prevents the agent from understanding all subnets it needs to assure (i.e., provide networking support -- self IPs, etc.). More specifically, the change modifies _get_subnets_to_assure() to return a dict where subnets are saved by subnet ID, not network ID. Before the change, a configuration with members on different subnets but the same network would result in only one of the subnets being returned because network ID was used as the key. Now, with subnet ID as the key, all unique subnets will be returned.

#### Where should the reviewer start?
network_service.py

#### Any background context?
Customer found defect.

