### PR TITLE
Sync VA with Route Domain

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_virtual_address.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_virtual_address.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
+import f5_openstack_agent.lbaasv2.drivers.bigip.virtual_address as \
+    virtual_address
+
 from f5_openstack_agent.lbaasv2.drivers.bigip.service_adapter import \
     ServiceModelAdapter
 from f5_openstack_agent.lbaasv2.drivers.bigip.virtual_address import \
@@ -21,27 +24,36 @@ from f5_openstack_agent.lbaasv2.drivers.bigip.virtual_address import \
 
 import mock
 import pytest
+import uuid
 
 
-class TestVirtualAddress(object):
+class TestVirtualAddressConstructor(object):
 
+    @staticmethod
     @pytest.fixture
-    def bigip(self):
-        bigip = mock.MagicMock()
+    def bigip():
+        bigip = mock.Mock()
 
         return bigip
 
+    @staticmethod
     @pytest.fixture
-    def adapter(self):
+    def adapter():
         conf = mock.MagicMock()
         conf.environment_prefix = "Project"
 
         return ServiceModelAdapter(conf)
 
+    @staticmethod
     @pytest.fixture
-    def loadbalancer(self):
+    def new_uuid():
+        return str(uuid.uuid4())
+
+    @staticmethod
+    @pytest.fixture
+    def loadbalancer(new_uuid):
         loadbalancer = {"name": "lb1",
-                        "tenant_id": "123456789",
+                        "tenant_id": new_uuid,
                         "id": "loadbalancer_id",
                         "traffic_group": "traffic-group-local-only",
                         "vip_address": "192.168.100.5",
@@ -49,13 +61,72 @@ class TestVirtualAddress(object):
 
         return loadbalancer
 
-    def test_create_va(self, bigip, adapter, loadbalancer):
+    @staticmethod
+    @pytest.fixture
+    def virtual_address(adapter, loadbalancer):
         va = VirtualAddress(adapter, loadbalancer)
+        return va
 
-        assert(va is not None)
-        assert(va.name == "Project_loadbalancer_id")
-        assert(va.partition == "Project_123456789")
-        assert(va.address == "192.168.100.5")
-        assert(va.traffic_group == "traffic-group-local-only")
-        assert(va.description == "lb1:")
-        assert(va.enabled == "yes")
+
+class TestVirtualAddressBuilder(TestVirtualAddressConstructor):
+
+    @pytest.fixture
+    def mock_logger(self, request):
+        logger = mock.Mock()
+        request.addfinalizer(self.cleanup)
+        self.freeze_log = virtual_address.LOG
+        virtual_address.LOG = logger
+        self.logger = logger
+        return logger
+
+    def cleanup(self):
+        virtual_address.LOG = self.freeze_log
+
+    @staticmethod
+    def mock_scenario(virtual_address):
+        m_remote = mock.Mock()
+        m_remote.address = virtual_address.model().get('address')
+        virtual_address.load = mock.Mock(return_value=m_remote)
+        virtual_address.virtual_address = mock.Mock()
+        virtual_address.delete = mock.Mock(side_effect=AssertionError)
+        virtual_address.create = mock.Mock(return_value=mock.Mock())
+        virtual_address.virtual_address.update = \
+            mock.Mock(return_value=mock.Mock())
+
+
+class TestVirtualAddress(TestVirtualAddressBuilder):
+
+    def test_create_va(self, virtual_address):
+        assert(virtual_address is not None)
+        assert(virtual_address.name == "Project_loadbalancer_id")
+        assert virtual_address.partition.startswith(
+            virtual_address.adapter.prefix)
+        assert(virtual_address.address == "192.168.100.5")
+        assert(virtual_address.traffic_group == "traffic-group-local-only")
+        assert(virtual_address.description == "lb1:")
+        assert(virtual_address.enabled == "yes")
+
+    def test_iwb_update(self, virtual_address, bigip, mock_logger):
+        def negative_delete_path(virtual_address, bigip):
+            TestVirtualAddressBuilder.mock_scenario(virtual_address)
+            virtual_address.load.return_value.address = 'xx.xx.xx.xx'
+            result = virtual_address.update(bigip)
+            virtual_address.load.assert_called_once_with(bigip)
+            assert result is virtual_address.create.return_value
+            self.logger.error.assert_called_once()
+
+        def positive_update(virtual_address, bigip):
+            TestVirtualAddressBuilder.mock_scenario(virtual_address)
+            result = virtual_address.update(bigip)
+            expected = virtual_address.model()
+            expected.pop('address')
+            virtual_address.virtual_address.update.assert_called_once_with(
+                bigip, expected)
+            assert result is \
+                virtual_address.virtual_address.update.return_value
+
+        negative_delete_path(virtual_address, bigip)
+        virtual_address = \
+            self.virtual_address(self.adapter(),
+                                 self.loadbalancer(self.new_uuid()))
+        positive_update(virtual_address, bigip)


### PR DESCRIPTION
Issues:
WIP #878

Problem:
* Virtual Addresses may have a different address than the stored one
* Update method would then create a new one without destroying old
* THis can result in lots of VA's that are floating on the BIG-IP

Analysis:
* This checks address and nukes the VA that has discrepency
* This cleans up the item on the BIG-IP to keep from stale items

Tests:
test_virtual_address.py was modified to perform isolation tests that
enforce knowledge of any changes to the code.

@jlongstaf 
#### What issues does this address?
WIP #878 

#### What's this change do?
encompasses changes introduced in [this PR commit](https://github.com/F5Networks/f5-openstack-agent/pull/763/commits/e5f166702e136cbd93073f71f548cca5348e15e0)

#### Where should the reviewer start?
Look at the PR and compare to changes in this PR's commit.

#### Any background context?
Common Networks