### PR TITLE
Re-Ordering pool creation

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -76,6 +76,8 @@ class LBaaSBuilder(object):
 
         self._assure_l7policies_deleted(service)
 
+        self._assure_pools_created(service)
+
         self._assure_listeners_deleted(service)
 
         self._assure_loadbalancer_deleted(service)
@@ -159,16 +161,38 @@ class LBaaSBuilder(object):
 
                 try:
                     # create or update pool
-                    try:
-                        if pool['provisioning_status'] \
-                                != plugin_const.PENDING_UPDATE:
-                            self.pool_builder.create_pool(svc, bigips)
-                        else:
-                            self.pool_builder.update_pool(svc, bigips)
-                    except HTTPError as err:
-                        if err.response.status_code != 409:
-                            raise f5_ex.PoolCreationException(err.message)
+                    if pool['provisioning_status'] \
+                            != plugin_const.PENDING_UPDATE:
+                        self.pool_builder.create_pool(svc, bigips)
+                    else:
+                        self.pool_builder.update_pool(svc, bigips)
+                except HTTPError as err:
+                    if err.response.status_code != 409:
+                        pool['provisioning_status'] = plugin_const.ERROR
+                        loadbalancer['provisioning_status'] = \
+                            plugin_const.ERROR
+                        raise f5_ex.PoolCreationException(err.message)
+                except Exception as err:
+                    pool['provisioning_status'] = plugin_const.ERROR
+                    loadbalancer['provisioning_status'] = \
+                        plugin_const.ERROR
+                    raise f5_ex.PoolCreationException(str(err))
 
+    def _assure_pools_configured(self, service):
+        if "pools" not in service:
+            return
+
+        pools = service["pools"]
+        loadbalancer = service["loadbalancer"]
+
+        bigips = self.driver.get_config_bigips()
+
+        for pool in pools:
+            if pool['provisioning_status'] != plugin_const.PENDING_DELETE:
+                svc = {"loadbalancer": loadbalancer,
+                       "pool": pool}
+                svc['members'] = self._get_pool_members(service, pool['id'])
+                try:
                     # assign pool name to virtual
                     pool_name = self.service_adapter.init_pool_name(
                         loadbalancer, pool)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_lbaas_builder.py
@@ -1116,6 +1116,7 @@ class TestLbaasBuilder(object):
         with mock.patch(VS_POOL_UPDATE_PATH) as mock_update_vs_pool:
             builder = LBaaSBuilder(mock.MagicMock(), mock_driver)
             builder._assure_pools_created(shared_pool_service)
+            builder._assure_pools_configured(shared_pool_service)
             svc = {
                 'listener': shared_pool_service['listeners'][0],
                 'members': [],
@@ -1152,6 +1153,7 @@ class TestLbaasBuilder(object):
         svc['pools'][0]['provisioning_status'] = 'PENDING_CREATE'
         builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
         builder._assure_pools_created(svc)
+        builder._assure_pools_configured(svc)
         assert mock_create.called
         assert not mock_update.called
 
@@ -1164,6 +1166,7 @@ class TestLbaasBuilder(object):
         svc['pools'][0]['provisioning_status'] = 'PENDING_UPDATE'
         builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
         builder._assure_pools_created(svc)
+        builder._assure_pools_configured(svc)
         assert mock_update.called
         assert not mock_create.called
 
@@ -1176,6 +1179,7 @@ class TestLbaasBuilder(object):
         svc['pools'][0]['provisioning_status'] = 'ACTIVE'
         builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
         builder._assure_pools_created(svc)
+        builder._assure_pools_configured(svc)
         assert not mock_update.called
         assert mock_create.called
 
@@ -1188,6 +1192,7 @@ class TestLbaasBuilder(object):
         svc['pools'][0]['provisioning_status'] = 'ERROR'
         builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
         builder._assure_pools_created(svc)
+        builder._assure_pools_configured(svc)
         assert not mock_update.called
         assert mock_create.called
 
@@ -1203,6 +1208,7 @@ class TestLbaasBuilder(object):
         svc['loadbalancer']['provisioning_status'] = 'PENDING_UPDATE'
         builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
         builder._assure_pools_created(svc)
+        builder._assure_pools_configured(svc)
         assert not mock_update.called
         assert mock_create.called
         assert mock_vs_update_pool.called
@@ -1221,6 +1227,7 @@ class TestLbaasBuilder(object):
         svc['loadbalancer']['provisioning_status'] = 'PENDING_UPDATE'
         builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
         builder._assure_pools_created(svc)
+        builder._assure_pools_configured(svc)
         assert not mock_update.called
         assert mock_create.called
         assert mock_vs_update_pool.called
@@ -1241,6 +1248,7 @@ class TestLbaasBuilder(object):
             MockHTTPError(MockHTTPErrorResponse409(), 'Exists')
         builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
         builder._assure_pools_created(svc)
+        builder._assure_pools_configured(svc)
         assert not mock_update.called
         assert mock_create.called
         assert mock_vs_update_pool.called
@@ -1261,6 +1269,7 @@ class TestLbaasBuilder(object):
             MockHTTPError(MockHTTPErrorResponse409(), 'Exists')
         builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
         builder._assure_pools_created(svc)
+        builder._assure_pools_configured(svc)
         assert not mock_update.called
         assert mock_create.called
         assert mock_vs_update_pool.called
@@ -1283,6 +1292,7 @@ class TestLbaasBuilder(object):
         with pytest.raises(f5_ex.PoolCreationException) as ex:
             builder._assure_pools_created(svc)
             assert ex.value.message == 'Exists'
+        builder._assure_pools_configured(svc)
         assert not mock_update.called
         assert mock_create.called
         assert svc['loadbalancer']['provisioning_status'] == 'ERROR'
@@ -1304,6 +1314,7 @@ class TestLbaasBuilder(object):
         with pytest.raises(f5_ex.PoolCreationException) as ex:
             builder._assure_pools_created(svc)
             assert ex.value.message == 'Exists'
+        builder._assure_pools_configured(svc)
         assert not mock_update.called
         assert mock_create.called
         assert svc['loadbalancer']['provisioning_status'] == 'ERROR'


### PR DESCRIPTION
Issues:
WIP #878

Problem:
* VIP port conflict in the current order of pool creation

Analysis:
* This re-orders the pool creation and splits it into two parts
  * Create the pool
  * Configure the pool and the adjacent objects

Tests:
Used previously-existing tests and modified them to fit

@jlongstaf 
#### What issues does this address?
WIP #878

Re-Ordering pool creation

Issues:
WIP #878

Problem:
* VIP port conflict in the current order of pool creation

Analysis:
* This re-orders the pool creation and splits it into two parts
  * Create the pool
  * Configure the pool and the adjacent objects

Tests:
Used previously-existing tests and modified them to fit