### PR TITLE
Add device id to port creation for subnets RPC

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -692,6 +692,7 @@ class iControlDriver(LBaaSBaseDriver):
             ic_host['platform'] = self.system_helper.get_platform(hostbigip)
             ic_host['serial_number'] = self.system_helper.get_serial_number(
                 hostbigip)
+            ic_host['device_interfaces'] = hostbigip.device_interfaces
             icontrol_endpoints[host] = ic_host
 
         self.agent_configurations['tunneling_ips'] = local_ips

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
@@ -550,6 +550,7 @@ class NetworkServiceBuilder(object):
         tenant_id = service['loadbalancer']['tenant_id']
         subnet = subnetinfo['subnet']
         snats_per_subnet = self.conf.f5_snat_addresses_per_subnet
+        lb_id = service['loadbalancer']['id']
 
         assure_bigips = \
             [bigip for bigip in assure_bigips
@@ -561,7 +562,7 @@ class NetworkServiceBuilder(object):
                   subnet['id'])
         if len(assure_bigips):
             snat_addrs = self.bigip_snat_manager.get_snat_addrs(
-                subnetinfo, tenant_id, snats_per_subnet)
+                subnetinfo, tenant_id, snats_per_subnet, lb_id)
 
             if len(snat_addrs) != snats_per_subnet:
                 raise f5_ex.SNAT_CreationException(

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
@@ -348,7 +348,8 @@ class LBaaSv2PluginRPC(object):
     @log_helpers.log_method_call
     def create_port_on_subnet(self, subnet_id=None,
                               mac_address=None, name=None,
-                              fixed_address_count=1):
+                              fixed_address_count=1,
+                              device_id=None, binding_profile={}):
         """Add a neutron port to the subnet."""
         port = None
         try:
@@ -359,7 +360,9 @@ class LBaaSv2PluginRPC(object):
                                mac_address=mac_address,
                                name=name,
                                fixed_address_count=fixed_address_count,
-                               host=self.host),
+                               host=self.host,
+                               device_id=device_id,
+                               binding_profile=binding_profile),
                 topic=self.topic
             )
         except messaging.MessageDeliveryFailure:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
@@ -65,7 +65,7 @@ class BigipSnatManager(object):
         LOG.error('Invalid f5_ha_type:%s' % self.driver.conf.f5_ha_type)
         return ''
 
-    def get_snat_addrs(self, subnetinfo, tenant_id, snat_count):
+    def get_snat_addrs(self, subnetinfo, tenant_id, snat_count, lb_id):
         # Get the ip addresses for snat """
         subnet = subnetinfo['subnet']
         snat_addrs = []
@@ -85,7 +85,7 @@ class BigipSnatManager(object):
                     subnet_id=subnet['id'],
                     mac_address=None,
                     name=index_snat_name,
-                    fixed_address_count=1)
+                    fixed_address_count=1, device_id=lb_id)
                 if new_port is not None:
                     ip_address = new_port['fixed_ips'][0]['ip_address']
 

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer.py
@@ -63,6 +63,17 @@ def test_create_delete_basic_lb(bigip, services, icd_config, icontrol_driver):
     assert call_record.get("operating_status", None) == 'ONLINE'
     assert call_record.get("provisioning_status", None) == 'ACTIVE'
 
+    assert fake_rpc.get_call_count('create_port_on_subnet') == 2
+
+    # Check the selfip call params
+    call_record = fake_rpc.get_calls('create_port_on_subnet')[0]
+    assert call_record.get("device_id", None) == lb_reader.id()
+
+    # Check the snat call params
+    call_record = fake_rpc.get_calls('create_port_on_subnet')[1]
+    assert call_record.get("device_id", None) == lb_reader.id()
+
+
     # Assert folder created
     assert bigip.folder_exists(folder)
 

--- a/test/functional/neutronless/testlib/fake_rpc.py
+++ b/test/functional/neutronless/testlib/fake_rpc.py
@@ -95,7 +95,9 @@ class FakeRPCPlugin(object):
                               subnet_id=None,
                               mac_address=None,
                               name=None,
-                              fixed_address_count=1):
+                              fixed_address_count=1,
+                              device_id=None,
+                              binding_profile={}):
 
         # Enforce specific call parameters
         if not subnet_id:


### PR DESCRIPTION
Issues:
Fixes #963

Problem:
In order to support the new port binding scheme we are adding the
loadbalancer id as the device_id for any ports that are created as
part of a loadbalancing service. This include self IPs and SNATS.

Analysis:
Extending the create_port_on_subnet() RPC call to accept 2 new
parameters: device_id and binding_profile.  This change required
a modification to the calls to create the SelfIP and SNATs that
added the loadbalancer ID as a parameter to these methods.  The load
balancer ID is used as the device_id of the Neutron port.

Modified the agent to include the MAC addresses of all BigIP devices
managed by the agent.

Tests:
tests/functional/neutronless/loadbalancer
