### PR TITLE
Feature.mitaka.common networks functional tests 807

### DIFF
--- a/test/functional/neutronless/conftest.py
+++ b/test/functional/neutronless/conftest.py
@@ -13,16 +13,216 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+import json
+import os
+import pytest
+import re
+import traceback
+# import sys
+
+from inspect import currentframe as cf
+from inspect import getframeinfo as gfi
+from inspect import getouterframes as gof
+from collections import deque
+from collections import namedtuple
+from copy import deepcopy
 
 from .testlib.bigip_client import BigIpClient
 from .testlib.fake_rpc import FakeRPCPlugin
 from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import \
     iControlDriver
 
-from copy import deepcopy
-import json
-import os
-import pytest
+DEBUG = True  # sys.flags.debug
+
+
+class Resource4TestTracker(object):
+    """Creates an object meant for tracking states assigned to the BIG-IP
+
+    This testing object will track the states that are assigned by the test
+    from inside of the service operations on the agent.  Upon closure, it will
+    destroy the objects in the revere order of the states that were assigned.
+
+    Additionally, it will take the service object and attempt the cleanup of
+    the provided cleanup# order.  Thus, if there is a set of keys:
+        ['cleanup0', 'cleanup10', 'cleanup2']
+    It will perform cleanup0, cleanup2, cleanup10 in that order.
+
+    As a last attempt to cleanup the environment on the BIG-IP, it will provide
+    the agent with a standard, empty configuration.
+    """
+    __entered = deque()
+    _empty_config = {
+        "loadbalancer": {}, "healthmonitors": [], "listeners": [],
+        "members": [], "networks": {}, "pools": [], "subnets": {}}
+    expected_chain = ['loadbalancer', 'listener', 'pool', 'member']
+
+    def __init__(self, service, icontrol_driver, expected_chain=None):
+        """obj = Resource4TestTracker(service, icontrol_driver)
+
+        The typical use case of this object is to encapsulate it within a
+        'with' statement:
+            expected_chain = ['loadbalancer', 'listener', 'pool', 'member']
+            with Resource4TestTracker(states, icontrol_driver,
+                                      expected_chain=expected_chain) as handle:
+                handle.deploy_next()
+                # test against handle.state
+
+                handle.cleanup()
+                # test against cleaned state (proper destruction)
+
+            # We are now stateless on the BIG-IP.
+
+        OPTIONS:
+            service - a dict that contains a set of keys that each represent
+                a state for the BIG-IP to be in.  Each KVP contains a dict that
+                then provides the BIG-IP with a state to be entering into.
+            icontrol_driver - a (typically mocked or modified) instance of the
+                agent's icontrol_driver.
+            expected_chain - The expected state workflow that the test will
+                require coming from the input data (service).
+        """
+        clean_re = re.compile("cleanup(\d+)")
+        found = service.keys()
+        expected_chain = expected_chain if expected_chain else \
+            self.expected_chain
+        possible = service.keys()
+        cleanup_queue = list()
+        for item in expected_chain:
+            assert item in found, "{} not in service!".format(item)
+            possible.remove(item)
+        for item in possible:
+            match = clean_re.search(item)
+            if match:
+                cleanup_queue.append(match)
+        cleanup_queue.sort(key=lambda x: int(x.group(1)))
+        self.cleanup_queue = map(lambda x: x.group(0), cleanup_queue)
+        self.expected_chain = expected_chain
+        self._set_service(service)
+        self.icontrol_driver = icontrol_driver
+        self._steps = iter(expected_chain)
+
+    def __enter__(self):
+        # there's nothing to construct, simply a process aspect at this time...
+        return self
+
+    def __exit__(self, *args, **kargs):
+        # cleanup appropriately...
+        self.cleanup()
+
+    def __clear(self):
+        # destroys in the derived order...
+        exceptions = deque()
+        Except = namedtuple('Except', 'type, message, stacktrace')
+        while True:
+            try:
+                state_name = self.__entered.popleft()
+            except IndexError:
+                break
+            state = self.service.get(self.__state_reflection(state_name), None)
+            try:
+                assert state, \
+                    "{} not in service!  Cannot cleanup!".format(state_name)
+                debug_msg("clearing with state({})".format(
+                    self.__state_reflection(state_name)))
+                self.icontrol_driver._common_service_handler(state)
+            except AssertionError as Err:
+                print(str(Err))
+            except Exception as Error:
+                exceptions.append(Except(str(type(Error)), str(Error),
+                                  traceback.format_exc()))
+        if exceptions:
+            stacks = str()
+            fmt = "{}({})\n{}\n"
+            for error in exceptions:
+                stacks = stacks + fmt.format(error.type, error.message,
+                                             error.stacktrace)
+            raise AssertionError("Teardown failed:\n{}".format(stacks))
+
+    def __deploy_state(self, state_name, keep_state=True):
+        # deploys a state-by-string
+        state = self.service.get(state_name, None)
+        assert state, "{} does not exist in service!".format(state_name)
+        debug_msg("deploying state({})".format(state_name))
+        self.icontrol_driver._common_service_handler(state)
+        if keep_state:
+            self._append(state_name, state)
+
+    def __state_reflection(self, state):
+        # This returns the expected delete format of the state given
+        if 'cleanup' in state:
+            return state
+        return "delete_{}".format(state)
+
+    def __triage_order(self):
+        # return the extended cleanup order...
+        self.__entered.extend(self.cleanup_queue)
+
+    def _append(self, state_name, state):
+        # add the state to the top of the FILO
+        self.state = state
+        self.state_name = state_name
+        self.__entered.appendleft(state_name)
+
+    def _set_service(self, service):
+        # assigns the service attribute, this should be a dict of states
+        assert isinstance(service, dict), "service is not a dict()!"
+        self.__service = service
+
+    def destroy_previous(self):
+        """Destroys the previous state
+
+        This will take from the queue of states and destroy it.  This means
+        that the delete_<state> of the previous state will be executed on the
+        BIG-IP.
+
+        Returns:
+            True - destroy state was deployed
+            False - out of states that were deployed
+        """
+        try:
+            state = self.__state_reflection(self.__entered.popleft())
+        except IndexError:
+            return False
+        try:
+            p_state = self.__entered.popleft()
+            self._append(p_state, self.service[p_state])
+        except IndexError:
+            self.state = None
+        self.__deploy_state(state, keep_state=False)
+        return True
+
+    def get_service(self):
+        """Returns the service attribute."""
+        return self.__service
+
+    def cleanup(self):
+        """Based upon the queued states, destroys the setup on the BIG-IP.
+
+        This will execute a thorough cleanup of the agent's setup on the BIG-IP
+        using normal operation paradigmes.
+        """
+        self.__triage_order()
+        self.__clear()
+        self.icontrol_driver._common_service_handler(self._empty_config)
+        self.__entered.clear()
+        self.cleanup_queue = list()
+
+    def deploy_next(self):
+        """Deploys the next state in the expected_chain """
+        self.__deploy_state(self._steps.next())
+
+    def enter_state(self, state_name):
+        """Hard-set the BIG-IP to a given state
+
+        This still depends on the object's originally-given service dict.  This
+        method will take the given state and assign it to the BIG-IP.
+
+        USE AT YOUR OWN RISK!  If things are out of order, you may get
+        unpredictable results, though we are supposed to handle this.
+        """
+        self.__deploy_state(state_name)
+
+    service = property(get_service, _set_service)
 
 
 @pytest.fixture
@@ -37,6 +237,14 @@ def bigip(request):
     request.addfinalizer(fin)
 
     return bigip
+
+
+def debug_msg(status):
+    caller_levels = dict(troubleshoot_cleaner=1, troubleshoot_obj_call=2,
+                         troubleshoot_test=3)
+    frame = gfi(gof(cf(caller_levels['troubleshoot_test']))[1][0])
+    print("{} [filename: {}, line: {}]".format(status, frame.filename,
+                                               frame.lineno))
 
 
 @pytest.fixture

--- a/test/functional/neutronless/loadbalancer/test_f5_common_networks.py
+++ b/test/functional/neutronless/loadbalancer/test_f5_common_networks.py
@@ -1,0 +1,191 @@
+# coding=utf-8
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import json
+import logging
+import pytest
+import requests
+
+from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import \
+    iControlDriver
+from f5_openstack_agent.lbaasv2.drivers.bigip.resource_helper import \
+    ResourceType
+
+from ..testlib.bigip_client import BigIpClient
+from ..testlib.fake_rpc import FakeRPCPlugin
+from ..testlib.service_reader import LoadbalancerReader
+from ..testlib.resource_validator import ResourceValidator
+from ..conftest import get_relative_path
+from ..conftest import Resource4TestTracker
+
+requests.packages.urllib3.disable_warnings()
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def services():
+    # ./f5-openstack-agent/test/functional/neutronless/conftest.py
+    relative = get_relative_path()
+    snat_pool_json = str("{}/f5-openstack-agent/test/functional/testdata/"
+                         "service_requests/snat_pool_common_networks.json")
+    neutron_services_filename = (snat_pool_json.format(relative))
+    return (json.load(open(neutron_services_filename)))
+
+
+@pytest.fixture(scope="module")
+def bigip():
+
+    return BigIpClient(pytest.symbols.bigip_mgmt_ip_public,
+                       pytest.symbols.bigip_username,
+                       pytest.symbols.bigip_password)
+
+
+@pytest.fixture
+def fake_plugin_rpc(services):
+
+    rpcObj = FakeRPCPlugin(
+        [services['loadbalancer'], services['listener'], services['pool'],
+         services['member'], services['delete_member'],
+         services['delete_listener'], services['delete_loadbalancer'],
+         services['cleanup0'], services['cleanup1']
+         ])  # expected is list
+
+    return rpcObj
+
+
+@pytest.fixture
+def icontrol_driver(icd_config, fake_plugin_rpc):
+    class ConfFake(object):
+        def __init__(self, params):
+            self.__dict__ = params
+            for k, v in self.__dict__.items():
+                if isinstance(v, unicode):
+                    self.__dict__[k] = v.encode('utf-8')
+
+        def __repr__(self):
+            return repr(self.__dict__)
+
+    icd = iControlDriver(ConfFake(icd_config),
+                         registerOpts=False)
+
+    icd.plugin_rpc = fake_plugin_rpc
+
+    return icd
+
+
+def test_tentant(bigip, services, icd_config, icontrol_driver):
+    """Test creating and deleting SNAT pools with common network listener.
+
+    The test procedure is testing that the needed items as follows:
+        - Test non-Common (tenant)
+            - Pools
+            - Pool Member
+            - Virtual Address
+            - Virtual Services
+    """
+    env_prefix = icd_config['environment_prefix']
+    validator = ResourceValidator(bigip, env_prefix)
+
+    # enable our config to be common_networks:
+    icontrol_driver.conf.f5_common_networks = True
+
+    expected_chain = ['loadbalancer', 'listener', 'pool', 'member']
+    with Resource4TestTracker(services, icontrol_driver, expected_chain) as \
+            bigip_handler:
+        bigip_handler.deploy_next()
+        lb_reader = LoadbalancerReader(bigip_handler.state)
+        folder = '{0}_{1}'.format(env_prefix, lb_reader.tenant_id())
+        assert bigip.folder_exists(folder)
+
+        # validate SNAT pool created in tenant partition with one member for LB
+        snat_pool_name = folder
+        snat_pool_folder = folder
+        lb_snat_name = '/Common/snat-traffic-group-local-only-{0}_0'
+        # we expect to a member as a snat-traffic-group-local-only for each sub
+        expected_members = map(lambda x: (lb_snat_name.format(x)),
+                               bigip_handler.state['subnets'].keys())
+        validator.assert_snatpool_valid(
+            snat_pool_name, snat_pool_folder, expected_members)
+
+        # create listener
+        bigip_handler.deploy_next()
+        listener = bigip_handler.state['listeners'][0]
+        validator.assert_virtual_valid(listener, folder)
+
+        # create pool
+        bigip_handler.deploy_next()
+        pool = bigip_handler.state['pools'][0]
+        validator.assert_pool_valid(pool, folder)
+
+        # create member
+        bigip_handler.deploy_next()
+
+        # Test member:
+        member = bigip_handler.state['members'][0]
+        validator.assert_member_valid(pool, member, folder)
+        expected_members = map(lambda x: (lb_snat_name.format(x)),
+                               bigip_handler.state['subnets'].keys())
+        validator.assert_snatpool_valid(snat_pool_name, snat_pool_folder,
+                                        expected_members)
+
+        # delete pool
+        bigip_handler.destroy_previous()
+        bigip_handler.destroy_previous()
+        validator.assert_pool_deleted(pool, None, folder)
+
+        # delete listener
+        bigip_handler.destroy_previous()
+        validator.assert_virtual_deleted(listener, folder)
+
+        # delete loadbalancer - good samaritan...
+        bigip_handler.cleanup()
+
+        # validate everything (including SNAT ppols) removed
+        assert not bigip.folder_exists(folder)
+
+
+@pytest.mark.skip(reason=str("Route domain and snatpool Common handling "
+                             "not done yet"))
+def test_common_owned_objs(bigip, services, icd_config, icontrol_driver):
+    """Tests that route domain and snatpool objects are in Common
+
+    This test simply validates whether or not the snatpool and route domain are
+    present in the common partition rather than only in the tenant.
+    """
+    # enable our config to be common_networks:
+    icontrol_driver.conf.f5_common_networks = True
+    env_prefix = icd_config['environment_prefix']
+    validator = ResourceValidator(bigip, env_prefix)
+
+    expected_chain = ['loadbalancer', 'listener', 'pool', 'member']
+    with Resource4TestTracker(services, icontrol_driver, expected_chain) as \
+            bigip_handler:
+        bigip_handler.deploy_next()
+        folder = 'Common'
+
+        # Once the route domain change to common has been implemented, this
+        # naming schema may change:
+        lb_reader = LoadbalancerReader(bigip_handler.state)
+        rd_name = '{0}_{1}'.format(env_prefix, lb_reader.tenant_id())
+        assert bigip.resource_exists(ResourceType.route_domain, folder)
+        rd = bigip.get_resource(ResourceType.route_domain, rd_name,
+                                partition=folder)
+
+        assert rd, "Route domain on /{} was not created!".format(folder)
+        # no need to be the good samaritan... let the object clean things up...
+
+    # assert that we're clean...
+    assert not bigip.folder_exists(folder)

--- a/test/functional/neutronless/loadbalancer/test_snat_common_network.py
+++ b/test/functional/neutronless/loadbalancer/test_snat_common_network.py
@@ -162,3 +162,9 @@ def test_snat_common_network(bigip, services, icd_config, icontrol_driver):
 
     # validate everything (including SNAT ppols) removed
     assert not bigip.folder_exists(folder)
+
+    # cleanup...
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service, delete_partition=True)
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service, delete_partition=True)

--- a/test/functional/testdata/service_requests/snat_pool.json
+++ b/test/functional/testdata/service_requests/snat_pool.json
@@ -1258,4 +1258,139 @@
       "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
     }
   }
-}]
+},{
+  "healthmonitors": [], 
+  "listeners": [], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+    "listeners": [], 
+    "name": "lb1", 
+    "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+    "operating_status": "ONLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_DELETE", 
+    "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:9cb0a8ec-40d1-5e9e-af8f-c452582821d2", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "cd6b5c48-4190-5346-9278-24acec015ee6", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-10-2-4-105.openstacklocal.", 
+          "hostname": "host-10-2-4-105", 
+          "ip_address": "10.2.4.105"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+        }
+      ], 
+      "id": "693a22bf-6a54-4b65-a14e-2a0e296d1d03", 
+      "mac_address": "fa:16:3e:07:1c:2f", 
+      "name": "loadbalancer-8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+      "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "security_groups": [
+        "242578f0-9807-4b48-9386-1cc2f3092068"
+      ], 
+      "status": "PENDING_DELETE", 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }, 
+    "vip_port_id": "693a22bf-6a54-4b65-a14e-2a0e296d1d03", 
+    "vip_subnet_id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7", 
+    "vxlan_vteps": [
+      "201.0.166.1", 
+      "201.0.168.1", 
+      "201.0.169.1", 
+      "201.0.151.10"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "232fba57-9e7e-4ecd-8450-4a53176af55a": {
+      "admin_state_up": true, 
+      "id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "mtu": 0, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 23, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+      ], 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "listeners": [], 
+  "loadbalancer": {}, 
+  "members": [], 
+  "networks": {
+    "232fba57-9e7e-4ecd-8450-4a53176af55a": {
+      "admin_state_up": true, 
+      "id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "mtu": 0, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 23, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "PENDING_DELETE", 
+      "subnets": [
+        "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+      ], 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {}
+}
+]

--- a/test/functional/testdata/service_requests/snat_pool_common_networks.json
+++ b/test/functional/testdata/service_requests/snat_pool_common_networks.json
@@ -1,0 +1,1396 @@
+{"loadbalancer": {
+  "healthmonitors": [], 
+  "listeners": [], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+    "listeners": [], 
+    "name": "lb1", 
+    "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+    "operating_status": "OFFLINE", 
+    "provider": null, 
+    "provisioning_status": "PENDING_CREATE", 
+    "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": false, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "unbound", 
+      "binding:vnic_type": "normal", 
+      "device_id": "8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+      "device_owner": "neutron:LOADBALANCERV2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-10-2-4-105.openstacklocal.", 
+          "hostname": "host-10-2-4-105", 
+          "ip_address": "10.2.4.105"
+        }
+      ], 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+        }
+      ], 
+      "id": "693a22bf-6a54-4b65-a14e-2a0e296d1d03", 
+      "mac_address": "fa:16:3e:07:1c:2f", 
+      "name": "loadbalancer-8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+      "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "security_groups": [
+        "242578f0-9807-4b48-9386-1cc2f3092068"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }, 
+    "vip_port_id": "693a22bf-6a54-4b65-a14e-2a0e296d1d03", 
+    "vip_subnet_id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7", 
+    "vxlan_vteps": [
+      "201.0.166.1", 
+      "201.0.168.1", 
+      "201.0.169.1", 
+      "201.0.151.10"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "232fba57-9e7e-4ecd-8450-4a53176af55a": {
+      "admin_state_up": true, 
+      "id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "mtu": 0, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 23, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+      ], 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }
+  }
+},"listener": {
+  "healthmonitors": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": null, 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "11dd1f0c-73c6-4388-b900-aa10d3eae7a4", 
+      "loadbalancer_id": "8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+      "name": "l1", 
+      "operating_status": "OFFLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 1080, 
+      "provisioning_status": "PENDING_CREATE", 
+      "sni_containers": [], 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+    "listeners": [
+      {
+        "id": "11dd1f0c-73c6-4388-b900-aa10d3eae7a4"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+    "operating_status": "ONLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:9cb0a8ec-40d1-5e9e-af8f-c452582821d2", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "cd6b5c48-4190-5346-9278-24acec015ee6", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-10-2-4-105.openstacklocal.", 
+          "hostname": "host-10-2-4-105", 
+          "ip_address": "10.2.4.105"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+        }
+      ], 
+      "id": "693a22bf-6a54-4b65-a14e-2a0e296d1d03", 
+      "mac_address": "fa:16:3e:07:1c:2f", 
+      "name": "loadbalancer-8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+      "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "security_groups": [
+        "242578f0-9807-4b48-9386-1cc2f3092068"
+      ], 
+      "status": "ACTIVE", 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }, 
+    "vip_port_id": "693a22bf-6a54-4b65-a14e-2a0e296d1d03", 
+    "vip_subnet_id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7", 
+    "vxlan_vteps": [
+      "201.0.166.1", 
+      "201.0.168.1", 
+      "201.0.169.1", 
+      "201.0.151.10"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "232fba57-9e7e-4ecd-8450-4a53176af55a": {
+      "admin_state_up": true, 
+      "id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "mtu": 0, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 23, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+      ], 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }
+  }
+},"pool": {
+  "healthmonitors": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "48a07101-0d40-4c17-b0f5-6cd31aeb5a11", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "11dd1f0c-73c6-4388-b900-aa10d3eae7a4", 
+      "loadbalancer_id": "8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+      "name": "l1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 1080, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+    "listeners": [
+      {
+        "id": "11dd1f0c-73c6-4388-b900-aa10d3eae7a4"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+    "operating_status": "ONLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:9cb0a8ec-40d1-5e9e-af8f-c452582821d2", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "cd6b5c48-4190-5346-9278-24acec015ee6", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-10-2-4-105.openstacklocal.", 
+          "hostname": "host-10-2-4-105", 
+          "ip_address": "10.2.4.105"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+        }
+      ], 
+      "id": "693a22bf-6a54-4b65-a14e-2a0e296d1d03", 
+      "mac_address": "fa:16:3e:07:1c:2f", 
+      "name": "loadbalancer-8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+      "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "security_groups": [
+        "242578f0-9807-4b48-9386-1cc2f3092068"
+      ], 
+      "status": "ACTIVE", 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }, 
+    "vip_port_id": "693a22bf-6a54-4b65-a14e-2a0e296d1d03", 
+    "vip_subnet_id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7", 
+    "vxlan_vteps": [
+      "201.0.166.1", 
+      "201.0.168.1", 
+      "201.0.169.1", 
+      "201.0.151.10"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "232fba57-9e7e-4ecd-8450-4a53176af55a": {
+      "admin_state_up": true, 
+      "id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "mtu": 0, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 23, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+      ], 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "48a07101-0d40-4c17-b0f5-6cd31aeb5a11", 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listeners": [
+        {
+          "id": "11dd1f0c-73c6-4388-b900-aa10d3eae7a4"
+        }
+      ], 
+      "members": [], 
+      "name": "p1", 
+      "operating_status": "OFFLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "PENDING_CREATE", 
+      "session_persistence": null, 
+      "sessionpersistence": null, 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }
+  ], 
+  "subnets": {
+    "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }
+  }
+},"member": {
+  "healthmonitors": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "48a07101-0d40-4c17-b0f5-6cd31aeb5a11", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "11dd1f0c-73c6-4388-b900-aa10d3eae7a4", 
+      "loadbalancer_id": "8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+      "name": "l1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 1080, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+    "listeners": [
+      {
+        "id": "11dd1f0c-73c6-4388-b900-aa10d3eae7a4"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+    "operating_status": "ONLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:9cb0a8ec-40d1-5e9e-af8f-c452582821d2", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "cd6b5c48-4190-5346-9278-24acec015ee6", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-10-2-4-105.openstacklocal.", 
+          "hostname": "host-10-2-4-105", 
+          "ip_address": "10.2.4.105"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+        }
+      ], 
+      "id": "693a22bf-6a54-4b65-a14e-2a0e296d1d03", 
+      "mac_address": "fa:16:3e:07:1c:2f", 
+      "name": "loadbalancer-8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+      "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "security_groups": [
+        "242578f0-9807-4b48-9386-1cc2f3092068"
+      ], 
+      "status": "ACTIVE", 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }, 
+    "vip_port_id": "693a22bf-6a54-4b65-a14e-2a0e296d1d03", 
+    "vip_subnet_id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7", 
+    "vxlan_vteps": [
+      "201.0.166.1", 
+      "201.0.168.1", 
+      "201.0.169.1", 
+      "201.0.151.10"
+    ]
+  }, 
+  "members": [
+    {
+      "address": "10.3.4.10", 
+      "admin_state_up": true, 
+      "gre_vteps": [], 
+      "id": "1166a785-f2a4-4fb1-b3e2-3d8a506efad6", 
+      "network_id": "3b820d18-3d4c-41b6-86cc-e4fbda763702", 
+      "operating_status": "OFFLINE", 
+      "pool_id": "48a07101-0d40-4c17-b0f5-6cd31aeb5a11", 
+      "port": {
+        "admin_state_up": true, 
+        "allowed_address_pairs": [], 
+        "binding:host_id": "", 
+        "binding:profile": {}, 
+        "binding:vif_details": {}, 
+        "binding:vif_type": "unbound", 
+        "binding:vnic_type": "normal", 
+        "device_id": "", 
+        "device_owner": "network:f5lbaasv2", 
+        "dns_name": null, 
+        "fixed_ips": [
+          {
+            "ip_address": "10.3.4.10", 
+            "subnet_id": "9f663c20-37b6-4a5a-aa8d-d0575e61c059"
+          }
+        ], 
+        "id": "92a9569e-12b4-49ad-a994-885b93684e08", 
+        "mac_address": "fa:16:3e:09:87:5b", 
+        "name": "", 
+        "network_id": "3b820d18-3d4c-41b6-86cc-e4fbda763702", 
+        "security_groups": [], 
+        "status": "ACTIVE", 
+        "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+      }, 
+      "protocol_port": 80, 
+      "provisioning_status": "PENDING_CREATE", 
+      "subnet_id": "9f663c20-37b6-4a5a-aa8d-d0575e61c059", 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+      "vxlan_vteps": [
+        "201.0.166.1", 
+        "201.0.168.1", 
+        "201.0.169.1", 
+        "201.0.151.10"
+      ], 
+      "weight": 1
+    }
+  ], 
+  "networks": {
+    "232fba57-9e7e-4ecd-8450-4a53176af55a": {
+      "admin_state_up": true, 
+      "id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "mtu": 0, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 23, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+      ], 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+      "vlan_transparent": null
+    }, 
+    "3b820d18-3d4c-41b6-86cc-e4fbda763702": {
+      "admin_state_up": true, 
+      "id": "3b820d18-3d4c-41b6-86cc-e4fbda763702", 
+      "mtu": 0, 
+      "name": "net1", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 91, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "9f663c20-37b6-4a5a-aa8d-d0575e61c059"
+      ], 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "48a07101-0d40-4c17-b0f5-6cd31aeb5a11", 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listeners": [
+        {
+          "id": "11dd1f0c-73c6-4388-b900-aa10d3eae7a4"
+        }
+      ], 
+      "members": [
+        {
+          "id": "1166a785-f2a4-4fb1-b3e2-3d8a506efad6"
+        }
+      ], 
+      "name": "p1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "ACTIVE", 
+      "session_persistence": null, 
+      "sessionpersistence": null, 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }
+  ], 
+  "subnets": {
+    "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }, 
+    "9f663c20-37b6-4a5a-aa8d-d0575e61c059": {
+      "allocation_pools": [
+        {
+          "end": "10.3.4.254", 
+          "start": "10.3.4.2"
+        }
+      ], 
+      "cidr": "10.3.4.0/24", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.3.4.1", 
+      "host_routes": [], 
+      "id": "9f663c20-37b6-4a5a-aa8d-d0575e61c059", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "", 
+      "network_id": "3b820d18-3d4c-41b6-86cc-e4fbda763702", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }
+  }
+},"delete_member": {
+  "healthmonitors": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "48a07101-0d40-4c17-b0f5-6cd31aeb5a11", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "11dd1f0c-73c6-4388-b900-aa10d3eae7a4", 
+      "loadbalancer_id": "8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+      "name": "l1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 1080, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+    "listeners": [
+      {
+        "id": "11dd1f0c-73c6-4388-b900-aa10d3eae7a4"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+    "operating_status": "ONLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:9cb0a8ec-40d1-5e9e-af8f-c452582821d2", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "cd6b5c48-4190-5346-9278-24acec015ee6", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-10-2-4-105.openstacklocal.", 
+          "hostname": "host-10-2-4-105", 
+          "ip_address": "10.2.4.105"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+        }
+      ], 
+      "id": "693a22bf-6a54-4b65-a14e-2a0e296d1d03", 
+      "mac_address": "fa:16:3e:07:1c:2f", 
+      "name": "loadbalancer-8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+      "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "security_groups": [
+        "242578f0-9807-4b48-9386-1cc2f3092068"
+      ], 
+      "status": "ACTIVE", 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }, 
+    "vip_port_id": "693a22bf-6a54-4b65-a14e-2a0e296d1d03", 
+    "vip_subnet_id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7", 
+    "vxlan_vteps": [
+      "201.0.166.1", 
+      "201.0.168.1", 
+      "201.0.169.1", 
+      "201.0.151.10"
+    ]
+  }, 
+  "members": [
+    {
+      "address": "10.3.4.10", 
+      "admin_state_up": true, 
+      "gre_vteps": [], 
+      "id": "1166a785-f2a4-4fb1-b3e2-3d8a506efad6", 
+      "network_id": "3b820d18-3d4c-41b6-86cc-e4fbda763702", 
+      "operating_status": "NO_MONITOR", 
+      "pool_id": "48a07101-0d40-4c17-b0f5-6cd31aeb5a11", 
+      "port": {
+        "admin_state_up": true, 
+        "allowed_address_pairs": [], 
+        "binding:host_id": "", 
+        "binding:profile": {}, 
+        "binding:vif_details": {}, 
+        "binding:vif_type": "unbound", 
+        "binding:vnic_type": "normal", 
+        "device_id": "", 
+        "device_owner": "network:f5lbaasv2", 
+        "dns_assignment": [
+          {
+            "fqdn": "host-10-3-4-10.openstacklocal.", 
+            "hostname": "host-10-3-4-10", 
+            "ip_address": "10.3.4.10"
+          }
+        ], 
+        "dns_name": "", 
+        "extra_dhcp_opts": [], 
+        "fixed_ips": [
+          {
+            "ip_address": "10.3.4.10", 
+            "subnet_id": "9f663c20-37b6-4a5a-aa8d-d0575e61c059"
+          }
+        ], 
+        "id": "92a9569e-12b4-49ad-a994-885b93684e08", 
+        "mac_address": "fa:16:3e:09:87:5b", 
+        "name": "", 
+        "network_id": "3b820d18-3d4c-41b6-86cc-e4fbda763702", 
+        "security_groups": [], 
+        "status": "ACTIVE", 
+        "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+      }, 
+      "protocol_port": 80, 
+      "provisioning_status": "PENDING_DELETE", 
+      "subnet_id": "9f663c20-37b6-4a5a-aa8d-d0575e61c059", 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+      "vxlan_vteps": [
+        "201.0.166.1", 
+        "201.0.168.1", 
+        "201.0.169.1", 
+        "201.0.151.10"
+      ], 
+      "weight": 1
+    }
+  ], 
+  "networks": {
+    "232fba57-9e7e-4ecd-8450-4a53176af55a": {
+      "admin_state_up": true, 
+      "id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "mtu": 0, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 23, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+      ], 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+      "vlan_transparent": null
+    }, 
+    "3b820d18-3d4c-41b6-86cc-e4fbda763702": {
+      "admin_state_up": true, 
+      "id": "3b820d18-3d4c-41b6-86cc-e4fbda763702", 
+      "mtu": 0, 
+      "name": "net1", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 91, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "9f663c20-37b6-4a5a-aa8d-d0575e61c059"
+      ], 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "48a07101-0d40-4c17-b0f5-6cd31aeb5a11", 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listeners": [
+        {
+          "id": "11dd1f0c-73c6-4388-b900-aa10d3eae7a4"
+        }
+      ], 
+      "members": [
+        {
+          "id": "1166a785-f2a4-4fb1-b3e2-3d8a506efad6"
+        }
+      ], 
+      "name": "p1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "ACTIVE", 
+      "session_persistence": null, 
+      "sessionpersistence": null, 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }
+  ], 
+  "subnets": {
+    "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }, 
+    "9f663c20-37b6-4a5a-aa8d-d0575e61c059": {
+      "allocation_pools": [
+        {
+          "end": "10.3.4.254", 
+          "start": "10.3.4.2"
+        }
+      ], 
+      "cidr": "10.3.4.0/24", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.3.4.1", 
+      "host_routes": [], 
+      "id": "9f663c20-37b6-4a5a-aa8d-d0575e61c059", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "", 
+      "network_id": "3b820d18-3d4c-41b6-86cc-e4fbda763702", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }
+  }
+},"delete_pool": {
+  "healthmonitors": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "48a07101-0d40-4c17-b0f5-6cd31aeb5a11", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "11dd1f0c-73c6-4388-b900-aa10d3eae7a4", 
+      "loadbalancer_id": "8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+      "name": "l1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 1080, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+    "listeners": [
+      {
+        "id": "11dd1f0c-73c6-4388-b900-aa10d3eae7a4"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+    "operating_status": "ONLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:9cb0a8ec-40d1-5e9e-af8f-c452582821d2", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "cd6b5c48-4190-5346-9278-24acec015ee6", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-10-2-4-105.openstacklocal.", 
+          "hostname": "host-10-2-4-105", 
+          "ip_address": "10.2.4.105"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+        }
+      ], 
+      "id": "693a22bf-6a54-4b65-a14e-2a0e296d1d03", 
+      "mac_address": "fa:16:3e:07:1c:2f", 
+      "name": "loadbalancer-8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+      "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "security_groups": [
+        "242578f0-9807-4b48-9386-1cc2f3092068"
+      ], 
+      "status": "ACTIVE", 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }, 
+    "vip_port_id": "693a22bf-6a54-4b65-a14e-2a0e296d1d03", 
+    "vip_subnet_id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7", 
+    "vxlan_vteps": [
+      "201.0.166.1", 
+      "201.0.168.1", 
+      "201.0.169.1", 
+      "201.0.151.10"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "232fba57-9e7e-4ecd-8450-4a53176af55a": {
+      "admin_state_up": true, 
+      "id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "mtu": 0, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 23, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+      ], 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "48a07101-0d40-4c17-b0f5-6cd31aeb5a11", 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listeners": [
+        {
+          "id": "11dd1f0c-73c6-4388-b900-aa10d3eae7a4"
+        }
+      ], 
+      "members": [], 
+      "name": "p1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "PENDING_DELETE", 
+      "session_persistence": null, 
+      "sessionpersistence": null, 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }
+  ], 
+  "subnets": {
+    "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }
+  }
+},"delete_listener": {
+  "healthmonitors": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": null, 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "11dd1f0c-73c6-4388-b900-aa10d3eae7a4", 
+      "loadbalancer_id": "8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+      "name": "l1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 1080, 
+      "provisioning_status": "PENDING_DELETE", 
+      "sni_containers": [], 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+    "listeners": [
+      {
+        "id": "11dd1f0c-73c6-4388-b900-aa10d3eae7a4"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+    "operating_status": "ONLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:9cb0a8ec-40d1-5e9e-af8f-c452582821d2", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "cd6b5c48-4190-5346-9278-24acec015ee6", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-10-2-4-105.openstacklocal.", 
+          "hostname": "host-10-2-4-105", 
+          "ip_address": "10.2.4.105"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+        }
+      ], 
+      "id": "693a22bf-6a54-4b65-a14e-2a0e296d1d03", 
+      "mac_address": "fa:16:3e:07:1c:2f", 
+      "name": "loadbalancer-8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+      "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "security_groups": [
+        "242578f0-9807-4b48-9386-1cc2f3092068"
+      ], 
+      "status": "ACTIVE", 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }, 
+    "vip_port_id": "693a22bf-6a54-4b65-a14e-2a0e296d1d03", 
+    "vip_subnet_id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7", 
+    "vxlan_vteps": [
+      "201.0.166.1", 
+      "201.0.168.1", 
+      "201.0.169.1", 
+      "201.0.151.10"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "232fba57-9e7e-4ecd-8450-4a53176af55a": {
+      "admin_state_up": true, 
+      "id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "mtu": 0, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 23, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+      ], 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }
+  }
+},"delete_loadbalancer": {
+  "healthmonitors": [], 
+  "listeners": [], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+    "listeners": [], 
+    "name": "lb1", 
+    "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+    "operating_status": "ONLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_DELETE", 
+    "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:9cb0a8ec-40d1-5e9e-af8f-c452582821d2", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "cd6b5c48-4190-5346-9278-24acec015ee6", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-10-2-4-105.openstacklocal.", 
+          "hostname": "host-10-2-4-105", 
+          "ip_address": "10.2.4.105"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+        }
+      ], 
+      "id": "693a22bf-6a54-4b65-a14e-2a0e296d1d03", 
+      "mac_address": "fa:16:3e:07:1c:2f", 
+      "name": "loadbalancer-8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+      "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "security_groups": [
+        "242578f0-9807-4b48-9386-1cc2f3092068"
+      ], 
+      "status": "ACTIVE", 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }, 
+    "vip_port_id": "693a22bf-6a54-4b65-a14e-2a0e296d1d03", 
+    "vip_subnet_id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7", 
+    "vxlan_vteps": [
+      "201.0.166.1", 
+      "201.0.168.1", 
+      "201.0.169.1", 
+      "201.0.151.10"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "232fba57-9e7e-4ecd-8450-4a53176af55a": {
+      "admin_state_up": true, 
+      "id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "mtu": 0, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 23, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+      ], 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }
+  }
+},"cleanup0": {
+  "healthmonitors": [], 
+  "listeners": [], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+    "listeners": [], 
+    "name": "lb1", 
+    "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+    "operating_status": "ONLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_DELETE", 
+    "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+    "vip_address": "10.2.4.105", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-168.int.lineratesystems.com:9cb0a8ec-40d1-5e9e-af8f-c452582821d2", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "cd6b5c48-4190-5346-9278-24acec015ee6", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-10-2-4-105.openstacklocal.", 
+          "hostname": "host-10-2-4-105", 
+          "ip_address": "10.2.4.105"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "10.2.4.105", 
+          "subnet_id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+        }
+      ], 
+      "id": "693a22bf-6a54-4b65-a14e-2a0e296d1d03", 
+      "mac_address": "fa:16:3e:07:1c:2f", 
+      "name": "loadbalancer-8856d03c-86f8-4533-93bc-31cfb3a1956b", 
+      "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "security_groups": [
+        "242578f0-9807-4b48-9386-1cc2f3092068"
+      ], 
+      "status": "PENDING_DELETE", 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }, 
+    "vip_port_id": "693a22bf-6a54-4b65-a14e-2a0e296d1d03", 
+    "vip_subnet_id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7", 
+    "vxlan_vteps": [
+      "201.0.166.1", 
+      "201.0.168.1", 
+      "201.0.169.1", 
+      "201.0.151.10"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "232fba57-9e7e-4ecd-8450-4a53176af55a": {
+      "admin_state_up": true, 
+      "id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "mtu": 0, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 23, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+      ], 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7": {
+      "allocation_pools": [
+        {
+          "end": "10.2.4.150", 
+          "start": "10.2.4.100"
+        }
+      ], 
+      "cidr": "10.2.4.0/24", 
+      "dns_nameservers": [
+        "10.190.20.5", 
+        "10.190.0.20"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "10.2.4.1", 
+      "host_routes": [], 
+      "id": "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "mgmt_v4_subnet", 
+      "network_id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "shared": true, 
+      "subnetpool_id": null, 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097"
+    }
+  }
+},"cleanup1": {
+  "healthmonitors": [], 
+  "listeners": [], 
+  "loadbalancer": {}, 
+  "members": [], 
+  "networks": {
+    "232fba57-9e7e-4ecd-8450-4a53176af55a": {
+      "admin_state_up": true, 
+      "id": "232fba57-9e7e-4ecd-8450-4a53176af55a", 
+      "mtu": 0, 
+      "name": "tempest-mgmt-network", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 23, 
+      "router:external": false, 
+      "shared": true, 
+      "status": "PENDING_DELETE", 
+      "subnets": [
+        "4dc7caad-f9a9-4050-914e-b60eb6cf8ef7"
+      ], 
+      "tenant_id": "97210b7b76294cc9ba0a023a75f6d097", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {}
+}
+}


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
Fixes #807 
WIP #807 - neutron testing infrastructure add: Keeping environment clean via a new decorator object
WIP #807 - `test_snat_common_network.py` now cleans up after itself using less intrusive means

#### What's this change do?
* 32587ae89ff170abf0e9f030ad8822d864b44561
  * Makes `test_snat_common_network.py` clean up after itself more appropriately
* dbc003b45a885e5c46434771fb0f26037d6ad4f7
  * **Tests will run without this; however, as a group, it will fail without 32587ae89ff170abf0e9f030ad8822d864b44561**
  * Creates a test that will validate the setup of a common network via the snat exchange up to a member
  * Creates a test that will test that Route Domains are initiated in the Common partition and that the SNATPool will also; however, this has not been implemented yet
    * This test is skipped for now via `pytest.mark.skip("skip", reason=...)`
* e710b2317bd107d7d51479b9320617dd0150826d
  * Creates a new neutronless BIG-IP handling object, `Resource4TestTracker`
    * This object, using the `with` block in python, will handle any cleanup from failed tests

#### Where should the reviewer start?
* e710b2317bd107d7d51479b9320617dd0150826d
  * or `./neutronless/conftest.py`

#### Any background context?
This is to satisfy the agent functional testing for the `f5_openstack_agent.ini`'s `f5_common_networks` setting addition performed earlier by #803 