### PR TITLE
Mitaka external gateway mode mitaka rebase.3c4d7ae5a4b170c0bb5c53fe3c9bfa50210eff96

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,9 @@ version |release|
 -----------------
 
 
+.. image:: https://coveralls.io/repos/github/F5Networks/f5-openstack-agent/badge.svg?branch=mitaka
+:target: https://coveralls.io/github/F5Networks/f5-openstack-agent?branch=mitaka
+         
 Introduction
 ------------
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -974,9 +974,15 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
         try:
             LOG.debug('received update_fdb_entries: %s host: %s'
                       % (fdb_entries, host))
-            self.lbdriver.fdb_update(fdb_entries)
+            # self.lbdriver.fdb_update(fdb_entries)
+            LOG.warning("update_fdb_entries: the LBaaSv2 Agent does not "
+                        "handle an update of the IP address of a neutron "
+                        "port. This port is generally tied to a member. If "
+                        "the IP address of a member was changed, be sure to "
+                        "also recreate the member in neutron-lbaas with the "
+                        "new address.")
         except q_exception.NeutronException as exc:
-            LOG.error("update_fdb_entrie: NeutronException: %s" % exc.msg)
+            LOG.error("update_fdb_entries: NeutronException: %s" % exc.msg)
         except Exception as exc:
             LOG.error("update_fdb_entrie: Exception: %s" % exc.message)
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -700,6 +700,7 @@ class iControlDriver(LBaaSBaseDriver):
             ic_host['platform'] = self.system_helper.get_platform(hostbigip)
             ic_host['serial_number'] = self.system_helper.get_serial_number(
                 hostbigip)
+            ic_host['device_interfaces'] = hostbigip.device_interfaces
             icontrol_endpoints[host] = ic_host
 
         self.agent_configurations['tunneling_ips'] = local_ips

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
@@ -550,6 +550,7 @@ class NetworkServiceBuilder(object):
         tenant_id = service['loadbalancer']['tenant_id']
         subnet = subnetinfo['subnet']
         snats_per_subnet = self.conf.f5_snat_addresses_per_subnet
+        lb_id = service['loadbalancer']['id']
 
         assure_bigips = \
             [bigip for bigip in assure_bigips
@@ -561,7 +562,7 @@ class NetworkServiceBuilder(object):
                   subnet['id'])
         if len(assure_bigips):
             snat_addrs = self.bigip_snat_manager.get_snat_addrs(
-                subnetinfo, tenant_id, snats_per_subnet)
+                subnetinfo, tenant_id, snats_per_subnet, lb_id)
 
             if len(snat_addrs) != snats_per_subnet:
                 raise f5_ex.SNAT_CreationException(

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
@@ -348,7 +348,8 @@ class LBaaSv2PluginRPC(object):
     @log_helpers.log_method_call
     def create_port_on_subnet(self, subnet_id=None,
                               mac_address=None, name=None,
-                              fixed_address_count=1):
+                              fixed_address_count=1,
+                              device_id=None, binding_profile={}):
         """Add a neutron port to the subnet."""
         port = None
         try:
@@ -359,7 +360,9 @@ class LBaaSv2PluginRPC(object):
                                mac_address=mac_address,
                                name=name,
                                fixed_address_count=fixed_address_count,
-                               host=self.host),
+                               host=self.host,
+                               device_id=device_id,
+                               binding_profile=binding_profile),
                 topic=self.topic
             )
         except messaging.MessageDeliveryFailure:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
@@ -65,7 +65,7 @@ class BigipSnatManager(object):
         LOG.error('Invalid f5_ha_type:%s' % self.driver.conf.f5_ha_type)
         return ''
 
-    def get_snat_addrs(self, subnetinfo, tenant_id, snat_count):
+    def get_snat_addrs(self, subnetinfo, tenant_id, snat_count, lb_id):
         # Get the ip addresses for snat """
         subnet = subnetinfo['subnet']
         snat_addrs = []
@@ -85,7 +85,7 @@ class BigipSnatManager(object):
                     subnet_id=subnet['id'],
                     mac_address=None,
                     name=index_snat_name,
-                    fixed_address_count=1)
+                    fixed_address_count=1, device_id=lb_id)
                 if new_port is not None:
                     ip_address = new_port['fixed_ips'][0]['ip_address']
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager.py
@@ -1,0 +1,42 @@
+# coding=utf-8
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5_openstack_agent.lbaasv2.drivers.bigip import agent_manager
+
+import mock
+import pytest
+
+
+@pytest.fixture
+@mock.patch('f5_openstack_agent.lbaasv2.drivers.bigip.agent_manager.'
+            'LbaasAgentManager._setup_rpc')
+@mock.patch('f5_openstack_agent.lbaasv2.drivers.bigip.agent_manager.'
+            'importutils.import_object')
+def agent_mgr_setup(mock_importutils, mock_setup_rpc):
+    return agent_manager.LbaasAgentManager(mock.MagicMock(name='conf'))
+
+
+@mock.patch('f5_openstack_agent.lbaasv2.drivers.bigip.agent_manager.LOG')
+def test_update_fdb_entries(mock_log, agent_mgr_setup):
+    '''When func is called in agent_manager, it prooduces a warning message.'''
+
+    agent_mgr_setup.update_fdb_entries('', '')
+    warning_msg = "update_fdb_entries: the LBaaSv2 Agent does not handle an " \
+        "update of the IP address of a neutron port. This port is generally " \
+        "tied to a member. If the IP address of a member was changed, be " \
+        "sure to also recreate the member in neutron-lbaas with the new " \
+        "address."
+    assert mock_log.warning.call_args == mock.call(warning_msg)

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer.py
@@ -63,6 +63,17 @@ def test_create_delete_basic_lb(bigip, services, icd_config, icontrol_driver):
     assert call_record.get("operating_status", None) == 'ONLINE'
     assert call_record.get("provisioning_status", None) == 'ACTIVE'
 
+    assert fake_rpc.get_call_count('create_port_on_subnet') == 2
+
+    # Check the selfip call params
+    call_record = fake_rpc.get_calls('create_port_on_subnet')[0]
+    assert call_record.get("device_id", None) == lb_reader.id()
+
+    # Check the snat call params
+    call_record = fake_rpc.get_calls('create_port_on_subnet')[1]
+    assert call_record.get("device_id", None) == lb_reader.id()
+
+
     # Assert folder created
     assert bigip.folder_exists(folder)
 

--- a/test/functional/neutronless/testlib/fake_rpc.py
+++ b/test/functional/neutronless/testlib/fake_rpc.py
@@ -95,7 +95,9 @@ class FakeRPCPlugin(object):
                               subnet_id=None,
                               mac_address=None,
                               name=None,
-                              fixed_address_count=1):
+                              fixed_address_count=1,
+                              device_id=None,
+                              binding_profile={}):
 
         # Enforce specific call parameters
         if not subnet_id:


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
Rebase from `mitaka` > `mitaka_external_gateway_mode`

#### What's this change do?
This simply rebases `mitaka` into `mitaka_external_gateway_mode` for further development to keep from deviating too far from `mitaka`.

#### Where should the reviewer start?
From the top of the commits.

#### Any background context?
This is simply a rebase.