### PR TITLE
Physical BIG-IPs supporting HPB should create their own ports on netw…

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -517,6 +517,11 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
             pending_lb_ids = set(
                 [lb['lb_id'] for lb in pending_loadbalancers]
             )
+
+            not_pending_lb_ids = all_loadbalancer_ids - pending_lb_ids
+            for lb_id in not_pending_lb_ids:
+                self.pending_services.pop(lb_id, None)
+
             LOG.debug(
                 "plugin produced the list of pending loadbalancer ids: %s"
                 % list(pending_lb_ids))

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
@@ -120,6 +120,17 @@ class NetworkServiceBuilder(object):
                            vtep_selfip_name))
         return local_ips
 
+    def assure_opflex_network_port(self, network_id, network):
+        port = None
+
+        port_name = "bigip-opflex-{}".format(network_id)
+
+        port = self.driver.plugin_rpc.create_port_on_network(
+            network_id=network_id,
+            name=port_name)
+
+        return port
+
     def is_service_connected(self, service):
         networks = service.get('networks', {})
         supported_net_types = ['vlan', 'vxlan', 'gre', 'opflex']
@@ -138,6 +149,12 @@ class NetworkServiceBuilder(object):
             if not segmentation_id:
                 if network_type in supported_net_types and \
                    self.conf.f5_network_segment_physical_network:
+
+                    if network_type == "opflex":
+                        # This is called only when the HPB config item
+                        # f5_network_segment_physical_network is set.
+                        self.assure_opflex_network_port(network_id, network)
+
                     return False
 
                 LOG.error("Misconfiguration: Segmentation ID is "
@@ -841,6 +858,13 @@ class NetworkServiceBuilder(object):
                                                    ip_address=selfip_address)
 
                 deleted_names.add(local_selfip_name)
+
+                if self.conf.f5_network_segment_physical_network:
+                    opflex_net_id = network.get('id')
+                    if opflex_net_id:
+                        opflex_net_port = "bigip-opflex-{}".format(
+                            opflex_net_id)
+                        deleted_names.add(opflex_net_port)
 
                 self.l2_service.delete_bigip_network(bigip, network)
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
@@ -369,6 +369,26 @@ class LBaaSv2PluginRPC(object):
         return port
 
     @log_helpers.log_method_call
+    def create_port_on_network(self, network_id=None, mac_address=None,
+                               name=None, host=None):
+        """Add a neutron port to the network."""
+        port = None
+        try:
+            port = self._call(
+                self.context,
+                self._make_msg('create_port_on_network',
+                               network_id=network_id,
+                               mac_address=mac_address,
+                               name=name,
+                               host=self.host),
+                topic=self.topic
+            )
+        except messaging.MessageDeliveryFailure:
+            LOG.error("agent->plugin RPC exception caught: "
+                      "create_port_on_subnet_with_specific_ip")
+
+        return port
+
     def create_port_on_subnet_with_specific_ip(self, subnet_id=None,
                                                mac_address=None,
                                                name=None,


### PR DESCRIPTION
…ork.

Issues:
Fixes #825

Problem:
When a physical BIG-IP is connected to a SDN which supports HPB,
the presence of pool members which are mapped back from their subnet_id
to a Neutron network, should cause the BIG-IP to assure if an existing
port already exists and if not create a port on the appropriate Neutron
network. The port creation thus signals the SDN that segment connectivity
is required for the BIG-iP to complete the LBaaS request. There must be
an agreed upon way in the port attributes to signal the SDN that it is
the BIG-IP which requires a segment connection. With Cisco ACI the host_id
attribute on the port needs to be specified as the LBaaS agent_id.

This applies only to network connectivity required for pool members as
the load balancer side port is automatically created by the community
LBaaS plugin.

Analysis:
This commit modifies the is_service_connected() check to issue a port
create request to the driver if HPB is active and the network does not
have a segmenation ID.

This differs from the original solution in that it only creates one port
for the member network named bigip-opflex-<network uuid>, and this port
is created by the agent.

This solution does not create a port for a member if one does not already
exist.  The user needs to make sure that member ports are either created
by Nova when the virtual server is created or by the administrator, when
the IP address is for a server on an external network.  This will work if
there are no member ports; however, FDB entries will not be added for
members on the BIG-IP.

Tests:
Manual

@<reviewer_id>
#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?
