### PR TITLE
Give Jenkinsfile greater control wrt its worker image.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,17 @@
 #!/usr/bin/env groovy
 
 pipeline {
-    agent { docker defaultWorker.getConfig("openstack-test") }
+    agent {
+        docker {
+            label "docker"
+            registryUrl "https://docker-registry.pdbld.f5net.com"
+            image "bdo/jenkins-worker-ubuntu-16.04:master"
+            args "-v /etc/localtime:/etc/localtime:ro" \
+                + " -v /srv/mesos/trtl/results:/home/jenkins/results" \
+                + " -v /srv/nfs:/testlab" \
+                + " --env-file /srv/kubernetes/infra/jenkins-worker/config/openstack-test.env"
+        }
+    }
     options {
         ansiColor('xterm')
         timestamps()

--- a/systest/scripts/install_test_infra.sh
+++ b/systest/scripts/install_test_infra.sh
@@ -18,12 +18,16 @@
 #### These commands are invoked by the CI worker during automated tests.
 #    The invocation at the time of this writing is in the "functest" rule
 #    in ../Makefile
-sudo -E apt-get update &&
-sudo -E apt-get install -y libssl-dev &&
-sudo -E apt-get install -y libffi-dev &&
-sudo -E pip install --upgrade pip &&
-sudo -E pip install tox &&
-sudo -E pip install git+ssh://git@gitlab.pdbld.f5net.com/bdo/testenv-all.git &&
-sudo -E pip install git+ssh://git@gitlab.pdbld.f5net.com/tools/pytest-meta.git &&
-sudo -E pip install git+ssh://git@gitlab.pdbld.f5net.com/tools/pytest-autolog.git &&
-sudo -E pip install git+ssh://git@gitlab.pdbld.f5net.com/tools/pytest-symbols.git
+apt-get update
+apt-get install -y libssl-dev
+apt-get install -y libffi-dev
+pip install --upgrade pip
+# - install testenv-all first because it has a bunch of pinned dependencies
+pip install git+ssh://git@gitlab.pdbld.f5net.com/bdo/testenv-all.git
+pip install git+ssh://git@gitlab.pdbld.f5net.com/tools/pytest-meta.git
+pip install git+ssh://git@gitlab.pdbld.f5net.com/tools/pytest-autolog.git
+pip install git+ssh://git@gitlab.pdbld.f5net.com/tools/pytest-symbols.git
+pip install tox virtualenv virtualenvwrapper
+
+# - list installed python packages
+pip freeze | tee python-pkgs.txt


### PR DESCRIPTION
@pjbreaux, @mattgreene, @zancas 

#### What issues does this address?
Fixes #791

#### What's this change do?
- Gives Jenkinsfile greater control wrt its worker image.
- Installs undocumented systest dependencies.

#### Where should the reviewer start?
n/a

#### Any background context?
no