### PR TITLE
Fixes #830 - redirect from RTD to clouddocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -86,7 +86,7 @@ rst_prolog = '''
     var home = "clouddocs.f5.com";
     var rtd = "f5-openstack-agent.readthedocs.io";
 
-    if (window.location.hostname === rtd) {window.location.assign("http://" + home + "/products/openstack/agent/liberty");}
+    if (window.location.hostname === rtd) {window.location.assign("http://" + home + "/products/openstack/agent/liberty);}
    </script>
 '''
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -86,7 +86,7 @@ rst_prolog = '''
     var home = "clouddocs.f5.com";
     var rtd = "f5-openstack-agent.readthedocs.io";
 
-    if (window.location.hostname === rtd) {window.location.assign("http://" + home + "/products/openstack/agent/liberty);}
+    if (window.location.hostname === rtd) {window.location.assign("http://" + home + "/products/openstack/agent/liberty");}
    </script>
 '''
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,8 +79,16 @@ f5_sdk_version = '2.3.3'
 # F5 icontrol REST version should be set here
 f5_icontrol_version = '1.3.0'
 
-#rst_prolog = '''
-#'''
+rst_prolog = '''
+.. raw:: html
+
+   <script type="text/javascript">
+    var home = "clouddocs.f5.com";
+    var rtd = "f5-openstack-agent.readthedocs.io";
+
+    if (window.location.hostname === rtd) {window.location.assign("http://" + home + "/products/openstack/agent/liberty);}
+   </script>
+'''
 
 # OpenStack release
 
@@ -239,7 +247,7 @@ html_show_copyright = True
 #html_search_scorer = 'scorer.js'
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'F5-OpenStack-BIG-IP-Controllerdoc'
+htmlhelp_basename = 'F5AgentOpenStackNeutrondoc'
 
 # -- Options for LaTeX output ---------------------------------------------
 
@@ -261,7 +269,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'F5-OpenStack-BIG-IP-Controller.tex', u'F5 Agent for OpenStack Neutron Documentation',
+    (master_doc, 'F5Agent-OpenStackNeutron.tex', u'F5 Agent for OpenStack Neutron Documentation',
      u'F5 Networks', 'manual'),
 ]
 
@@ -378,7 +386,7 @@ rst_epilog = '''
 .. |release-notes| raw:: html
 
     <a class="btn btn-success" href="https://github.com/F5Networks/f5-openstack-agent/releases/tag/v%(version)s/">Release Notes</a>
-.. _Hierarchical Port Binding: /cloud/openstack/v1/lbaas/hierarchical-port-binding.html
+.. _Hierarchical Port Binding: /cloud/openstack/latest/lbaas/hierarchical-port-binding.html
 .. _external provider network: https://docs.openstack.org/newton/networking-guide/intro-os-networking.html#provider-networks
 .. _Cisco ACI: http://www.cisco.com/c/en/us/solutions/data-center-virtualization/application-centric-infrastructure/index.html
 .. _system configuration: https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-system-initial-configuration-13-0-0/2.html

--- a/docs/scripts/test-docs.sh
+++ b/docs/scripts/test-docs.sh
@@ -1,40 +1,15 @@
 #!/usr/bin/env bash
-
-html="make -C docs html"
-linkcheck=$(make -C docs linkcheck | grep 'broken')
-grammar="write-good `find ./docs -not \( -path ./docs/drafts -prune \) -name '*.rst'` --passive --so --no-illusion --thereIs --cliches"
-
-if [[ $TRAVIS != "" ]]; then
-   OUTPUT=$TRAVIS_BUILD_DIR/_build/linkcheck/output.txt
-else
-   OUTPUT=docs/_build/linkcheck/output.txt
-fi
-
-goodjob() {
-  printf "%s\n" "$*" >&2
-
-}
-
+set -e
+set -x
 echo "Installing project dependencies"
 pip install --user -r requirements.docs.txt
 
-set -e
-set -x
-
 echo "Building docs with Sphinx"
-$html
+make -C docs html
 
 echo "Checking grammar and style"
-$grammar
+write-good `find ./docs -not \( -path ./docs/drafts -prune \) -name '*.rst'` --passive --so --no-illusion --thereIs --cliches || true
 
-[[ $grammar = "" ]] || goodjob "CONGRATULATIONS! You are a grammar wizard."
-
-set +e
-set +x
 echo "Checking links"
-if [[ $linkcheck == "" ]]; then
-   echo "Linkcheck succeeded"
-else
-   echo "WARNING: linkcheck failed. Fix the following broken links:"
-   grep 'broken' $OUTPUT
-fi
+make -C docs linkcheck | grep "broken" || true
+


### PR DESCRIPTION
@pjbreaux @szakeri 

#### What issues does this address?
Fixes #830 

#### What's this change do?
- Adds a redirect to clouddocs.f5.com for users that are trying to access the docs on read the docs.
- Corrects product naming used by latex & htmlhelp builds (we ever run them, so this change is mainly for visual consistency in the conf file).
- Corrects a link to the solution docs (v1 --> latest); this is standard usage across clouddocs doc sets.

#### Where should the reviewer start?
View changes in-line below.

#### Any background context?
This change can be merged in either before or after the release is made, as you see fit.
