### PR TITLE
Bugfix.mitaka.fixing relative path to use pytest call as backup 833

### DIFF
--- a/test/functional/neutronless/loadbalancer/test_f5_common_networks.py
+++ b/test/functional/neutronless/loadbalancer/test_f5_common_networks.py
@@ -39,7 +39,7 @@ LOG = logging.getLogger(__name__)
 def services():
     # ./f5-openstack-agent/test/functional/neutronless/conftest.py
     relative = get_relative_path()
-    snat_pool_json = str("{}/f5-openstack-agent/test/functional/testdata/"
+    snat_pool_json = str("{}/test/functional/testdata/"
                          "service_requests/snat_pool_common_networks.json")
     neutron_services_filename = (snat_pool_json.format(relative))
     return (json.load(open(neutron_services_filename)))

--- a/test/functional/neutronless/loadbalancer/test_snat_common_network.py
+++ b/test/functional/neutronless/loadbalancer/test_snat_common_network.py
@@ -35,7 +35,7 @@ LOG = logging.getLogger(__name__)
 def services():
     # ./f5-openstack-agent/test/functional/neutronless/conftest.py
     relative = get_relative_path()
-    snat_pool_json = str("{}/f5-openstack-agent/test/functional/testdata/"
+    snat_pool_json = str("{}/test/functional/testdata/"
                          "service_requests/snat_pool.json".format(relative))
     neutron_services_filename = (
         os.path.join(os.path.dirname(os.path.abspath(__file__)),


### PR DESCRIPTION
@pjbreaux 
#### What issues does this address?
Fixes #833 

#### What's this change do?
* Makes the neutronless.conftest.get_relative_path() fixture use the py.test arguments as a backup

#### Where should the reviewer start?
Changes to `./test/functional/neutronless/conftest`.  This should not impact other tests or methods that may use this fixture.

#### Any background context?
This is based upon the failure found in #833 within trtl