### PR TITLE
setup.py missing universal truth in setup_req*.txt

### DIFF
--- a/f5-openstack-agent-dist/Docker/redhat/7/Dockerfile
+++ b/f5-openstack-agent-dist/Docker/redhat/7/Dockerfile
@@ -1,5 +1,7 @@
 FROM centos:7
 
 RUN yum update -y && yum install rpm-build make python-setuptools git -y
+RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
+RUN python get-pip.py
 
 COPY ./build-rpms.sh /

--- a/f5-openstack-agent-dist/Docker/ubuntu/14.04/Dockerfile
+++ b/f5-openstack-agent-dist/Docker/ubuntu/14.04/Dockerfile
@@ -5,6 +5,7 @@ RUN apt-get update && apt-get install -y \
 	python-stdeb \
 	fakeroot \
 	python-all \
+    python-pip \
 	git
 
 COPY ./build-debs.sh /

--- a/setup.py
+++ b/setup.py
@@ -12,36 +12,50 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-import f5_openstack_agent
+import os
+import pip
 import setuptools
+
+import f5_openstack_agent
+
+cwd = os.getcwd()
+try:
+    install_requirements = []
+    reqs_iter = \
+        pip.req.parse_requirements('./setup_requirements.txt', session='setup')
+    install_requirements = map(lambda x: str(x.req), reqs_iter)
+except pip.exceptions.InstallationError as Err:
+    exclude = ['/tox/', '/.tox/', '/pip-', 'rpm']
+    check = any(map(lambda x: x in cwd, exclude))
+    if not check:  # tested without for pip install ./
+        raise pip.exceptions.InstallationError("{}: {}".format(Err, cwd))
 
 setuptools.setup(
     version=f5_openstack_agent.__version__,
     name="f5-openstack-agent",
-    description = ("F5 Networks Agent for OpenStack services"),
-    license = 'Apache License, Version 2.0',
+    description=("F5 Networks Agent for OpenStack services"),
+    license='Apache License, Version 2.0',
     author="F5 Networks",
     author_email="f5_openstack_agent@f5.com",
-    data_files=[('/etc/neutron/services/f5', ['etc/neutron/services/f5/f5-openstack-agent.ini']),
+    data_files=[('/etc/neutron/services/f5',
+                 ['etc/neutron/services/f5/f5-openstack-agent.ini']),
                 ('/etc/init.d', ['etc/init.d/f5-oslbaasv2-agent']),
-                ('/usr/lib/systemd/system', ['lib/systemd/system/f5-openstack-agent.service']),
+                ('/usr/lib/systemd/system',
+                 ['lib/systemd/system/f5-openstack-agent.service']),
                 ('/usr/bin/f5', ['bin/debug_bundler.py'])],
-    packages=setuptools.find_packages(exclude=['*.test', '*.test.*', 'test*', 'test']),
-    classifiers=[
-        'Environment :: OpenStack',
-	'Intended Audience :: Information Technology',
-	'Intended Audience :: System Administrators',
-	'License :: OSI Approved :: Apache Software License',
-	'Operating System :: POSIX :: Linux',
-	'Programming Language :: Python',
-	'Programming Language :: Python :: 2',
-	'Programming Language :: Python :: 2.7'
-    ],
+    packages=setuptools.find_packages(exclude=['*.test', '*.test.*', 'test*',
+                                               'test']),
+    classifiers='''Environment :: OpenStack
+Intended Audience :: Information Technology
+Intended Audience :: System Administrators
+License :: OSI Approved :: Apache Software License
+Operating System :: POSIX :: Linux
+Programming Language :: Python
+Programming Language :: Python :: 2
+Programming Language :: Python :: 2.7'''.split("\n"),
     entry_points={
         'console_scripts': [
-            'f5-oslbaasv2-agent = f5_openstack_agent.lbaasv2.drivers.bigip.agent:main'
-        ]
-    },
-    install_requires=['f5-sdk==2.3.3']
+            str('f5-oslbaasv2-agent ='
+                'f5_openstack_agent.lbaasv2.drivers.bigip.agent:main')]},
+    install_requires=install_requirements
 )
-


### PR DESCRIPTION
Issues:
Fixes #958

Problem:
* `setup_requirements.txt` missing from `setup.py`

Analysis:
* This adds it and allows for pip library to exist for redhat and ubuntu
  * Both required for build Dockerfile's

Tests:
This is driven by the:
`./f5-openstack-agent-dist/scripts/test_install.sh`
Test script for building packages and validating them.

@zancas 
#### What issues does this address?
Fixes #958 
#### What's this change do?
* This adds it and allows for pip library to exist for redhat and ubuntu
  * Both required for build Dockerfile's

#### Where should the reviewer start?
setup.py
#### Any background context?
The setup.py had to be modified as well as both build Dockerfile's (redhat and ubuntu)