### PR TITLE
Update docs test script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ deploy:
     skip_cleanup: true
     on:
       repo: F5Networks/f5-openstack-agent
-      all_branches: true
+      branch: liberty
       condition: $TRAVIS_TAG = ""
     script:
     - ./docs/scripts/deploy-docs.sh publish-product-docs-to-prod openstack/agent $TRAVIS_BRANCH

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ The F5 Agent for OpenStack Neutron is an OpenStack `Neutron plugin agent <https:
 Documentation
 -------------
 
-Documentation is published on `clouddocs.f5.com <http://clouddocs.f5.com/products/openstack/latest/agent/>`_.
+Documentation is published on `clouddocs.f5.com <http://clouddocs.f5.com/products/openstack/agent/latest>`_.
 
 Compatibility
 -------------

--- a/docs/scripts/test-docs.sh
+++ b/docs/scripts/test-docs.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -x
+#set -x
 set -e
 
 echo "Building docs with Sphinx"
@@ -12,6 +12,3 @@ write-good `find ./docs -not \( -path ./docs/drafts -prune \) -name '*.rst'` --p
 set +e
 echo "Checking links"
 make -C docs linkcheck
-
-echo "The following links are broken:"
-grep "broken" docs/_build/linkcheck/output.txt


### PR DESCRIPTION
@pjbreaux 

#### What issues does this address?
Fixes #814 #811 

#### What's this change do?
#. Removes the `grep` command from the docs test script that is breaking the build.
#. Changes the branch condition so docs only deploy from specific branches.
#. Fixes an incorrect path to the agent product docs on clouddocs.

#### Where should the reviewer start?

#### Any background context?
Ref: **https://travis-ci.org/F5Networks/f5-openstack-agent/builds/257469658**

I've also updated the image we use to build/test/deploy the docs so the build won't fail when we're on a release branch (e.g., jodie-liberty-release). 
