### PR TITLE
Mitaka external gateway mode.handle missing lb in icontrol driver.sync 878

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -321,6 +321,9 @@ def is_connected(method):
 
 class iControlDriver(LBaaSBaseDriver):
     '''gets rpc plugin from manager (which instantiates, via importutils'''
+    positive_plugin_const_state = \
+        tuple([plugin_const.ACTIVE, plugin_const.PENDING_CREATE,
+               plugin_const.PENDING_UPDATE])
 
     def __init__(self, conf, registerOpts=True):
         # The registerOpts parameter allows a test to
@@ -1337,10 +1340,10 @@ class iControlDriver(LBaaSBaseDriver):
             if 'provisioning_status' in member:
                 provisioning_status = member['provisioning_status']
 
-                if (provisioning_status == plugin_const.PENDING_CREATE or
-                        provisioning_status == plugin_const.PENDING_UPDATE):
+                if provisioning_status in self.positive_plugin_const_state:
 
-                    if timed_out:
+                    if timed_out and \
+                            provisioning_status != plugin_const.ACTIVE:
                         member['provisioning_status'] = plugin_const.ERROR
                         operating_status = lb_const.OFFLINE
                     else:
@@ -1366,8 +1369,7 @@ class iControlDriver(LBaaSBaseDriver):
         for health_monitor in health_monitors:
             if 'provisioning_status' in health_monitor:
                 provisioning_status = health_monitor['provisioning_status']
-                if (provisioning_status == plugin_const.PENDING_CREATE or
-                        provisioning_status == plugin_const.PENDING_UPDATE):
+                if provisioning_status in self.positive_plugin_const_state:
                         self.plugin_rpc.update_health_monitor_status(
                             health_monitor['id'],
                             plugin_const.ACTIVE,
@@ -1388,8 +1390,7 @@ class iControlDriver(LBaaSBaseDriver):
         for pool in pools:
             if 'provisioning_status' in pool:
                 provisioning_status = pool['provisioning_status']
-                if (provisioning_status == plugin_const.PENDING_CREATE or
-                        provisioning_status == plugin_const.PENDING_UPDATE):
+                if provisioning_status in self.positive_plugin_const_state:
                         self.plugin_rpc.update_pool_status(
                             pool['id'],
                             plugin_const.ACTIVE,
@@ -1409,8 +1410,7 @@ class iControlDriver(LBaaSBaseDriver):
         for listener in listeners:
             if 'provisioning_status' in listener:
                 provisioning_status = listener['provisioning_status']
-                if (provisioning_status == plugin_const.PENDING_CREATE or
-                        provisioning_status == plugin_const.PENDING_UPDATE):
+                if provisioning_status in self.positive_plugin_const_state:
                         self.plugin_rpc.update_listener_status(
                             listener['id'],
                             plugin_const.ACTIVE,
@@ -1433,8 +1433,7 @@ class iControlDriver(LBaaSBaseDriver):
         for l7rule in l7rules:
             if 'provisioning_status' in l7rule:
                 provisioning_status = l7rule['provisioning_status']
-                if (provisioning_status == plugin_const.PENDING_CREATE or
-                        provisioning_status == plugin_const.PENDING_UPDATE):
+                if provisioning_status in self.positive_plugin_const_state:
                         self.plugin_rpc.update_l7rule_status(
                             l7rule['id'],
                             l7rule['policy_id'],
@@ -1455,8 +1454,7 @@ class iControlDriver(LBaaSBaseDriver):
         for l7policy in l7policies:
             if 'provisioning_status' in l7policy:
                 provisioning_status = l7policy['provisioning_status']
-                if (provisioning_status == plugin_const.PENDING_CREATE or
-                        provisioning_status == plugin_const.PENDING_UPDATE):
+                if provisioning_status in self.positive_plugin_const_state:
                         self.plugin_rpc.update_l7policy_status(
                             l7policy['id'],
                             plugin_const.ACTIVE,
@@ -1476,8 +1474,7 @@ class iControlDriver(LBaaSBaseDriver):
         provisioning_status = loadbalancer.get('provisioning_status',
                                                plugin_const.ERROR)
 
-        if (provisioning_status == plugin_const.PENDING_CREATE or
-                provisioning_status == plugin_const.PENDING_UPDATE):
+        if provisioning_status in self.positive_plugin_const_state:
             if timed_out:
                 operating_status = (lb_const.OFFLINE)
                 if provisioning_status == plugin_const.PENDING_CREATE:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -987,13 +987,12 @@ class iControlDriver(LBaaSBaseDriver):
     @is_connected
     def sync(self, service):
         """Sync service defintion to device"""
-        # plugin_rpc may not be set when unit testing
-        if self.plugin_rpc:
+        # loadbalancer and plugin_rpc may not be set
+        lb_id = service.get('loadbalancer', dict()).get('id', '')
+        if hasattr(self, 'plugin_rpc') and self.plugin_rpc and lb_id:
             # Get the latest service. It may have changed.
-            service = self.plugin_rpc.get_service_by_loadbalancer_id(
-                service['loadbalancer']['id']
-            )
-        if service['loadbalancer']:
+            service = self.plugin_rpc.get_service_by_loadbalancer_id(lb_id)
+        if service.get('loadbalancer', None):
             return self._common_service_handler(service)
         else:
             LOG.debug("Attempted sync of deleted pool")

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/conftest.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/conftest.py
@@ -16,6 +16,135 @@
 import os
 import pytest
 import sys
+import uuid
+
+from neutron.common import constants as plugin_const
+
+
+class TestingWithServiceConstructor(object):
+    """An object class meant for the use of constructing service objects
+
+    This object class is meant to assist tests in orchestrating the appropraite
+    steps to create a unique service object.  From there, the tests themselves
+    can perform additional operations to make the service object what they
+    need.
+    """
+    defaultservice = \
+        dict(listeners=[], loadbalancer={}, pools=[], networks={}, subnets={},
+             healthmonitors=[], members=[], l7policies=[], l7policy_rules=[])
+
+    @staticmethod
+    @pytest.fixture
+    def new_id():
+        return str(uuid.uuid4())
+
+    @staticmethod
+    @pytest.fixture
+    def esd():
+        # Generate a esd mocked item that is pretty lame until more
+        # intelligence is needed.
+        return dict(lbaas_stcp='lbaas_stcp', lbaas_ctcp='lbaas_ctcp',
+                    lbaas_cssl_profile='lbaas_cssl_profile',
+                    lbaas_persist='lbaas_persist',
+                    lbaas_fallback_persist='lbaas_fallback_persist',
+                    lbaas_irule=['rule1', 'rule2'],
+                    lbaas_policy=['policy1', 'policy2'],
+                    lbaas_sssl_profile='lbaas_sssl_profile')
+
+    @classmethod
+    @pytest.fixture
+    def service_with_network(cls, new_id):
+        service = cls.defaultservice.copy()
+        new_network = dict(id=new_id, name='network', mtu=0, shared=False,
+                           status='ACTIVE', subnets=[], tenant_id=cls.new_id(),
+                           vlan_transparent=None)
+        service['networks'][new_id] = new_network
+        return service
+
+    @staticmethod
+    @pytest.fixture
+    def service_with_subnet(new_id, service_with_network):
+        network_id = service_with_network['networks'].keys()[0]
+        network = service_with_network['networks'][network_id]
+        tenant_id = network['tenant_id']
+        allocation_pools = [dict(start='10.22.22.2', end='10.22.22.48')]
+        dns_servers = ['10.22.22.2']
+        host_routes = []
+        new_subnet = \
+            dict(allocation_pools=allocation_pools, tenant_id=tenant_id,
+                 dns_servers=dns_servers, host_routes=host_routes,
+                 cidr='10.22.22.0/22', gateway='10.22.22.1', id=new_id,
+                 ip_version=4, ipv6_address_mode=None, ipv6_ra_mode=None,
+                 enable_dhcp=True)
+        network['subnets'].append(new_subnet)
+        service_with_network['subnets'][new_id] = new_subnet
+        return service_with_network
+
+    @classmethod
+    @pytest.fixture
+    def service_with_loadbalancer(cls, new_id, service_with_subnet):
+        network_id = service_with_subnet['networks'].keys()[0]
+        subnet_id = service_with_subnet['subnets'].keys()[0]
+        network = service_with_subnet['networks'][network_id]
+        tenant_id = network['tenant_id']
+        vip_address = '10.22.22.4'
+        device_id = cls.new_id()
+        hostname = 'host-{}'.format(vip_address.replace('.', '-'))
+        dns_assignment = \
+            dict(fqdn="{}.openstacklocal.".format(hostname),
+                 hostname=hostname, ip_address=vip_address)
+        fixed_ips = [dict(ip_address=vip_address, subnet_id=subnet_id)]
+        vip_port = \
+            dict(admin_state_up=True, allowed_address_pairs=[],
+                 device_id=device_id, divcie_owner='newutron:LOADBALANCERV2',
+                 dns_assignment=dns_assignment, dns_name=None,
+                 extra_dhcp_opts=[], id=cls.new_id(), network_id=network_id,
+                 name='loadbalancer-'.format(new_id), security_groups=[],
+                 mac_address='xx:xx:xx:xx:xx:xx', status='UP',
+                 tenant_id=tenant_id, fixed_ips=fixed_ips)
+        new_lb = \
+            dict(admin_state_up=True, description='', gre_vteps=[], id=new_id,
+                 listeners=[], name='lb1', network_id=network_id,
+                 operating_status='OFFLINE', provider=None, vip_port=vip_port,
+                 provisioning_status=plugin_const.PENDING_CREATE,
+                 vip_address=vip_address, dns_name=None,
+                 dns_assignment=[dns_assignment],
+                 tenant_id=tenant_id, vip_id=vip_port['id'],
+                 vip_subnet_id=subnet_id, vxlan_vteps=[])
+        service_with_subnet['loadbalancer'] = new_lb
+        return service_with_subnet
+
+    @staticmethod
+    @pytest.fixture
+    def service_with_listener(new_id, service_with_loadbalancer):
+        svc = service_with_loadbalancer
+        lb = svc['loadbalancer']
+        lb['listeners'].append(new_id)
+        tenant_id = lb['tenant_id']
+        lb_id = lb['id']
+        lb['provisioning_status'] = plugin_const.PENDING_UPDATE
+        new_listener = \
+            dict(admin_state_up=True, connection_limit=-1,
+                 default_pool_id=None, default_tls_container_id=None,
+                 description='', id=new_id, loadbalaner_id=lb_id,
+                 name='l1', operating_status='OFFLINE', protocol='HTTP',
+                 protocol_port=8080, sni_containers=[], tenant_id=tenant_id,
+                 provisioning_status=plugin_const.PENDING_CREATE)
+        svc['listeners'].append(new_listener)
+        return svc
+
+    def service_with_pool(new_id, service_with_listener):
+        # update as needed for more intelligence...
+        svc = service_with_listener
+        li = svc['listeners'][0]
+        tenant_id = li['tenant_id']
+        li['default_pool_id'] = new_id
+        li['provisioning_status'] = plugin_const.PENDING_UPDATE
+        new_pool = {'id': new_id, 'listeners': [dict(id=li['id'])],
+                    'provisioning_status': plugin_const.PENDING_CREATE,
+                    'tenant_id': tenant_id}
+        svc['pools'].append(new_pool)
+        return svc
 
 
 @pytest.fixture

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager_LbaasAgentManager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager_LbaasAgentManager.py
@@ -20,11 +20,20 @@ import pytest
 from mock import Mock
 from mock import patch
 
+from neutron.common import constants as plugin_const
+
 import f5_openstack_agent.lbaasv2.drivers.bigip.agent_manager as agent_manager
 import f5_openstack_agent.lbaasv2.drivers.bigip.plugin_rpc as plugin_rpc
 
+import f5_openstack_agent.lbaasv2.drivers.bigip.test.conftest as ct
 
-class TestLbaasAgentManagerConstructor(object):
+
+class TestLbaasAgentManagerConstructor(ct.TestingWithServiceConstructor):
+    @staticmethod
+    @pytest.fixture
+    def target_class():
+        return agent_manager.LbaasAgentManager
+
     @staticmethod
     @pytest.fixture
     @patch('f5_openstack_agent.lbaasv2.drivers.bigip.agent_manager.'
@@ -173,6 +182,40 @@ class TestLbaasAgentManager(TestLbaasAgentManagerBuilder):
 
         full_path(fully_mocked_target)
 
+    def test_validate_service(self, fully_mocked_target, mock_logger):
+        def setup_target(target):
+            target.plugin_rpc = Mock()
+            target.lbdriver = Mock()
+            target.has_provisioning_status_of_error = Mock(return_value=True)
+            target.lbdriver.service_exists.return_value = True
+            target.lbdriver.service_rename_required.return_value = False
+            target.cache = Mock()
+            target.agent_host = 'host'
+
+        def reset_target(target):
+            target.lbdriver.sync.reset_mock()
+            self.logger.debug.reset_mock()
+
+        def negative_path(target):
+            # needs to be fix to cover all logical paths...
+            setup_target(target)
+            lb_id = 1
+            target.validate_service(lb_id)
+            target.lbdriver.sync.assert_called_once_with(
+                target.plugin_rpc.get_service_by_loadbalancer_id.return_value)
+
+        def positive_path(target):
+            # needs to be fixed to coverall logical paths...
+            lb_id = 1
+            target.has_provisioning_status_of_error.return_value = False
+            target.validate_service(lb_id)
+            target.lbdriver.sync.assert_not_called
+            assert 'Found service' in self.logger.debug.call_args[0][0]
+
+        negative_path(fully_mocked_target)
+        reset_target(fully_mocked_target)
+        positive_path(fully_mocked_target)
+
     def test_validate_services(self, fully_mocked_target):
         lb_ids = [1, 2]
         fully_mocked_target.cache = Mock()
@@ -259,3 +302,29 @@ class TestLbaasAgentManager(TestLbaasAgentManagerBuilder):
                 assert expected_call in call_args_list[cnt][0]
 
         functional_path(fully_mocked_target, fully_mocked_plugin_rpc)
+
+    def test_has_provisioning_error(self, target_class, service_with_listener):
+        svc = service_with_listener
+
+        def reset_svc(svc):
+            listener = svc['listeners'][0]
+            loadbalancer = svc['loadbalancer']
+            listener['provisioning_status'] = plugin_const.ACTIVE
+            loadbalancer['provisioning_status'] = plugin_const.ACTIVE
+
+        def negative_list_scenario(target, svc):
+            reset_svc(svc)
+            svc['listeners'][0]['provisioning_status'] = plugin_const.ERROR
+            assert target.has_provisioning_status_of_error(svc)
+            assert svc['loadbalancer']['provisioning_status'] == \
+                plugin_const.ERROR
+
+        def negative_dict_scenario(target, svc):
+            reset_svc(svc)
+            svc['loadbalancer']['provisioning_status'] = plugin_const.ERROR
+            assert target.has_provisioning_status_of_error(svc)
+            assert svc['loadbalancer']['provisioning_status'] == \
+                plugin_const.ERROR
+
+        negative_list_scenario(target_class, svc)
+        negative_dict_scenario(target_class, svc)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_icontrol_driver.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+import uuid
+
+from mock import Mock
+from mock import patch
+
+import neutron.plugins.common.constants as plugin_const
+import neutron_lbaas.services.loadbalancer.constants as lb_const
+
+import f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver as target_mod
+
+
+class TestiControlDriverConstructor(object):
+    @staticmethod
+    @pytest.fixture
+    @patch('f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver.'
+           'iControlDriver.__init__')
+    def fully_mocked_target(init):
+        init.return_value = None
+        return target_mod.iControlDriver()
+
+    @staticmethod
+    @pytest.fixture
+    def new_uuid():
+        return str(uuid.uuid4())
+
+    @staticmethod
+    @pytest.fixture
+    def dumb_svc_obj(new_uuid):
+        return dict(id=new_uuid)
+
+    @classmethod
+    def basic_svc_obj(cls, provisioning_status):
+        svc_obj = dict(provisioning_status=provisioning_status)
+        svc_obj.update(cls.dumb_svc_obj(cls.new_uuid()))
+        return svc_obj
+
+    @classmethod
+    @pytest.fixture
+    def svc_obj_pending_update(cls):
+        svc_obj = cls.basic_svc_obj(plugin_const.PENDING_UPDATE)
+        return [svc_obj]
+
+    @classmethod
+    @pytest.fixture
+    def svc_obj_pending_create(cls):
+        svc_obj = cls.basic_svc_obj(plugin_const.PENDING_CREATE)
+        return [svc_obj]
+
+    @classmethod
+    @pytest.fixture
+    def svc_obj_active(cls):
+        svc_obj = cls.basic_svc_obj(plugin_const.ACTIVE)
+        return [svc_obj]
+
+    @staticmethod
+    @pytest.fixture
+    def positive_svc_obj_list(svc_obj_pending_update,
+                              svc_obj_pending_create, svc_obj_active):
+        positive_members = svc_obj_pending_update
+        positive_members.extend(svc_obj_pending_create)
+        positive_members.extend(svc_obj_active)
+        return positive_members
+
+    @staticmethod
+    def mock_targets_plugin_rpc(target):
+        target.plugin_rpc = Mock()
+
+
+class TestiControlDriverBuilder(TestiControlDriverConstructor):
+    @pytest.fixture
+    def mock_logger(self, request):
+        self.freeze_logger = target_mod.LOG
+        request.addfinalizer(self.cleanup)
+        logger = Mock()
+        self.logger = logger
+        target_mod.LOG = logger
+        return logger
+
+    def cleanup(self):
+        target_mod.LOG = self.freeze_logger
+
+    def update_svc_obj_positive_path(self, target, positive_svc_objs, method,
+                                     test_method, timeout=None):
+        self.mock_targets_plugin_rpc(target)
+        method = getattr(target, method)
+        if isinstance(timeout, type(None)):
+            method(positive_svc_objs)
+        else:
+            method(positive_svc_objs, timeout)
+        if test_method:
+            called_method = getattr(target.plugin_rpc, test_method)
+            args_list = called_method.call_args_list
+            assert called_method.call_count == 3
+            all(map(lambda x: lb_const.ONLINE in x, args_list))
+
+
+class TestiControlDriver(TestiControlDriverBuilder):
+    def test_update_member_status(self, fully_mocked_target,
+                                  positive_svc_obj_list):
+        self.update_svc_obj_positive_path(
+            fully_mocked_target, positive_svc_obj_list,
+            '_update_member_status', 'update_member_status', timeout=False)
+
+    def test_update_health_monitor_status(self, fully_mocked_target,
+                                          positive_svc_obj_list):
+        self.update_svc_obj_positive_path(
+            fully_mocked_target, positive_svc_obj_list,
+            '_update_health_monitor_status', 'update_health_monitor_status')
+
+    def test_update_pool_status(self, fully_mocked_target,
+                                positive_svc_obj_list):
+        self.update_svc_obj_positive_path(
+            fully_mocked_target, positive_svc_obj_list,
+            '_update_pool_status', 'update_pool_status')
+
+    def test_update_listener_status(self, fully_mocked_target,
+                                    positive_svc_obj_list):
+        for svc_obj in positive_svc_obj_list:
+            svc_obj['operating_status'] = Mock()
+        svc = dict(listeners=positive_svc_obj_list)
+        self.update_svc_obj_positive_path(
+            fully_mocked_target, svc, '_update_listener_status',
+            'update_listener_status')
+
+    def test_update_l7rule_status(self, fully_mocked_target,
+                                  positive_svc_obj_list):
+        for svc_obj in positive_svc_obj_list:
+            svc_obj['policy_id'] = self.new_uuid()
+        self.update_svc_obj_positive_path(
+            fully_mocked_target, positive_svc_obj_list,
+            '_update_l7rule_status', 'update_l7rule_status')
+
+    def test_update_l7policy_status(self, fully_mocked_target,
+                                    positive_svc_obj_list):
+        self.update_svc_obj_positive_path(
+            fully_mocked_target, positive_svc_obj_list,
+            '_update_l7policy_status', 'update_l7policy_status')

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_icontrol_driver.py
@@ -24,9 +24,12 @@ import neutron.plugins.common.constants as plugin_const
 import neutron_lbaas.services.loadbalancer.constants as lb_const
 
 import f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver as target_mod
+import f5_openstack_agent.lbaasv2.drivers.bigip.utils
+
+import conftest as ct
 
 
-class TestiControlDriverConstructor(object):
+class TestiControlDriverConstructor(ct.TestingWithServiceConstructor):
     @staticmethod
     @pytest.fixture
     @patch('f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver.'
@@ -82,10 +85,25 @@ class TestiControlDriverConstructor(object):
     def mock_targets_plugin_rpc(target):
         target.plugin_rpc = Mock()
 
+    @staticmethod
+    @pytest.fixture
+    def mocked_target_with_connection(fully_mocked_target):
+        fully_mocked_target.connected = True
+        return fully_mocked_target
+
 
 class TestiControlDriverBuilder(TestiControlDriverConstructor):
     @pytest.fixture
+    def mock_is_connected(self, request):
+        request.addfinalizer(self.cleanup)
+        self.freeze_is_connected = target_mod.is_connected
+        is_connected = Mock()
+        target_mod.is_connected = is_connected
+        self.is_connected = is_connected
+
+    @pytest.fixture
     def mock_logger(self, request):
+        # Useful for tracking logger events in icontrol_driver.py
         self.freeze_logger = target_mod.LOG
         request.addfinalizer(self.cleanup)
         logger = Mock()
@@ -93,8 +111,23 @@ class TestiControlDriverBuilder(TestiControlDriverConstructor):
         target_mod.LOG = logger
         return logger
 
+    @pytest.fixture
+    def mock_log_utils(self, request):
+        # Necessary for by-passing @serialized cleanly
+        logger = Mock()
+        request.addfinalizer(self.cleanup)
+        self.freeze_log_utils = \
+            f5_openstack_agent.lbaasv2.drivers.bigip.utils.LOG
+        f5_openstack_agent.lbaasv2.drivers.bigip.utils.LOG = logger
+
     def cleanup(self):
-        target_mod.LOG = self.freeze_logger
+        if hasattr(self, 'freeze_log_utils'):
+            f5_openstack_agent.lbaasv2.drivers.bigip.utils.LOG = \
+                self.freeze_log_utils
+        if hasattr(self, 'freeze_logger'):
+            target_mod.LOG = self.freeze_logger
+        if hasattr(self, 'freeze_is_connected'):
+            target_mod.is_connected = self.freeze_is_connected
 
     def update_svc_obj_positive_path(self, target, positive_svc_objs, method,
                                      test_method, timeout=None):
@@ -152,3 +185,45 @@ class TestiControlDriver(TestiControlDriverBuilder):
         self.update_svc_obj_positive_path(
             fully_mocked_target, positive_svc_obj_list,
             '_update_l7policy_status', 'update_l7policy_status')
+
+    def test_sync(self, mocked_target_with_connection,
+                  service_with_loadbalancer, mock_logger, mock_is_connected,
+                  mock_log_utils):
+
+        def setup_target(target, svc):
+            target.service_queue = list()
+            target._common_service_handler = Mock(return_value='pass')
+
+        def setup_plugin_rpc(target, svc):
+            target.plugin_rpc = Mock()
+            target.plugin_rpc.get_service_by_loadbalancer_id = \
+                Mock(return_value=svc)
+
+        def without_plugin_rpc(target, svc):
+            setup_target(target, svc)
+            assert target.sync(svc) == 'pass'
+            target._common_service_handler.assert_called_once_with(svc)
+
+        def with_plugin_rpc(target, svc):
+            setup_target(target, svc)
+            setup_plugin_rpc(target, svc)
+            assert target.sync(svc) == 'pass'
+            target.plugin_rpc.get_service_by_loadbalancer_id.\
+                assert_called_with(svc['loadbalancer']['id'])
+            target._common_service_handler.assert_called_once_with(svc)
+
+        def without_lb(target, svc):
+            setup_target(target, svc)
+            setup_plugin_rpc(target, svc)
+            assert not target.sync({})
+            target.plugin_rpc.get_service_by_loadbalancer_id.\
+                assert_not_called()
+            target._common_service_handler.assert_not_called()
+        without_plugin_rpc(mocked_target_with_connection,
+                           service_with_loadbalancer)
+        with_plugin_rpc(
+            self.mocked_target_with_connection(self.fully_mocked_target()),
+            service_with_loadbalancer)
+        without_lb(
+            self.mocked_target_with_connection(self.fully_mocked_target()),
+            service_with_loadbalancer)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_lbaas_builder.py
@@ -785,6 +785,38 @@ class TestLbaasBuilder(TestLBaaSBuilderConstructor):
         neutron.plugins.common.constants = self.neutron_plugin_constants
         f5_openstack_agent.lbaasv2.drivers.bigip.lbaas_builder.LOG = LOG
 
+    def test_set_status_as_active(self, fully_mocked_target):
+        preserved = ['PENDING_DELETE', 'ERROR']
+
+        def new_svc_obj(status):
+            state = getattr(neutron.plugins.common.constants, status)
+            return dict(provisioning_status=state, id=1)
+
+        def is_state(svc_obj, state):
+            state = getattr(neutron.plugins.common.constants, state)
+            return svc_obj['provisioning_status'] == state
+
+        def preserve_status(target):
+            for state in preserved:
+                svc = new_svc_obj(state)
+                target._set_status_as_active(svc, force=False)
+                assert is_state(svc, state)
+
+        def forced_through_preserved_status(target):
+            for state in preserved:
+                svc = new_svc_obj(state)
+                target._set_status_as_active(svc, force=True)
+                assert is_state(svc, 'ACTIVE')
+
+        def other_status(target):
+            svc = new_svc_obj('PENDING_UPDATE')
+            target._set_status_as_active(svc)
+            assert is_state(svc, 'ACTIVE')
+
+        preserve_status(fully_mocked_target)
+        forced_through_preserved_status(fully_mocked_target)
+        other_status(fully_mocked_target)
+
     def test_assure_listeners_created(self, service, create_self):
         listener = service.get('listeners')[0]
         target = self.builder

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_listener_services.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_listener_services.py
@@ -15,124 +15,21 @@
 #
 
 import pytest
-import uuid
 
 from mock import Mock
 
 from neutron.common import constants as plugin_const
 
-import f5_openstack_agent.lbaasv2.drivers.bigip.resource_helper
-
 import f5_openstack_agent.lbaasv2.drivers.bigip.listener_service \
     as listener_service
+import f5_openstack_agent.lbaasv2.drivers.bigip.resource_helper
+
+import f5_openstack_agent.lbaasv2.drivers.bigip.test.conftest as ct
 
 
-class TestListenerServiceBuilderConstructor(object):
+class TestListenerServiceBuilderConstructor(ct.TestingWithServiceConstructor):
     # contains all quick service-related creation items
     # contains all static, class, or non-intelligent object manipulations
-    defaultservice = \
-        dict(listeners=[], loadbalancer={}, pools=[], networks={}, subnets={},
-             healthmonitors=[], members=[])
-
-    @staticmethod
-    @pytest.fixture
-    def new_id():
-        return str(uuid.uuid4())
-
-    @staticmethod
-    @pytest.fixture
-    def esd():
-        # Generate a esd mocked item that is pretty lame until more
-        # intelligence is needed.
-        return dict(lbaas_stcp='lbaas_stcp', lbaas_ctcp='lbaas_ctcp',
-                    lbaas_cssl_profile='lbaas_cssl_profile',
-                    lbaas_persist='lbaas_persist',
-                    lbaas_fallback_persist='lbaas_fallback_persist',
-                    lbaas_irule=['rule1', 'rule2'],
-                    lbaas_policy=['policy1', 'policy2'],
-                    lbaas_sssl_profile='lbaas_sssl_profile')
-
-    @classmethod
-    @pytest.fixture
-    def service_with_network(cls, new_id):
-        service = cls.defaultservice.copy()
-        new_network = dict(id=new_id, name='network', mtu=0, shared=False,
-                           status='ACTIVE', subnets=[], tenant_id=cls.new_id(),
-                           vlan_transparent=None)
-        service['networks'][new_id] = new_network
-        return service
-
-    @staticmethod
-    @pytest.fixture
-    def service_with_subnet(new_id, service_with_network):
-        network_id = service_with_network['networks'].keys()[0]
-        network = service_with_network['networks'][network_id]
-        tenant_id = network['tenant_id']
-        allocation_pools = [dict(start='10.22.22.2', end='10.22.22.48')]
-        dns_servers = ['10.22.22.2']
-        host_routes = []
-        new_subnet = \
-            dict(allocation_pools=allocation_pools, tenant_id=tenant_id,
-                 dns_servers=dns_servers, host_routes=host_routes,
-                 cidr='10.22.22.0/22', gateway='10.22.22.1', id=new_id,
-                 ip_version=4, ipv6_address_mode=None, ipv6_ra_mode=None,
-                 enable_dhcp=True)
-        network['subnets'].append(new_subnet)
-        service_with_network['subnets'][new_id] = new_subnet
-        return service_with_network
-
-    @classmethod
-    @pytest.fixture
-    def service_with_loadbalancer(cls, new_id, service_with_subnet):
-        network_id = service_with_subnet['networks'].keys()[0]
-        subnet_id = service_with_subnet['subnets'].keys()[0]
-        network = service_with_subnet['networks'][network_id]
-        tenant_id = network['tenant_id']
-        vip_address = '10.22.22.4'
-        device_id = cls.new_id()
-        hostname = 'host-{}'.format(vip_address.replace('.', '-'))
-        dns_assignment = \
-            dict(fqdn="{}.openstacklocal.".format(hostname),
-                 hostname=hostname, ip_address=vip_address)
-        fixed_ips = [dict(ip_address=vip_address, subnet_id=subnet_id)]
-        vip_port = \
-            dict(admin_state_up=True, allowed_address_pairs=[],
-                 device_id=device_id, divcie_owner='newutron:LOADBALANCERV2',
-                 dns_assignment=dns_assignment, dns_name=None,
-                 extra_dhcp_opts=[], id=cls.new_id(), network_id=network_id,
-                 name='loadbalancer-'.format(new_id), security_groups=[],
-                 mac_address='xx:xx:xx:xx:xx:xx', status='UP',
-                 tenant_id=tenant_id, fixed_ips=fixed_ips)
-        new_lb = \
-            dict(admin_state_up=True, description='', gre_vteps=[], id=new_id,
-                 listeners=[], name='lb1', network_id=network_id,
-                 operating_status='OFFLINE', provider=None, vip_port=vip_port,
-                 provisioning_status=plugin_const.PENDING_CREATE,
-                 vip_address=vip_address, dns_name=None,
-                 dns_assignment=[dns_assignment],
-                 tenant_id=tenant_id, vip_id=vip_port['id'],
-                 vip_subnet_id=subnet_id, vxlan_vteps=[])
-        service_with_subnet['loadbalancer'] = new_lb
-        return service_with_subnet
-
-    @staticmethod
-    @pytest.fixture
-    def service_with_listener(new_id, service_with_loadbalancer):
-        svc = service_with_loadbalancer
-        lb = svc['loadbalancer']
-        lb['listeners'].append(new_id)
-        tenant_id = lb['tenant_id']
-        lb_id = lb['id']
-        new_listener = \
-            dict(admin_state_up=True, connection_limit=-1,
-                 default_pool_id=None, default_tls_container_id=None,
-                 description='', id=new_id, loadbalaner_id=lb_id,
-                 name='l1', operating_status='OFFLINE', protocol='HTTP',
-                 protocol_port=8080, sni_containers=[], tenant_id=tenant_id,
-                 provisioning_status=plugin_const.PENDING_CREATE)
-        svc['listeners'].append(new_listener)
-        return svc
-
     @staticmethod
     def creation_mode_listener(svc, listener):
         svc['listener'] = listener


### PR DESCRIPTION
Compensate for missing lb in sync()

Issues:
WIP #878

Problem:
* `icontrol_driver.iControlDriver.sync()` fails if there's no lb in svc

Analysis:
* This adds double precautions to prevent issues

Tests:
* Tested all cases for the method sync()
* Added these tests to test_icontrol_driver.py
* Modified the test constructor to handle @is_connected
* Modified the test constructor to handle @serialized

@jlongstaf 
#### What issues does this address?
WIP #878

#### What's this change do?
* This adds double precautions to prevent issues

#### Where should the reviewer start?
`icontrol_driver.iControlDriver.sync()`

#### Any background context?
Common Networks changes.