### PR TITLE
Travis change for greater tracking of RPM issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,17 +21,21 @@ install:
 script:
     - tox -e style,unit
     - python f5-openstack-agent-dist/scripts/universal_truth.py
+    - echo "setup.cfg:"
+    - cat setup.cfg
+    - echo "stdeb.cfg:"
+    - cat f5-openstack-agent-dist/deb_dist/stdeb.cfg
     - f5-openstack-agent-dist/scripts/package_agent.sh "redhat" "7"
     - f5-openstack-agent-dist/scripts/package_agent.sh "redhat" "6"
     - f5-openstack-agent-dist/scripts/package_agent.sh "ubuntu" "14.04"
     - sudo chown -R travis:travis ${DIST_REPO}/rpms/build
     - sudo chown -R travis:travis ${DIST_REPO}/deb_dist/*.deb
+    - f5-openstack-agent-dist/scripts/test_install.sh "redhat" "7" ${PKG_RELEASE_EL7}
+    - f5-openstack-agent-dist/scripts/test_install.sh "ubuntu" "14.04" ${PKG_RELEASE_1404}
     - ./docs/scripts/docker-docs.sh ./docs/scripts/test-docs.sh
 after_success:
   - md5sum ${PKG_RELEASE_EL7} > ${PKG_RELEASE_EL7}.md5 && md5sum --check ${PKG_RELEASE_EL7}.md5
   - md5sum ${PKG_RELEASE_1404} > ${PKG_RELEASE_1404}.md5 && md5sum --check ${PKG_RELEASE_1404}.md5
-  - f5-openstack-agent-dist/scripts/test_install.sh "redhat" "7" ${PKG_RELEASE_EL7}
-  - f5-openstack-agent-dist/scripts/test_install.sh "ubuntu" "14.04" ${PKG_RELEASE_1404}
 deploy:
   - provider: releases
     api_key:

--- a/f5-openstack-agent-dist/Docker/redhat/install_test/fetch_and_install_deps.py
+++ b/f5-openstack-agent-dist/Docker/redhat/install_test/fetch_and_install_deps.py
@@ -57,13 +57,14 @@ def fetch_agent_dependencies(dist_dir, version, release, agent_pkg):
     else:
         print("Success")
 
+    f5_sdk_version = None  # default for later evaluation for a clean exit...
     for line in output.split('\n'):
         print(line, dep_match_re.pattern)
         match = dep_match_re.match(line)
         if match:
             groups = list(match.groups())
             my_dep = ReqDetails(groups[0], groups[2], groups[3])
-            if 'f5-sdk' in my_dep.name:
+            if 'f5-sdk' in my_dep.name and re.search(' [><]?=', line):
                 f5_sdk_version = my_dep.version
             else:
                 requires.append(my_dep)

--- a/f5-openstack-agent-dist/Docker/ubuntu/install_test/fetch_and_install_deps.py
+++ b/f5-openstack-agent-dist/Docker/ubuntu/install_test/fetch_and_install_deps.py
@@ -65,10 +65,10 @@ def fetch_agent_dependencies(dist_dir, version, release, agent_pkg):
             if match:
                 groups = list(match.groups())
                 my_dep = ReqDetails(*groups)
-                if 'f5-sdk' in my_dep.name and '=' in my_dep.oper:
+                if 'f5-sdk' in my_dep.name and '=' in my_dep.oper and \
+                        '!=' not in my_dep.oper:
                     f5_sdk_version = my_dep.version
-                else:
-                    requires.append(my_dep)
+                requires.append(my_dep)
         break
 
     # we know we will always need this...
@@ -86,9 +86,11 @@ def fetch_agent_dependencies(dist_dir, version, release, agent_pkg):
     github_sdk_url = (sdk_github_addr % re.sub("-\d+", "", f5_sdk_version))
     f5_sdk_pkg = "python-f5-sdk-rest_%s_1404_all.deb" % \
         (f5_sdk_version)
+    f5_sdk_version_bld = "{}-1".format(f5_sdk_version) \
+        if '-1' not in f5_sdk_version else f5_sdk_version
     curlCmd = \
         ("curl -L -o /tmp/%s %s/python-f5-sdk_%s_1404_all.deb" %
-         (f5_sdk_pkg, github_sdk_url, f5_sdk_version))
+         (f5_sdk_pkg, github_sdk_url, f5_sdk_version_bld))
 
     print("Fetching f5-sdk package from github")
     (output, status) = runCommand(curlCmd)

--- a/f5-openstack-agent-dist/deb_dist/stdeb.cfg
+++ b/f5-openstack-agent-dist/deb_dist/stdeb.cfg
@@ -1,3 +1,0 @@
-[DEFAULT]
-Depends:
-	python-f5-sdk (=2.3.3-1)

--- a/f5-openstack-agent-dist/scripts/construct_setups.py
+++ b/f5-openstack-agent-dist/scripts/construct_setups.py
@@ -28,6 +28,11 @@ from collections import deque
 from collections import namedtuple
 from pip.req import parse_requirements as p_reqs
 
+default_setup_cfg = deque()
+default_stdeb_cfg = deque()
+default_setup_cfg.append('[bdist_rpm]\n')
+default_stdeb_cfg.append('[DEFAULT]\n')
+
 
 def construct_cfgs(**kargs):
     """construct_cfgs
@@ -84,6 +89,13 @@ def _read_in_cfgs(cfg):
                 line = fh.readline()
     except IOError:
         pass  # we then have empty contents... all well...
+    if not cfgs:
+        if cfg.endswith('setup.cfg'):
+            cfgs = default_setup_cfg
+        elif cfg.endswith('stdeb.cfg'):
+            cfgs = default_stdeb_cfg
+        else:
+            cfgs = deque()
     return cfgs
 
 
@@ -139,14 +151,20 @@ def _construct_file(setup_cfg, setup, fmt, start):
     if not os.path.isfile(setup) or not os.access(setup, os.R_OK):
         print(setup + " does not exist or is not readable")
         exit_cleanly(error_number=errno.ENOSYS)
-    contents = _read_in_cfgs(setup_cfg) if os.path.isfile(setup_cfg) else \
-        deque()
+    contents = _read_in_cfgs(setup_cfg)
     parsed_reqs = map(lambda x: (x.req), p_reqs(setup, session="pkg"))
     if not parsed_reqs:
         print("Nothing to do!\n%s\nDoes not contain any reqs parsable!" %
               setup)
         exit_cleanly(error_number=0)
     try:
+        base_dir = os.path.dirname(setup_cfg)
+        if not os.path.isdir(base_dir):
+            try:
+                os.mkdir(base_dir)
+            except OSError as Error:
+                if Error.errno != errno.EEXIST:
+                    raise
         with open(setup_cfg, 'w') as fh:
             pkg_type = ''
             if contents:

--- a/f5-openstack-agent-dist/scripts/construct_setups.py
+++ b/f5-openstack-agent-dist/scripts/construct_setups.py
@@ -57,7 +57,7 @@ not suggested to use this function if you intend to get control back again.
 
 def _construct_cfgs_from_json(args):
     Args = namedtuple('Args', 'setup, reqs, fmt, start')
-    rpm = Args(args['setup_cfg'], args['setup_requirements'], '%s%s',
+    rpm = Args(args['setup_cfg'], args['setup_requirements'], '%s %s',
                'requires = ')
     deb = Args(args['stdeb_cfg'], args['setup_requirements'], '%s (%s), ',
                'Depends:\n    ')

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_rpm]
-requires =  f5-sdk >= 2.3.3


### PR DESCRIPTION
Issues:
Fixes #930

Problem:
* RPM packages are getting created in Travis
  * With a rate of about 20%, random parsing errors can occur with deps

Analysis:
* The test protion of travis scripting was moved to 'script' section
  * This is a mission-critical section for declaring a test failure
  * Upon test failure, work around is to rebuild the test to get rpm

Tests:
* This is test code

@richbrowne 
#### What's this change do?
Moves the testing portion of Travis's testing code for RPM package building (and debian by proxy) into the Travis's `script` section.  This should cause the tests to fail if/when a package is not properly built.

#### Where should the reviewer start?
.travis.yml file

#### Any background context?
This is only to address our tests failing if/when a travis build fails.