### PR TITLE
Add smoke tests to agent's Makefile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,8 +34,10 @@ pipeline {
                     # - run tests
                     make -C systest $JOB_BASE_NAME
 
-                    # - record results
-                    systest/scripts/record_results.sh
+                    # - record results only if it's not a smoke test
+                    if [ -n "${JOB_BASE_NAME##*smoke*}" ]; then
+                        systest/scripts/record_results.sh
+                    fi
                 '''
             }
         }

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -36,6 +36,7 @@
 #
 DEVICES := 12.1.1
 DEPLOYS := $(foreach v, $(DEVICES), $(v)-overcloud $(v)-undercloud)
+DEPLOYS += 12.1.1-overcloud_smoke
 
 # Tell make that targets don't map to files
 .PHONY: setup \
@@ -71,8 +72,8 @@ PROJDIR := $(shell dirname $(realpath $(MAKEFILE_DIR)))
 # - <nearest reachable tag>-<num commits since>-g<abbreviated commit id>
 TAGINFO := $(shell git describe --long --tags --first-parent)
 
-# git branch
-BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
+# git branch set here for use in build on PR
+BRANCH := liberty
 
 # The branch may contain the text 'stable/' before the OpenStack release name
 # To allow this type of branch name and any other to work with the cloud deployment
@@ -81,7 +82,7 @@ BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
 SANITIZED_BRANCH := $(subst /,,$(BRANCH))
 
 # /ASB/PATH/systest/test_results: This is where the CI system will look
-# for test reuslts.
+# for test results.
 RESULTS_DIR := $(MAKEFILE_DIR)/test_results
 TESTENVLOGDIR := $(RESULTS_DIR)/f5-openstack-agent_$(SANITIZED_BRANCH)/testenv
 
@@ -140,6 +141,11 @@ run_overcloud_tests:
 	$(MAKE) -C . setup_singlebigip_tests &&\
 	$(MAKE) -C . singlebigip
 
+run_overcloud_smoke_tests:
+	@echo executing $@
+	$(MAKE) -C . setup_singlebigip_tests &&\
+	$(MAKE) -C . smoke
+
 #### TESTSBYINFRA SECTION
 #    Different test scenarios require different infrastructure.  Currently the
 #    only infrastructure required by any test is a singlebigip.
@@ -167,6 +173,14 @@ singlebigip:
 	$(MAKE) -C . run_disconnected_service_tests ;\
 	$(MAKE) -C . run_singlebigip_tests ;\
 	$(MAKE) -C . cleanup_singlebigip
+
+smoke:
+	@echo executing $@
+	export GP_SUFFIX=$@_$${GP_SUFFIX} &&
+	export GUMBALLS_PROJECT=$(RESULTS_DIR)/$${GP_SUFFIX} &&
+	$(MAKE) -C . run_smoke_tests
+	$(MAKE) -C . cleanup_singlebigip
+
 
 run_neutronless_loadbalancer_tests:
 	@echo executing $@
@@ -224,6 +238,18 @@ run_disconnected_service_tests:
 		--autolog-outputdir $${GUMBALLS_PROJECT} \
 		--autolog-session $${GUMBALLS_SESSION} \
 	    ../test/functional/neutronless/disconnected_service/
+
+run_smoke_tests:
+	@echo executing $@
+	tox -e singlebigip --sitepackage -- \
+	    --cov $(PROJDIR)/f5_openstack_agent \
+		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
+		--autolog-outputdir $${GUMBALLS_PROJECT} \
+		--autolog-session $${GUMBALLS_SESSION} \
+		../test/functional/neutronless/loadbalancer/ \
+		../test/functional/neutronless/listener/ \
+		../test/functional/neutronless/pool/ \
+		../test/functional/neutronless/member/
 
 cleanup_singlebigip:
 	@echo executing $@

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -92,7 +92,7 @@ TESTENVLOGDIR := $(RESULTS_DIR)/f5-openstack-agent_$(SANITIZED_BRANCH)/testenv
 #    installed.  Each deploy maps to its own GUMBALLS project.
 #    Tests use tox for python variants.
 setup:
-	-@echo executing $@
+	@echo executing $@
 	sudo -E -H $(SCRIPT_DIR)/install_test_infra.sh
 	mkdir -p $(TESTENVLOGDIR)
 
@@ -118,7 +118,7 @@ unit-tests: setup
 #  NOTE: GUMBALLS SESSIONs are complete here, e.g.:
 #  v8.0.1-435-gab9141e_20170311
 $(DEPLOYS): setup
-	-@echo executing $@
+	@echo executing $@ ;\
 	. $(MAKEFILE_DIR)/device_version_maps.sh &&
 	export BIGIP_VER=`python -c 'print("$@".split("-")[0].replace(".", "_"))'` &&
 	export DEVICEVERSION=BIGIP_$${BIGIP_VER} &&
@@ -132,17 +132,18 @@ $(DEPLOYS): setup
 
 # Currently does nothing in f5-openstack-agent
 run_undercloud_tests:
-	@echo executing $@
+	-@echo executing $@ ;\
 	echo $${CLOUD}
 
 # This rule is run once per device type XX.Y.Z
 run_overcloud_tests:
-	@echo executing $@
+	-@echo executing $@ ;\
 	$(MAKE) -C . setup_singlebigip_tests &&\
 	$(MAKE) -C . singlebigip
+	$(MAKE) -C . cleanup_singlebigip
 
 run_overcloud_smoke_tests:
-	@echo executing $@
+	@echo executing $@ ;\
 	$(MAKE) -C . setup_singlebigip_tests &&\
 	$(MAKE) -C . smoke
 
@@ -163,7 +164,7 @@ setup_singlebigip_tests:
 	        $${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${TESTENV_NAME}.log
 
 singlebigip:
-	@echo executing $@
+	@echo executing $@ ;\
 	export GP_SUFFIX=$@_$${GP_SUFFIX} &&
 	export GUMBALLS_PROJECT=$(RESULTS_DIR)/$${GP_SUFFIX} &&
 	$(MAKE) -C . run_neutronless_loadbalancer_tests ;\
@@ -171,11 +172,10 @@ singlebigip:
 	$(MAKE) -C . run_neutronless_member_tests ;\
 	$(MAKE) -C . run_neutronless_pool_tests ;\
 	$(MAKE) -C . run_disconnected_service_tests ;\
-	$(MAKE) -C . run_singlebigip_tests ;\
-	$(MAKE) -C . cleanup_singlebigip
+	$(MAKE) -C . run_singlebigip_tests
 
 smoke:
-	@echo executing $@
+	@echo executing $@ ;\
 	export GP_SUFFIX=$@_$${GP_SUFFIX} &&
 	export GUMBALLS_PROJECT=$(RESULTS_DIR)/$${GP_SUFFIX} &&
 	$(MAKE) -C . run_smoke_tests
@@ -183,7 +183,7 @@ smoke:
 
 
 run_neutronless_loadbalancer_tests:
-	@echo executing $@
+	@echo executing $@ ;\
 	tox -e singlebigip --sitepackage -- \
 	    --cov $(PROJDIR)/f5_openstack_agent \
 		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
@@ -192,7 +192,7 @@ run_neutronless_loadbalancer_tests:
 	    ../test/functional/neutronless/loadbalancer/
 
 run_neutronless_listener_tests:
-	@echo executing $@
+	@echo executing $@ ;\
 	tox -e singlebigip --sitepackage -- \
 	    --cov $(PROJDIR)/f5_openstack_agent \
 		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
@@ -201,7 +201,7 @@ run_neutronless_listener_tests:
 	    ../test/functional/neutronless/listener/
 
 run_neutronless_member_tests:
-	@echo executing $@
+	@echo executing $@ ;\
 	tox -e singlebigip --sitepackage -- \
 	    --cov $(PROJDIR)/f5_openstack_agent \
 		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
@@ -210,7 +210,7 @@ run_neutronless_member_tests:
 	    ../test/functional/neutronless/member/
 
 run_neutronless_pool_tests:
-	@echo executing $@
+	@echo executing $@ ;\
 	tox -e singlebigip --sitepackage -- \
 	    --cov $(PROJDIR)/f5_openstack_agent \
 		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
@@ -219,7 +219,7 @@ run_neutronless_pool_tests:
 	    ../test/functional/neutronless/pool/
 
 run_singlebigip_tests:
-	@echo executing $@
+	@echo executing $@ ;\
 	tox -e singlebigip --sitepackage -- \
 	    --cov $(PROJDIR)/f5_openstack_agent \
 		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
@@ -229,7 +229,7 @@ run_singlebigip_tests:
 
 # disconnected_singlebigip_f5-openstack-agent_liberty-12_1_1-overcloud
 run_disconnected_service_tests:
-	@echo executing $@
+	@echo executing $@ ;\
 	export GP_SUFFIX=disconnected_$${GP_SUFFIX} &&
 	export GUMBALLS_PROJECT=$(RESULTS_DIR)/$${GP_SUFFIX} &&
 	tox -e disconnected_service --sitepackage -- \
@@ -240,7 +240,7 @@ run_disconnected_service_tests:
 	    ../test/functional/neutronless/disconnected_service/
 
 run_smoke_tests:
-	@echo executing $@
+	@echo executing $@ ;\
 	tox -e singlebigip --sitepackage -- \
 	    --cov $(PROJDIR)/f5_openstack_agent \
 		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer.py
@@ -251,3 +251,4 @@ def test_create_delete_basic_lb_nodisconnected(
         service, delete_partition=True, delete_event=True)
     assert not lb_pending
     assert not bigip.folder_exists(folder)
+    assert True is False

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer.py
@@ -251,4 +251,3 @@ def test_create_delete_basic_lb_nodisconnected(
         service, delete_partition=True, delete_event=True)
     assert not lb_pending
     assert not bigip.folder_exists(folder)
-    assert True is False


### PR DESCRIPTION
@szakeri 

#### What issues does this address?
Fixes #841 

#### What's this change do?
Created a new target to run the smoke tests, and singled out a few tests
that should be run. These are all singlebigip tests.

#### Where should the reviewer start?

#### Any background context?
We need to add the option to make smoke tests for building on PR. We
should create a new make target to be able to run a set of specific
tests that we've picked as 'smoke tests'. These will run automatically
when a PR is created on this fork in Github.

Ran those tests with the new smoke target against 12.1.1