### PR TITLE
Feature.mitaka.common networks2 true

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
@@ -129,8 +129,13 @@ class L2ServiceBuilder(object):
             self.fdb_connector.set_context(context)
 
     def is_common_network(self, network):
-        # Does this network belong in the /Common folder?
+        """Returns True if this belongs in the /Common folder
+
+        This object method will return positive if the L2ServiceBuilder object
+        should be stored under the Common partition on the BIG-IP.
+        """
         return network['shared'] or \
+            self.conf.f5_common_networks or \
             (network['id'] in self.conf.common_network_ids) or \
             ('router:external' in network and
              network['router:external'] and

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_l2_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_l2_service.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from mock import Mock
+from mock import patch
+
+from f5_openstack_agent.lbaasv2.drivers.bigip.l2_service import \
+    L2ServiceBuilder
+
+
+class Test_L2ServiceBuilder(object):
+    """Performs tests against L2ServiceBuilder
+
+    The beginning variable assignments should reflect the items that should be
+    rotated back to their original values in code-space in the teardown()
+    method.  All items that are manipulated to mocks initially should be
+    performed in a fixture method when repeated.
+    """
+
+    @pytest.fixture(autouse=True)
+    def create_self(self, request):
+        """Creates a 'blank' L2ServiceBuilder instance in self
+
+        This method is executed for every test method during runtime.
+        """
+        request.addfinalizer(self.teardown)
+
+        # create our fake driver object...
+        self.driver = Mock()
+        self.driver.conf = Mock()
+        force_false = ['vlan_binding_driver']
+        list_vars = ['f5_external_physical_mappings']
+        for item in force_false:
+            setattr(self.driver.conf, item, False)
+        for item in list_vars:
+            setattr(self.driver.conf, item, list())
+
+        # set our mocks...
+        self.system_helper = Mock()
+        self.network_helper = Mock()
+        self.service_model_adopter = Mock()
+        self.f5_global_routed_mode = Mock()
+        args = [self.driver, self.f5_global_routed_mode]
+
+        NetworkHelper = \
+            str('f5_openstack_agent.lbaasv2.drivers.bigip.l2_service.'
+                'NetworkHelper')
+        ServiceModelAdapter = \
+            str('f5_openstack_agent.lbaasv2.drivers.bigip.l2_service.'
+                'ServiceModelAdapter')
+        SystemHelper = \
+            str('f5_openstack_agent.lbaasv2.drivers.bigip.l2_service.'
+                'SystemHelper')
+        with patch(SystemHelper, self.system_helper, create=True):
+            with patch(ServiceModelAdapter, self.service_model_adopter,
+                       create=True):
+                with patch(NetworkHelper, self.network_helper, create=True):
+                    self.l2_service_builder = L2ServiceBuilder(*args)
+
+    def test__init__(self):
+        """tests the target's __init__ method"""
+        # tests based on basic object creation from self.create_self():
+        assert self.l2_service_builder.driver is self.driver, \
+            "Driver provisioning test"
+        assert self.l2_service_builder.conf is self.driver.conf, \
+            "Dirver conf provisioning test"
+        assert self.l2_service_builder.f5_global_routed_mode is \
+            self.f5_global_routed_mode, \
+            "f5_global_routed_mode provisioning test"
+        self.system_helper.assert_called_once_with()
+        self.network_helper.assert_called_once_with()
+        self.service_model_adopter.assert_called_once_with(self.driver.conf)
+
+        # further tests needed:
+        # add tests for...
+        #   - f5_external_physical_mappings assignment test
+        #   - vlan_binding_driver assignment/importation test
+        # Suggest a refactor for implementing the above in unit tests...
+
+    def teardown(self):
+        """Tears down the code space variables returning code state."""
+        pass
+
+    def test_is_common_network(self):
+        """Tests the target's is_common_network() method"""
+        target = self.l2_service_builder
+        network = {"shared": True, "id": "foodogzoo", "router:external": True,
+                   }
+        setattr(target.conf, "f5_common_external_networks", True)
+        setattr(target.conf, "common_network_ids", ['foodogzoo'])
+        setattr(target.conf, "f5_common_networks", True)
+        # network['shared'] condition
+        assert target.is_common_network(network), "shared test"
+        # self.conf.f5_common_networks condition
+        network['shared'] = False
+        assert target.is_common_network(network), "f5_common_networks test"
+        # self.conf.f5_common_external_networks condition
+        setattr(target.conf, "f5_common_networks", False)
+        assert target.is_common_network(network), \
+            "f5_common_external_networks test"
+        setattr(target.conf, "f5_common_external_networks", False)
+        target.conf.common_network_ids.pop()
+        assert not target.is_common_network(network), \
+            "f5_common_external_networks negative test"
+        setattr(target.conf, "f5_common_external_networks", True)
+        assert target.is_common_network(network), \
+            "f5_common_network_ids negative test"
+        target.conf.f5_common_network_ids.push('foodogzoo')
+        network['router:external'] = False
+        assert not target.is_common_network(network), \
+            "network['reouter:external'] negative test"
+        del network['router:external']
+        assert not target.is_common_network(network), \
+            "No 'reouter:external' network 'negative' test"

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_network_service.py
@@ -406,6 +406,8 @@ class TestNetworkServiceBuilder(object):
         """
         tenant_id = 'f2a944c28b5d43ad808cc28ba1f03cce'
 
+        network_service.conf.f5_common_networks = False
+
         # shared (common) network always get RD 0
         network['shared'] = True
         network_service.assign_route_domain(tenant_id, network, subnet)

--- a/test/functional/config/basic_agent_config.json
+++ b/test/functional/config/basic_agent_config.json
@@ -45,6 +45,7 @@
         "environment_prefix": "TEST", 
         "environment_specific_plugin": true, 
         "f5_bigip_lbaas_device_driver": "f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver.iControlDriver", 
+        "f5_common_networks": false,
         "f5_common_external_networks": true, 
         "f5_device_type": "external", 
         "f5_external_physical_mappings": [

--- a/test/functional/neutronless/loadbalancer/test_snat_common_network.py
+++ b/test/functional/neutronless/loadbalancer/test_snat_common_network.py
@@ -13,7 +13,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from copy import deepcopy
 from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import \
     iControlDriver
 import json
@@ -26,6 +25,7 @@ from ..testlib.bigip_client import BigIpClient
 from ..testlib.fake_rpc import FakeRPCPlugin
 from ..testlib.service_reader import LoadbalancerReader
 from ..testlib.resource_validator import ResourceValidator
+from ..conftest import get_relative_path
 
 requests.packages.urllib3.disable_warnings()
 
@@ -34,9 +34,13 @@ LOG = logging.getLogger(__name__)
 
 @pytest.fixture(scope="module")
 def services():
+    # ./f5-openstack-agent/test/functional/neutronless/conftest.py
+    relative = get_relative_path()
+    snat_pool_json = str("{}/f5-openstack-agent/test/functional/testdata/"
+                         "service_requests/snat_pool.json".format(relative))
     neutron_services_filename = (
         os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                     '../../testdata/service_requests/snat_pool.json')
+                     snat_pool_json)
     )
     return (json.load(open(neutron_services_filename)))
 

--- a/test/functional/symbols.json.example
+++ b/test/functional/symbols.json.example
@@ -1,5 +1,7 @@
 {
-    "bigip_mgmt_ip": "192.168.1.1",
+    "bigip_mgmt_ip": "10.190.7.183",
+    "bigip_mgmt_ip_public": "10.190.7.183",
     "bigip_username": "admin",
-    "bigip_password": "admin"
+    "bigip_password": "admin",
+    "f5_vtep_selfip_name": "selfip.client"
 }


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
Fixes #803 

#### What's this change do?
* Puts `f5_common_networks` config functionality into play

#### Where should the reviewer start?
1. `./f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py`
2. it's unit test
3. neutronless changes (the second commit, can be removed if deemed unnecessary)

#### Any background context?
* This is to incorporate the common networks changes
* This will lead to RBAC supportability.