### PR TITLE
Cherry-Pick from Mitaka: Common Networks handle added to the .ini conf file

### DIFF
--- a/etc/neutron/services/f5/f5-openstack-agent.ini
+++ b/etc/neutron/services/f5/f5-openstack-agent.ini
@@ -431,6 +431,12 @@ f5_snat_mode = True
 #
 f5_snat_addresses_per_subnet = 1
 #
+# This setting will cause all networks to be
+# defined under the common partition on the
+# BIG-IP rather than offer the flexibility to
+# assign networks to different partitions..
+f5_common_networks = False
+#
 # This setting will cause all networks with 
 # the router:external attribute set to True
 # to be created in the Common partition and

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -174,6 +174,10 @@ OPTS = [  # XXX maybe we should make this a dictionary
         help='Strict route domain isolation'
     ),
     cfg.BoolOpt(
+        'f5_common_networks', default=False,
+        help='All networks defined under Common partition'
+    ),
+    cfg.BoolOpt(
         'f5_common_external_networks', default=True,
         help='Treat external networks as common'
     ),

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_icontrol_driver_opts.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_icontrol_driver_opts.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import re
+
+import f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver as target
+
+import oslo_config.cfg as cfg
+
+opts = target.OPTS
+
+# For new entries, put the expected default and help=True or False for whether
+# it should have a help statement.
+expected = {'f5_common_networks': dict(default=False, help=True)}
+
+
+def test_opts_type():
+    """Check that all opts are a oslo_config.cfg.* object"""
+    type_check = re.compile('oslo_config\.cfg\.(\w+Opt)')
+    for opt in opts:
+        match = type_check.search(str(opt))
+        assert match, str("{} is not recognized as a oslo_config.cfg.*"
+                          " object!").format(opt)
+        assert hasattr(cfg, match.group(1)), \
+            str("{} is not a subclass of oslo_config.cfg").format(opt)
+
+
+def test_expected():
+    """test_expected - goes through the expected and validates
+
+    This test function will run through the expected dict and attempt to
+    determine that:
+    -   'key' is in the collected opts from build time
+    -   opts[x].name == 'key'
+    -   opts[x].help exits if expected['key']['help'] exists
+    -   opts[x].default == expected['key']['default']
+    This may not yet reflect all options in the opts; however, it should
+    reflect newly-added items.
+    """
+    global expected
+    collected = dict()
+    for opt in opts:
+        if opt.name in expected:
+            collected[opt.name] = opt
+    for exp_name in expected:
+        assert exp_name in collected, "{} not found in opts!".format(exp_name)
+        exp_result = expected[exp_name]
+        opt = collected[exp_name]
+        assert opt.help or not exp_result['help'], "{} help test".format(
+            exp_name)
+        if 'default' in exp_result:
+            assert opt.default == exp_result['default'], \
+                "{} default test".format(exp_name)


### PR DESCRIPTION
Issues:
Fixes #794

Problem:
* No handle for setting all networks into Common
* Inhibiting to the new feature for Common networks

Analysis:
* Adding an f5_common_networks handle in the ini config file
* Adding the boolean definition and default to `icontrol_driver.py`

Tests:
unit test ./test/test_icontrol_driver_opts.py

@pjbreaux 
#### What issues does this address?
Fixes #794 

#### What's this change do?
* Creates a variable to enable all created networks to be put into Common partition

#### Where should the reviewer start?
* The f5-openstack-agent.ini
* The icontrol_driver.py

#### Any background context?
* This is the first step towards adding this feature.