### PR TITLE
update_fdb_entries in agent_manager.py does not expect proper data structure from neturon

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -930,8 +930,14 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
         try:
             LOG.debug('received update_fdb_entries: %s host: %s'
                       % (fdb_entries, host))
-            self.lbdriver.fdb_update(fdb_entries)
+            # self.lbdriver.fdb_update(fdb_entries)
+            LOG.warning("update_fdb_entries: the LBaaSv2 Agent does not "
+                        "handle an update of the IP address of a neutron "
+                        "port. This port is generally tied to a member. If "
+                        "the IP address of a member was changed, be sure to "
+                        "also recreate the member in neutron-lbaas with the "
+                        "new address.")
         except q_exception.NeutronException as exc:
-            LOG.error("update_fdb_entrie: NeutronException: %s" % exc.msg)
+            LOG.error("update_fdb_entries: NeutronException: %s" % exc.msg)
         except Exception as exc:
-            LOG.error("update_fdb_entrie: Exception: %s" % exc.message)
+            LOG.error("update_fdb_entries: Exception: %s" % exc.message)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager.py
@@ -1,0 +1,42 @@
+# coding=utf-8
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5_openstack_agent.lbaasv2.drivers.bigip import agent_manager
+
+import mock
+import pytest
+
+
+@pytest.fixture
+@mock.patch('f5_openstack_agent.lbaasv2.drivers.bigip.agent_manager.'
+            'LbaasAgentManager._setup_rpc')
+@mock.patch('f5_openstack_agent.lbaasv2.drivers.bigip.agent_manager.'
+            'importutils.import_object')
+def agent_mgr_setup(mock_importutils, mock_setup_rpc):
+    return agent_manager.LbaasAgentManager(mock.MagicMock(name='conf'))
+
+
+@mock.patch('f5_openstack_agent.lbaasv2.drivers.bigip.agent_manager.LOG')
+def test_update_fdb_entries(mock_log, agent_mgr_setup):
+    '''When func is called in agent_manager, it prooduces a warning message.'''
+
+    agent_mgr_setup.update_fdb_entries('', '')
+    warning_msg = "update_fdb_entries: the LBaaSv2 Agent does not handle an " \
+        "update of the IP address of a neutron port. This port is generally " \
+        "tied to a member. If the IP address of a member was changed, be " \
+        "sure to also recreate the member in neutron-lbaas with the new " \
+        "address."
+    assert mock_log.warning.call_args == mock.call(warning_msg)


### PR DESCRIPTION
@ssorenso 
#### What issues does this address?
Fixes #782 

#### What's this change do?
Instead of implementing code that would affect no change on the BIG-IP
device anyway, I simply commented out the call to update the fdb
entries and log a warning message when this event is seen in the agent,
thus showing the user a likely reason why the message was produced and
how they can remedy the situation.

#### Where should the reviewer start?

#### Any background context?
Okay, after doing some research into this issue, I've come to a few
points of clarification.

1. The only way I see an update_fdb_entries message kicked from neutron is
in the case that the member IP address has changed through a neutron
port update command.

2. In the case that the member IP address is changed via step 1 above, we
actually make no change on the BIG-IP device. An fdb entry does not
contain the IP address of the member.

3. If the member address changes in neutron, we must update neutron-lbaas
to that fact (this is not in the scope of this issue).

Thus, we do not need to pay attention to the update_fdb_entries message with
the current iteration of the agent.