### PR TITLE
added fixes to fix orphaned listeners

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -819,7 +819,7 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                 listeners = self.lbdriver.get_all_deployed_listeners()
                 if listeners:
                     # Ask Neutron for the status of all deployed listeners
-                    listener_status = self.plugin_rpc.validate_listener_state(
+                    listener_status = self.plugin_rpc.validate_listeners_state(
                         list(listeners.keys()))
                     LOG.debug('validated_pools_state returned: %s'
                               % listener_status)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -145,27 +145,6 @@ class LBaaSBuilder(object):
                    "listener": listener,
                    "networks": networks}
 
-            # if listener['provisioning_status'] \
-            #             == plugin_const.PENDING_UPDATE:
-            #    try:
-            #        self.listener_builder.update_listener(svc, bigips)
-            #    except Exception as err:
-            #        loadbalancer['provisioning_status'] = plugin_const.ERROR
-            #        listener['provisioning_status'] = plugin_const.ERROR
-            #        raise f5_ex.VirtualServerUpdateException(err.message)
-            #
-            # elif listener['provisioning_status'] != \
-            #        plugin_const.PENDING_DELETE:
-            #    try:
-            #       # create_listener() will do an update if VS exists
-            #        self.listener_builder.create_listener(svc, bigips)
-            #        listener['operating_status'] = \
-            #            svc['listener']['operating_status']
-            #    except Exception as err:
-            #        loadbalancer['provisioning_status'] = plugin_const.ERROR
-            #        listener['provisioning_status'] = plugin_const.ERROR
-            #        raise f5_ex.VirtualServerCreationException(err.message)
-
             if listener['provisioning_status'] != \
                     plugin_const.PENDING_DELETE:
                 try:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
@@ -511,6 +511,24 @@ class LBaaSv2PluginRPC(object):
         return service
 
     @log_helpers.log_method_call
+    def validate_listeners_state(self, listeners):
+        """Get the status of a list of listener IDs in Neutron"""
+        service = {}
+        try:
+            service = self._call(
+                self.context,
+                self._make_msg('validate_pools_state',
+                               listeners=listeners,
+                               host=self.host),
+                topic=self.topic
+            )
+        except messaging.MessageDeliveryFailure:
+            LOG.error("agent->plugin RPC exception caught: ",
+                      "validate_pool_state")
+
+        return service
+
+    @log_helpers.log_method_call
     def validate_pools_state(self, pools):
         """Get the status of a list of pools IDs in Neutron"""
         service = {}

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
@@ -517,7 +517,7 @@ class LBaaSv2PluginRPC(object):
         try:
             service = self._call(
                 self.context,
-                self._make_msg('validate_pools_state',
+                self._make_msg('validate_listeners_state',
                                listeners=listeners,
                                host=self.host),
                 topic=self.topic


### PR DESCRIPTION
@richbrowne 
@jlongstaf 
#### What issues does this address?
Fixes #730 

#### What's this change do?
Added a fix where an AttributeError exception happens when no pool object is defined and added the orphaned object support for listeners when a loadbalancer is still ACTIVE, but the listener was deleted while a BIG-IP was disable (did handle that case previously).

