### PR TITLE
Mitaka external gatway mode.assure lbs pending delete 878

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -623,10 +623,11 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                 error_status = handle_error(error_status, obj)
             elif expected_tree[item] == list and \
                     isinstance(obj, list):
-                for cnt, obj in enumerate(obj):
-                    if len(obj) == 1:
-                        obj = obj[cnt][obj]
-                    error_status = handle_error(error_status, obj)
+                for item in obj:
+                    if len(item) == 1:
+                        # {'networks': [{'id': {<network_obj>}}]}
+                        item = item[item.keys()[0]]
+                    error_status = handle_error(error_status, item)
         if error_status:
             loadbalancer['provisioning_status'] = plugin_const.ERROR
         return error_status

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -126,7 +126,7 @@ class LBaaSBuilder(object):
                                   loadbalancer["network_id"],
                                   all_subnet_hints,
                                   False)
-        self._set_status_as_active(loadbalancer, force=True)
+        self._set_status_as_active(loadbalancer)
 
     def _assure_listeners_created(self, service):
         if 'listeners' not in service:
@@ -146,31 +146,28 @@ class LBaaSBuilder(object):
 
             if pool:
                 svc['pool'] = pool
-            if self._is_not_pending_delete(listener) and \
-                    self._is_not_error(listener):
-                if listener['provisioning_status'] == \
-                        plugin_const.PENDING_UPDATE:
-                    try:
-                        self.listener_builder.update_listener(svc, bigips)
-                    except Exception as err:
-                        loadbalancer['provisioning_status'] = \
-                            plugin_const.ERROR
-                        listener['provisioning_status'] = plugin_const.ERROR
-                        raise f5_ex.VirtualServerUpdateException(err.message)
+            if listener['provisioning_status'] == \
+                    plugin_const.PENDING_UPDATE:
+                try:
+                    self.listener_builder.update_listener(svc, bigips)
+                except Exception as err:
+                    loadbalancer['provisioning_status'] = \
+                        plugin_const.ERROR
+                    listener['provisioning_status'] = plugin_const.ERROR
+                    raise f5_ex.VirtualServerUpdateException(err.message)
 
-                elif listener['provisioning_status'] != \
-                        plugin_const.PENDING_DELETE:
-                    try:
-                        # create_listener() will do an update if VS exists
-                        self.listener_builder.create_listener(svc, bigips)
-                        listener['operating_status'] = \
-                            svc['listener']['operating_status']
-                    except Exception as err:
-                        loadbalancer['provisioning_status'] = \
-                            plugin_const.ERROR
-                        listener['provisioning_status'] = plugin_const.ERROR
-                        raise f5_ex.VirtualServerCreationException(err.message)
-                self._set_status_as_active(listener)
+            elif self._is_not_pending_delete(listener):
+                try:
+                    # create_listener() will do an update if VS exists
+                    self.listener_builder.create_listener(svc, bigips)
+                    listener['operating_status'] = \
+                        svc['listener']['operating_status']
+                except Exception as err:
+                    loadbalancer['provisioning_status'] = \
+                        plugin_const.ERROR
+                    listener['provisioning_status'] = plugin_const.ERROR
+                    raise f5_ex.VirtualServerCreationException(err.message)
+            self._set_status_as_active(listener)
 
     def _assure_pools_created(self, service):
         if "pools" not in service:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -126,7 +126,7 @@ class LBaaSBuilder(object):
                                   loadbalancer["network_id"],
                                   all_subnet_hints,
                                   False)
-        self._set_status_as_active(loadbalancer)
+        self._set_status_as_active(loadbalancer, force=True)
 
     def _assure_listeners_created(self, service):
         if 'listeners' not in service:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager_LbaasAgentManager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager_LbaasAgentManager.py
@@ -326,5 +326,16 @@ class TestLbaasAgentManager(TestLbaasAgentManagerBuilder):
             assert svc['loadbalancer']['provisioning_status'] == \
                 plugin_const.ERROR
 
+        def awkward_network_nest(target, svc):
+            reset_svc(svc)
+            svc['loadbalancer']['provisioning_status'] = plugin_const.ERROR
+            listener_id = svc['listeners'][0]['id']
+            awkward = {listener_id: svc['listeners'][0]}
+            svc['listeners'][0] = awkward
+            assert target.has_provisioning_status_of_error(svc)
+            assert svc['loadbalancer']['provisioning_status'] == \
+                plugin_const.ERROR
+
         negative_list_scenario(target_class, svc)
         negative_dict_scenario(target_class, svc)
+        awkward_network_nest(target_class, svc)


### PR DESCRIPTION
Preserve PENDING_DELETE and ERROR when needed

Issues:
Fixes #878

Problem:
* PENDING_DELETE, in some cases, would not be preserved

Analysis:
* Changed the _set_status_as_active to use a 'force' option
* Put a force option as True during places in the code where necessary

Tests:
Modified the test_lbaas_builder.py to offer a test to lock the
functionality of tis preservation code.

@jlongstaf 
#### What issues does this address?
WIP #878 

#### What's this change do?
* Changed the _set_status_as_active to use a 'force' option
* Put a force option as True during places in the code where necessary

#### Where should the reviewer start?
lbaas_builder.py

#### Any background context?
This further engrains the previous PR... if this one passes but the other one fails the smoke tests, then I think this fixes the previous PR's commit's items...

They were; however, two different items for the common networks items.