### PR TITLE
Add a coveralls badge to the README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,9 @@ version |release|
 -----------------
 
 
+.. image:: https://coveralls.io/repos/github/F5Networks/f5-openstack-agent/badge.svg?branch=mitaka
+:target: https://coveralls.io/github/F5Networks/f5-openstack-agent?branch=mitaka
+         
 Introduction
 ------------
 


### PR DESCRIPTION
@ssorenso 
#### What issues does this address?
Fixes #940


#### What's this change do?
This adds a badge to the README so visitors can immediately learn the coverage state of the branch.