### PR TITLE
Agent manager lbdriver not initialized in proper order

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -254,6 +254,9 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
         LOG.debug('setting service resync intervl to %d seconds' %
                   self.service_resync_interval)
 
+        # Load the driver.
+        self._load_driver(conf)
+
         # Set the agent ID
         if self.conf.agent_id:
             self.agent_host = self.conf.agent_id
@@ -296,9 +299,6 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
 
         # Setup RPC for communications to and from controller
         self._setup_rpc()
-
-        # Load the driver.
-        self._load_driver(conf)
 
         # Set driver context for RPC.
         self.lbdriver.set_context(self.context)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1599,7 +1599,7 @@ class iControlDriver(LBaaSBaseDriver):
                 self.tenant_manager.assure_tenant_created(service)
             except Exception as e:
                 LOG.error("Tenant folder creation exception: %s",
-                          e.message)
+                          str(e))
                 if lb_provisioning_status != plugin_const.PENDING_DELETE:
                     loadbalancer['provisioning_status'] = \
                         plugin_const.ERROR


### PR DESCRIPTION
Issues:
Fixes #893

Problem:
The lbaasv2 agent is not registering with neutron in the neutron agent-list upon
installation and start of the process. The service status looks as though it is active.

Analysis:
Moved the load_driver call to initialize the agent_manager driver attribute
before it is used to build configuration.

Tests:
Manual
