### PR TITLE
neutronless test failures

### DIFF
--- a/test/functional/neutronless/disconnected_service/conftest.py
+++ b/test/functional/neutronless/disconnected_service/conftest.py
@@ -19,14 +19,30 @@ import os
 import pytest
 import time
 
-from f5.bigip import ManagementRoot
-from f5.utils.testutils.registrytools import register_device
-from f5.utils.testutils.registrytools import AGENT_LB_DEL_ORDER
 from f5.utils.testutils.registrytools import order_by_weights
+from f5.utils.testutils.registrytools import register_device
 from icontrol.exceptions import iControlUnexpectedHTTPError
 
 from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import\
     iControlDriver
+
+
+AGENT_LB_DEL_ORDER = {'/mgmt/tm/ltm/virtual/': 1,
+                      '/mgmt/tm/ltm/pool': 2,
+                      'mgmt/tm/ltm/node/': 3,
+                      'monitor': 4,
+                      'virtual-address': 5,
+                      'mgmt/tm/net/self/': 6,
+                      '/mgmt/tm/net/fdb': 7,
+                      'mgmt/tm/net/tunnels/tunnel/': 8,
+                      'mgmt/tm/net/tunnels/vxlan/': 9,
+                      'mgmt/tm/net/tunnels/gre': 10,
+                      'mgmt/tm/net/vlan': 11,
+                      'route': 12,
+                      '/mgmt/tm/ltm/snatpool': 13,
+                      '/mgmt/tm/ltm/snat-translation': 14,
+                      '/mgmt/tm/net/route-domain': 15,
+                      '/mgmt/tm/sys/folder': 16}
 
 
 @pytest.fixture(scope='module')

--- a/test/functional/neutronless/disconnected_service/test_disconnected_service_creation.py
+++ b/test/functional/neutronless/disconnected_service/test_disconnected_service_creation.py
@@ -17,6 +17,7 @@
 from conftest import remove_elements
 from conftest import setup_neutronless_test
 from copy import deepcopy
+from distutils.version import StrictVersion
 from f5.bigip import ManagementRoot
 from f5.utils.testutils.registrytools import register_device
 from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import \
@@ -46,17 +47,17 @@ FEATURE_OFF_COMMON_NET = OSLO_CONFIGS["feature_off_common_net"]
 FEATURE_ON['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
 FEATURE_OFF['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
 FEATURE_OFF_GRM['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
-FEATURE_OFF_COMMON_NET['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
+FEATURE_OFF_COMMON_NET['icontrol_hostname'] = \
+    pytest.symbols.bigip_mgmt_ip_public
 
 
 tmos_version = ManagementRoot(
-                   pytest.symbols.bigip_mgmt_ip_public,
-                   pytest.symbols.bigip_username,
-                   pytest.symbols.bigip_password
-               ).tmos_version
+    pytest.symbols.bigip_mgmt_ip_public,
+    pytest.symbols.bigip_username,
+    pytest.symbols.bigip_password).tmos_version
 dashed_mgmt_ip = pytest.symbols.bigip_mgmt_ip_public.replace('.', '-')
 icontrol_fqdn = 'host-' + dashed_mgmt_ip + '.openstacklocal'
-if tmos_version == '12.1.0':
+if StrictVersion(tmos_version) >= StrictVersion('12.1.0'):
     icontrol_fqdn = 'bigip1'
 neutron_services_filename =\
     os.path.join(osd(os.path.abspath(__file__)), 'neutron_services.json')

--- a/test/functional/neutronless/listener/test_listener_update.py
+++ b/test/functional/neutronless/listener/test_listener_update.py
@@ -13,7 +13,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from copy import deepcopy
 import json
 import logging
 import os
@@ -60,7 +59,7 @@ def test_listener_update(
         icd_config,
         icontrol_driver):
 
-    env_prefix = 'Project'
+    env_prefix = 'TEST'
     service_iter = iter(services)
 
     # Create loadbalancer
@@ -69,35 +68,35 @@ def test_listener_update(
 
     # Create listener (no name, description)
     l = get_next_listener(service_iter, icontrol_driver, bigip, env_prefix)
-    assert l.name.startswith('Project_')
+    assert l.name.startswith('TEST_')
     assert not hasattr(l, 'description')
     assert l.connectionLimit == 0
     assert l.enabled
 
     # Update name ('spring'). Description is changed to include name.
     l = get_next_listener(service_iter, icontrol_driver, bigip, env_prefix)
-    assert l.name.startswith('Project_')
+    assert l.name.startswith('TEST_')
     assert l.description == 'spring:'
     assert l.connectionLimit == 0
     assert l.enabled
 
     # Update description ('has sprung')
     l = get_next_listener(service_iter, icontrol_driver, bigip, env_prefix)
-    assert l.name.startswith('Project_')
+    assert l.name.startswith('TEST_')
     assert l.description == 'spring: has-sprung'
     assert l.connectionLimit == 0
     assert l.enabled
 
     # Update connection limit (200)
     l = get_next_listener(service_iter, icontrol_driver, bigip, env_prefix)
-    assert l.name.startswith('Project_')
+    assert l.name.startswith('TEST_')
     assert l.description == 'spring: has-sprung'
     assert l.connectionLimit == 200
     assert l.enabled
 
     # Update admin_state_up (False)
     l = get_next_listener(service_iter, icontrol_driver, bigip, env_prefix)
-    assert l.name.startswith('Project_')
+    assert l.name.startswith('TEST_')
     assert l.description == 'spring: has-sprung'
     assert l.connectionLimit == 200
     assert l.disabled

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer.py
@@ -15,7 +15,6 @@
 
 
 from ..testlib.service_reader import LoadbalancerReader
-from copy import deepcopy
 import json
 import logging
 import os
@@ -47,7 +46,7 @@ def test_create_delete_basic_lb(bigip, services, icd_config, icontrol_driver):
     lb_reader = LoadbalancerReader(service)
     env_prefix = icd_config['environment_prefix']
     fake_rpc = icontrol_driver.plugin_rpc
-    hostname = pytest.symbols.bigip_mgmt_ip_public
+    hostname = bigip.get_device_name()
 
     folder = '%s_%s' % (env_prefix, lb_reader.tenant_id())
 
@@ -140,19 +139,21 @@ def test_create_delete_basic_lb(bigip, services, icd_config, icontrol_driver):
 
     # Delete the loadbalancer
     service = service_iter.next()
-    lb_pending = icontrol_driver._common_service_handler(service, delete_partition=True,
-                                                         delete_event=True)
+    lb_pending = \
+        icontrol_driver._common_service_handler(
+            service, delete_partition=True, delete_event=True)
     assert not lb_pending
     assert not bigip.folder_exists(folder)
 
-def test_create_delete_basic_lb_nodisconnected(bigip, services, icd_config, icontrol_driver):
 
+def test_create_delete_basic_lb_nodisconnected(
+        bigip, services, icd_config, icontrol_driver):
     service_iter = iter(services)
     service = service_iter.next()
     lb_reader = LoadbalancerReader(service)
     env_prefix = icd_config['environment_prefix']
     fake_rpc = icontrol_driver.plugin_rpc
-    hostname = pytest.symbols.bigip_mgmt_ip_public
+    hostname = bigip.get_device_name()
     icd_config['f5_network_segment_physical_network'] = None
 
     folder = '%s_%s' % (env_prefix, lb_reader.tenant_id())
@@ -246,7 +247,7 @@ def test_create_delete_basic_lb_nodisconnected(bigip, services, icd_config, icon
 
     # Delete the loadbalancer
     service = service_iter.next()
-    lb_pending = icontrol_driver._common_service_handler(service, delete_partition=True,
-                                                             delete_event=True)
+    lb_pending = icontrol_driver._common_service_handler(
+        service, delete_partition=True, delete_event=True)
     assert not lb_pending
     assert not bigip.folder_exists(folder)

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer_opflex.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer_opflex.py
@@ -47,7 +47,7 @@ def test_create_delete_basic_lb(bigip, services, icd_config, icontrol_driver):
     lb_reader = LoadbalancerReader(service)
     env_prefix = icd_config['environment_prefix']
     fake_rpc = icontrol_driver.plugin_rpc
-    hostname = pytest.symbols.bigip_mgmt_ip_public
+    hostname = bigip.get_device_name()
 
     folder = '%s_%s' % (env_prefix, lb_reader.tenant_id())
 
@@ -149,7 +149,7 @@ def test_featureoff_create_delete_basic_lb(bigip, services, icd_config, icontrol
     lb_reader = LoadbalancerReader(service)
     env_prefix = icd_config['environment_prefix']
     fake_rpc = icontrol_driver.plugin_rpc
-    hostname = pytest.symbols.bigip_mgmt_ip_public
+    hostname = bigip.get_device_name()
     icd_config['f5_network_segment_physical_network'] = None
 
     folder = '%s_%s' % (env_prefix, lb_reader.tenant_id())

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer_rd.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer_rd.py
@@ -64,7 +64,7 @@ def my_test_create_delete_basic_lb_no_namespace(bigip, services, icd_config, ico
     lb_reader = LoadbalancerReader(service)
     env_prefix = icd_config['environment_prefix']
     fake_rpc = icontrol_driver.plugin_rpc
-    hostname = pytest.symbols.bigip_mgmt_ip_public
+    hostname = bigip.get_device_name()
     icd_config['use_namespaces'] = False
 
     folder = '%s_%s' % (env_prefix, lb_reader.tenant_id())

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer_snat.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer_snat.py
@@ -47,7 +47,7 @@ def test_create_delete_lb_autosnat(bigip, services, icd_config, icontrol_driver)
     lb_reader = LoadbalancerReader(service)
     env_prefix = icd_config['environment_prefix']
     fake_rpc = icontrol_driver.plugin_rpc
-    hostname = pytest.symbols.bigip_mgmt_ip_public
+    hostname = bigip.get_device_name()
 
     # Change the configuration so that Auto SNAT is used.
     icd_config['f5_snat_addresses_per_subnet'] = 0
@@ -137,7 +137,7 @@ def test_create_delete_lb_multisnat(bigip, services, icd_config, icontrol_driver
     fake_rpc = icontrol_driver.plugin_rpc
     icd_config['f5_snat_addresses_per_subnet'] = 5
     folder = '%s_%s' % (env_prefix, lb_reader.tenant_id())
-    hostname = pytest.symbols.bigip_mgmt_ip_public
+    hostname = bigip.get_device_name()
 
     # Make sure we are starting clean.
     assert not bigip.folder_exists(folder)
@@ -240,7 +240,7 @@ def test_create_delete_lb_snatoff(bigip, services, icd_config, icontrol_driver):
     lb_reader = LoadbalancerReader(service)
     env_prefix = icd_config['environment_prefix']
     fake_rpc = icontrol_driver.plugin_rpc
-    hostname = pytest.symbols.bigip_mgmt_ip_public
+    hostname = bigip.get_device_name()
 
     # Change the configuration so that Auto SNAT is used.
     icd_config['f5_snat_mode'] = "false"

--- a/test/functional/neutronless/loadbalancer/test_snat_common_network.py
+++ b/test/functional/neutronless/loadbalancer/test_snat_common_network.py
@@ -22,7 +22,6 @@ import os
 import pytest
 import requests
 
-from ..testlib.bigip_client import BigIpClient
 from ..testlib.fake_rpc import FakeRPCPlugin
 from ..testlib.service_reader import LoadbalancerReader
 from ..testlib.resource_validator import ResourceValidator
@@ -39,14 +38,6 @@ def services():
                      '../../testdata/service_requests/snat_pool.json')
     )
     return (json.load(open(neutron_services_filename)))
-
-
-@pytest.fixture(scope="module")
-def bigip():
-
-    return BigIpClient(pytest.symbols.bigip_mgmt_ip_public,
-                       pytest.symbols.bigip_username,
-                       pytest.symbols.bigip_password)
 
 
 @pytest.fixture

--- a/test/functional/neutronless/testlib/bigip_client.py
+++ b/test/functional/neutronless/testlib/bigip_client.py
@@ -18,6 +18,7 @@ import re
 import urllib
 
 from f5.bigip import ManagementRoot
+from f5_openstack_agent.lbaasv2.drivers.bigip import cluster_manager
 from f5_openstack_agent.lbaasv2.drivers.bigip import resource_helper
 from f5_openstack_agent.lbaasv2.drivers.bigip import system_helper
 
@@ -83,3 +84,7 @@ class BigIpClient(object):
                             partition=partition)
 
         return False
+
+    def get_device_name(self):
+        cm = cluster_manager.ClusterManager()
+        return cm.get_device_name(self.bigip)


### PR DESCRIPTION
@szakeri 
#### What issues does this address?
Fixes #693 

#### What's this change do?
Updated loabalancer tests to use the correct device name, which
masquerades as the hostname in the object naming schemes. We basically
reproduced the way the agent originally creates the object name to
create the expectation in the test.

#### Where should the reviewer start?

#### Any background context?
Multiple tests in neutronless/loadbalancer test suite fail against
liberty, mitaka, and newton with failure to find selfip object on
device.

Ran tests in local sandbox. This should turn some of our red nightly tests green!