### PR TITLE
Update docs test script to avoid linkcheck failures 

### DIFF
--- a/docs/scripts/test-docs.sh
+++ b/docs/scripts/test-docs.sh
@@ -1,14 +1,49 @@
 #!/usr/bin/env bash
 
-#set -x
+html="make -C docs html"
+linkcheck="sphinx-build -b linkcheck docs docs/_build/linkcheck"
+grammar="write-good `find ./docs -not \( -path ./docs/drafts -prune \) -name '*.rst'` --passive --so --no-illusion --thereIs --cliches"
+
+if [ $TRAVIS="true" ];
+   then OUTPUT_DIR=${TRAVIS_BUILD_DIR}/_build/linkcheck
+fi
+
+warn() {
+  printf "%s\n" "$*" >&2
+
+  exit 0
+}
+
+die()  {
+  printf "%s\n" "$*" >&2
+
+  exit 1
+}
+
+goodjob() {
+  printf "%s\n" "$*" >&2
+
+}
+
+make -C docs clean
+
+echo $TRAVIS
+
 set -e
 
 echo "Building docs with Sphinx"
-make -C docs html
+set -x
+$html
 
 echo "Checking grammar and style"
-write-good `find ./docs -not \( -path ./docs/drafts -prune \) -name '*.rst'` --passive --so --no-illusion --thereIs --cliches
+set -x
+$grammar
+set +x
+[[ $grammar = "" ]] || goodjob "CONGRATULATIONS! You are a grammar wizard."
 
-set +e
 echo "Checking links"
-make -C docs linkcheck
+if [[ $linkcheck != "" ]]; then
+   sphinx-build -b linkcheck docs docs/_build/linkcheck | grep 'broken'
+   warn "WARNING: Link check failed. See output above for errors."
+   else echo "Linkcheck succeeded"
+fi


### PR DESCRIPTION
@pjbreaux 

#### What issues does this address?
N/A

#### What's this change do?

When we create release branches and tags, the docs linkcheck can fail because some release targets don't exist yet. 

This PR contains an update to the docs test script that treats linkcheck failures as warnings, so they don't break the whole build.

#### Where should the reviewer start?

#### Any background context?
