### PR TITLE
Refactor fdb updates

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
@@ -763,12 +763,13 @@ class L2ServiceBuilder(object):
                 fdbs[tunnel_name]['records'] = dict()
 
             records = fdbs[tunnel_name]['records']
-            mac_addr = member['port']['mac_address']
-            self.append_member_fdb_records(network,
-                                           member,
-                                           records,
-                                           mac_addr,
-                                           ip_address=member['address'])
+            if 'port' in member and 'mac_address' in member['port']:
+                mac_addr = member['port']['mac_address']
+                self.append_member_fdb_records(network,
+                                               member,
+                                               records,
+                                               mac_addr,
+                                               ip_address=member['address'])
 
         return fdbs
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
@@ -783,6 +783,6 @@ class L2ServiceBuilder(object):
     def append_member_fdb_records(self, network, member, records,
                                   mac_addr, ip_address=''):
         vteps = _get_vteps(network, member)
-        if len(vteps) > 0:
-            records[mac_addr] = {'endpoint': vteps[0],
+        for vtep in vteps:
+            records[mac_addr] = {'endpoint': vtep,
                                  'ip_address': ip_address}

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
@@ -62,6 +62,12 @@ def _get_tunnel_fake_mac(network, local_ip):
     return mac_prefix + ':'.join("%02x" % octet for octet in mac)
 
 
+def _get_vteps(network, vtep_source):
+    net_type = network['provider:network_type']
+    vtep_type = net_type + '_vteps'
+    return vtep_source.get(vtep_type, [])
+
+
 class L2ServiceBuilder(object):
 
     def __init__(self, driver, f5_global_routed_mode):
@@ -564,106 +570,6 @@ class L2ServiceBuilder(object):
             return
         self.vcmp_manager.disassoc_vlan_with_vcmp_guest(bigip, vlan_name)
 
-    def add_bigip_fdbs(self, bigip, net_folder, fdb_info, vteps_by_type):
-        # Add fdb records for a mac/ip with specified vteps
-        network = fdb_info['network']
-        net_type = network['provider:network_type']
-        vteps_key = net_type + '_vteps'
-        if vteps_key in vteps_by_type:
-            vteps = vteps_by_type[vteps_key]
-            if net_type == 'gre':
-                self.add_gre_fdbs(bigip, net_folder, fdb_info, vteps)
-            elif net_type == 'vxlan':
-                self.add_vxlan_fdbs(bigip, net_folder, fdb_info, vteps)
-
-    def add_gre_fdbs(self, bigip, net_folder, fdb_info, vteps):
-        # Add gre fdb records
-        network = fdb_info['network']
-        ip_address = fdb_info['ip_address']
-        mac_address = fdb_info['mac_address']
-        tunnel_name = _get_tunnel_name(network)
-        for vtep in vteps:
-            if mac_address:
-                mac_addr = mac_address
-            else:
-                mac_addr = _get_tunnel_fake_mac(network, vtep)
-            self.network_helper.add_fdb_entry(
-                bigip,
-                tunnel_name=tunnel_name,
-                partition=net_folder,
-                mac_address=mac_addr,
-                vtep_ip_address=vtep,
-                arp_ip_address=ip_address)
-
-    def add_vxlan_fdbs(self, bigip, net_folder, fdb_info, vteps):
-        # Add vxlan fdb records
-        network = fdb_info['network']
-        ip_address = fdb_info['ip_address']
-        mac_address = fdb_info['mac_address']
-        tunnel_name = _get_tunnel_name(network)
-        for vtep in vteps:
-            if mac_address:
-                mac_addr = mac_address
-            else:
-                mac_addr = _get_tunnel_fake_mac(network, vtep)
-
-            self.network_helper.add_fdb_entry(
-                bigip,
-                tunnel_name=tunnel_name,
-                partition=net_folder,
-                mac_address=mac_addr,
-                vtep_ip_address=vtep,
-                arp_ip_address=ip_address)
-
-    def delete_bigip_fdbs(self, bigip, net_folder, fdb_info, vteps_by_type):
-        # Delete fdb records for a mac/ip with specified vteps
-        network = fdb_info['network']
-        net_type = network['provider:network_type']
-        vteps_key = net_type + '_vteps'
-        if vteps_key in vteps_by_type:
-            vteps = vteps_by_type[vteps_key]
-            if net_type == 'gre':
-                self.delete_gre_fdbs(bigip, net_folder, fdb_info, vteps)
-            elif net_type == 'vxlan':
-                self.delete_vxlan_fdbs(bigip, net_folder, fdb_info, vteps)
-
-    def delete_gre_fdbs(self, bigip, net_folder, fdb_info, vteps):
-        # delete gre fdb records
-        network = fdb_info['network']
-        ip_address = fdb_info['ip_address']
-        mac_address = fdb_info['mac_address']
-        tunnel_name = _get_tunnel_name(network)
-        for vtep in vteps:
-            if mac_address:
-                mac_addr = mac_address
-            else:
-                mac_addr = _get_tunnel_fake_mac(network, vtep)
-
-            self.network_helper.delete_fdb_entry(
-                bigip,
-                tunnel_name=tunnel_name,
-                mac_address=mac_addr,
-                arp_ip_address=ip_address,
-                partition=net_folder)
-
-    def delete_vxlan_fdbs(self, bigip, net_folder, fdb_info, vteps):
-        # delete vxlan fdb records
-        network = fdb_info['network']
-        ip_address = fdb_info['ip_address']
-        mac_address = fdb_info['mac_address']
-        tunnel_name = _get_tunnel_name(network)
-        for vtep in vteps:
-            if mac_address:
-                mac_addr = mac_address
-            else:
-                mac_addr = _get_tunnel_fake_mac(network, vtep)
-            self.network_helper.delete_fdb_entry(
-                bigip,
-                tunnel_name=tunnel_name,
-                mac_address=mac_addr,
-                arp_ip_address=ip_address,
-                partition=net_folder)
-
     def add_bigip_fdb(self, bigip, fdb):
         # Add entries from the fdb relevant to the bigip
         for fdb_operation in \
@@ -801,3 +707,73 @@ class L2ServiceBuilder(object):
             LOG.error(error_message)
             raise f5_ex.InvalidNetworkType(error_message)
         return network_name, preserve_network_name
+
+    def _get_network_folder(self, network):
+        if self.is_common_network(network):
+            return 'Common'
+        else:
+            return self.service_adapter.get_folder_name(network['tenant_id'])
+
+    def add_fdb_entries(self, bigips, loadbalancer, members):
+        """Update fdb entries for loadbalancer and member VTEPs.
+
+        :param bigips: one or more BIG-IPs to update.
+        :param loadbalancer: Loadbalancer with VTEPs to update. Can be None.
+        :param members: List of members. Can be emtpy ([]).
+        """
+        tunnel_records = self.create_fdb_records(loadbalancer, members)
+        for bigip in bigips:
+            self.network_helper.add_fdb_entries(bigip,
+                                                fdb_entries=tunnel_records)
+
+    def delete_fdb_entries(self, bigips, loadbalancer, members):
+        """Remove fdb entries for loadbalancer and member VTEPs.
+
+        :param bigips: one or more BIG-IPs to update.
+        :param loadbalancer: Loadbalancer with VTEPs to remove. Can be None.
+        :param members: List of members. Can be emtpy ([]).
+        """
+        tunnel_records = self.create_fdb_records(loadbalancer, members)
+        for bigip in bigips:
+            self.network_helper.delete_fdb_entries(bigip,
+                                                   fdb_entries=tunnel_records)
+
+    def create_fdb_records(self, loadbalancer, members):
+        fdbs = {}
+
+        if loadbalancer:
+            network = loadbalancer['network']
+            tunnel_name = _get_tunnel_name(network)
+            fdbs[tunnel_name] = {}
+            fdbs[tunnel_name]['folder'] = self._get_network_folder(network)
+            records = {}
+            fdbs[tunnel_name]['records'] = records
+            self.append_fdb_records(network, loadbalancer, records)
+
+        for member in members:
+            network = member['network']
+            tunnel_name = _get_tunnel_name(network)
+            if tunnel_name not in fdbs:
+                fdbs[tunnel_name] = {}
+                fdbs[tunnel_name]['folder'] = self._get_network_folder(network)
+                fdbs[tunnel_name]['records'] = {}
+
+            records = fdbs['tunnel_name']['records']
+            mac_addr = member['port']['mac_address']
+            self.append_fdb_records(network,
+                                    member,
+                                    records,
+                                    mac_addr=mac_addr,
+                                    ip_address=member['address'])
+
+        return fdbs
+
+    def append_fdb_records(self, network, vtep_source, records,
+                           mac_addr=None, ip_address=''):
+        vteps = _get_vteps(network, vtep_source)
+        for vtep in vteps:
+            if not mac_addr:
+                mac_addr = _get_tunnel_fake_mac(network, vtep)
+            records[mac_addr] = {'name': mac_addr,
+                                 'endpoint': vtep,
+                                 'ip_address': ip_address}

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
@@ -758,7 +758,7 @@ class L2ServiceBuilder(object):
                 fdbs[tunnel_name]['folder'] = self._get_network_folder(network)
                 fdbs[tunnel_name]['records'] = {}
 
-            records = fdbs['tunnel_name']['records']
+            records = fdbs[tunnel_name]['records']
             mac_addr = member['port']['mac_address']
             self.append_fdb_records(network,
                                     member,
@@ -773,7 +773,9 @@ class L2ServiceBuilder(object):
         vteps = _get_vteps(network, vtep_source)
         for vtep in vteps:
             if not mac_addr:
-                mac_addr = _get_tunnel_fake_mac(network, vtep)
-            records[mac_addr] = {'name': mac_addr,
-                                 'endpoint': vtep,
-                                 'ip_address': ip_address}
+                mac_addr_key = _get_tunnel_fake_mac(network, vtep)
+            else:
+                mac_addr_key = mac_addr
+
+            records[mac_addr_key] = {'endpoint': vtep,
+                                     'ip_address': ip_address}

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
@@ -659,8 +659,8 @@ class NetworkServiceBuilder(object):
 
         bigips = self.driver.get_all_bigips()
 
-        update_members = []
-        delete_members = []
+        update_members = list()
+        delete_members = list()
         update_loadbalancer = None
         delete_loadbalancer = None
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_l2_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_l2_service.py
@@ -1,0 +1,365 @@
+# coding=utf-8
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5_openstack_agent.lbaasv2.drivers.bigip.l2_service import \
+    _get_tunnel_name
+from f5_openstack_agent.lbaasv2.drivers.bigip.l2_service import \
+    L2ServiceBuilder
+from f5_openstack_agent.lbaasv2.drivers.bigip.network_helper import \
+    NetworkHelper
+
+import mock
+import pytest
+
+
+@pytest.fixture
+def bigips():
+    return [mock.MagicMock()]
+
+
+@pytest.fixture
+def l2_service():
+    driver = mock.MagicMock()
+    driver.conf = mock.MagicMock()
+    driver.conf.vlan_binding_driver = None
+    return L2ServiceBuilder(driver, False)
+
+
+@pytest.fixture
+def service():
+    return {
+        u"listeners": [{
+            u"admin_state_up": True,
+            u"connection_limit": -1,
+            u"default_pool_id": None,
+            u"default_tls_container_id": None,
+            u"description": u"",
+            u"id": u"5108c2fe-29bd-4e5b-94de-99034c561a15",
+            u"l7_policies": [],
+            u"loadbalancer_id": u"75e9326d-67ec-42b7-9647-3fc1c51c0091",
+            u"name": u"listener2",
+            u"operating_status": u"ONLINE",
+            u"protocol": u"HTTPS",
+            u"protocol_port": 443,
+            u"provisioning_status": u"ACTIVE",
+            u"sni_containers": [],
+            u"tenant_id": u"980e3f914f3e40359c3c2d9470fb2e8a"
+        }],
+        u'loadbalancer': {
+            u'admin_state_up': True,
+            u'description': u'',
+            u'gre_vteps': [u'201.0.162.1',
+                           u'201.0.160.1',
+                           u'201.0.165.1'],
+            u'id': u'd5a0396e-e862-4cbf-8eb9-25c7fbc4d593',
+            u'listeners': [
+                {u'id': u'e3af03f4-d3df-4c9b-b3dd-8002f133d5bf'}],
+            u'name': u'',
+            u'network_id': u'cdf1eb6d-9b17-424a-a054-778f3d3a5490',
+            u'operating_status': u'ONLINE',
+            u'pools': [
+                {u'id': u'2dbca6cd-30d8-4013-9c9a-df0850fabf52'}],
+            u'provider': u'f5networks',
+            u'provisioning_status': u'ACTIVE',
+            u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd',
+            u'vip_address': u'172.16.101.3',
+            u'vip_port': {u'admin_state_up': True,
+                          u'allowed_address_pairs': [],
+                          u'binding:host_id':
+                              u'host-164.int.lineratesystems.com:16ea1e',
+                          u'binding:profile': {},
+                          u'binding:vif_details': {},
+                          u'binding:vif_type': u'binding_failed',
+                          u'binding:vnic_type': u'normal',
+                          u'created_at': u'2016-10-24T21:17:30',
+                          u'description': None,
+                          u'device_id': u'0bd0b8ff-1c51-5061-b0c4',
+                          u'device_owner': u'network:f5lbaasv2',
+                          u'dns_name': None,
+                          u'extra_dhcp_opts': [],
+                          u'fixed_ips': [
+                              {u'ip_address': u'172.16.101.3',
+                               u'subnet_id': u'81f42a8a-fc98-4281-8de4'}],
+                          u'id': u'38a13e5c-6863-4537-80a3',
+                          u'mac_address': u'fa:16:3e:94:65:0c',
+                          u'name': u'loadbalancer-d5a0396e-e862',
+                          u'network_id': u'cdf1eb6d-9b17-424a',
+                          u'security_groups': [u'df88afdb-2bc6-4621'],
+                          u'status': u'DOWN',
+                          u'tenant_id': u'd9ed216f67f04a84bf8fd',
+                          u'updated_at': u'2016-10-24T21:17:31'},
+            u'vip_port_id': u'38a13e5c-6863-4537-80a3-c788d5f0c9ce',
+            u'vip_subnet_id': u'81f42a8a-fc98-4281-8de4-2b946e931457',
+            u'vxlan_vteps':
+                ['192.168.130.136', '192.168.130.20', '192.168.130.131',
+                 '192.168.130.8', '192.168.130.7', '192.168.130.46',
+                 '192.168.130.48', '192.168.130.12', '192.168.130.47',
+                 '192.168.130.106', '192.168.130.115', '192.168.130.99',
+                 '192.168.130.116', '192.168.130.44', '192.168.130.118',
+                 '192.168.130.109', '192.168.130.28', '192.168.130.40',
+                 '192.168.130.127', '192.168.130.100', '192.168.130.41',
+                 '192.168.130.105', '192.168.130.124', '192.168.130.138',
+                 '192.168.130.111', '192.168.130.31', '192.168.130.137',
+                 '192.168.130.22', '192.168.130.135', '192.168.130.62',
+                 '192.168.130.45', '192.168.130.140', '192.168.130.113',
+                 '192.168.130.84', '192.168.130.121', '192.168.130.88',
+                 '192.168.130.42', '192.168.130.39', '192.168.130.114',
+                 '192.168.130.57', '192.168.130.38', '192.168.130.101',
+                 '192.168.130.110', '192.168.130.126']},
+        u'members': [{u'address': u'10.2.2.3',
+                      u'admin_state_up': True,
+                      u'id': u'1e7bfa17-a38f-4728-a3a7-aad85da69712',
+                      u'name': u'',
+                      u'network_id': u'cdf1eb6d-9b17-424a-a054-778f3d3a5490',
+                      u'operating_status': u'ONLINE',
+                      u'pool_id': u'2dbca6cd-30d8-4013-9c9a-df0850fabf52',
+                      u'protocol_port': 8080,
+                      u'provisioning_status': u'ACTIVE',
+                      u'subnet_id': u'81f42a8a-fc98-4281-8de4-2b946e931457',
+                      u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd',
+                      u'port': {'mac_address': 'fa:16:3e:0d:fa:c8'},
+                      u'vxlan_vteps': ['192.168.130.59'],
+                      u'weight': 1},
+                     {u'address': u'10.2.2.4',
+                      u'admin_state_up': True,
+                      u'id': u'1e7bfa17-a38f-4728-a3a7-aad85da69712',
+                      u'name': u'',
+                      u'network_id': u'81f42a8a-9b17-424a-a054-778f3d3a5490',
+                      u'operating_status': u'ONLINE',
+                      u'pool_id': u'2dbca6cd-30d8-4013-9c9a-df0850fabf52',
+                      u'protocol_port': 8080,
+                      u'provisioning_status': u'ACTIVE',
+                      u'subnet_id': u'81f42a8a-fc98-4281-8de4-2b946e931457',
+                      u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd',
+                      u'port':  {'mac_address': 'fa:16:3e:0d:fa:c6'},
+                      u'gre_vteps': ['192.168.130.60'],
+                      u'weight': 1}],
+        u'networks': {
+            u'cdf1eb6d-9b17-424a-a054-778f3d3a5490': {
+                'status': 'ACTIVE',
+                'subnets': ['82b3db18-e97d-4288-81ab-12b04758f595'],
+                'name': 'lifecycle', 'provider:physical_network': None,
+                'admin_state_up': True,
+                'tenant_id': 'd1cae4d1238243419b3894ecea85c4aa', 'mtu': 1500,
+                'router:external': False, 'vlan_transparent': None,
+                'shared': False, 'provider:network_type': 'vxlan',
+                'id': 'b2efb43c-60a7-4032-be03-b3ccb2990c03',
+                'provider:segmentation_id': 5218
+            },
+            u'81f42a8a-9b17-424a-a054-778f3d3a5490': {
+                'status': 'ACTIVE',
+                'subnets': ['82b3db18-e97d-4288-81ab-12b04758f595'],
+                'name': 'lifecycle', 'provider:physical_network': None,
+                'admin_state_up': True,
+                'tenant_id': 'd1cae4d1238243419b3894ecea85c4aa', 'mtu': 1500,
+                'router:external': False, 'vlan_transparent': None,
+                'shared': False, 'provider:network_type': 'gre',
+                'id': 'b2efb43c-60a7-4032-be03-b3ccb2990c03',
+                'provider:segmentation_id': 2130
+            }
+        },
+        u'pools': [{u'admin_state_up': True,
+                    u'description': u'',
+                    u'healthmonitor_id': u'70fed03a-efc4-460a-8a21',
+                    u'id': u'2dbca6cd-30d8-4013-9c9a-df0850fabf52',
+                    u'l7_policies': [],
+                    u'lb_algorithm': u'ROUND_ROBIN',
+                    u'listeners':[
+                        {u'id': '5108c2fe-29bd-4e5b-94de-99034c561a15'}],
+                    u'loadbalancer_id': u'd5a0396e-e862-4cbf-8eb9-25c7fbc4d59',
+                    u'name': u'',
+                    u'operating_status': u'ONLINE',
+                    u'partition': 'Test_d9ed216f67f04a84bf8fd97c155855cd',
+                    u'protocol': u'HTTP',
+                    u'provisioning_status': u'ACTIVE',
+                    u'session_persistence': None,
+                    u'sessionpersistence': None,
+                    u'tenant_id': u'd9ed216f67f04a84bf8fd97c155855cd'}],
+    }
+
+
+class TestL2ServiceBuilder(object):
+
+    def test_create_fdb_records(self, l2_service, service):
+        loadbalancer = service['loadbalancer']
+        network_id = loadbalancer['network_id']
+        loadbalancer['network'] = service['networks'][network_id]
+        members = list()
+        for member in service['members']:
+            network_id = member['network_id']
+            member['network'] = service['networks'][network_id]
+            members.append(member)
+
+        tunnel_records = l2_service.create_fdb_records(loadbalancer, members)
+
+        # two networks, two sets of records
+        assert len(tunnel_records) == 2
+
+        # vxlan records has both lb and one member
+        tunnel_name = _get_tunnel_name(members[0]['network'])
+        assert tunnel_name == 'tunnel-vxlan-5218'
+        vxlan_records = tunnel_records[tunnel_name]['records']
+        assert len(vxlan_records) == (len(loadbalancer.get('vxlan_vteps')) + 1)
+
+        # gre recoreds has only second member
+        tunnel_name = _get_tunnel_name(members[1]['network'])
+        assert tunnel_name == 'tunnel-gre-2130'
+        gre_records = tunnel_records[tunnel_name]['records']
+        assert len(gre_records) == 1
+
+    def test_empty_fdb_records(self, l2_service):
+        loadbalancer = None
+        members = list()
+        tunnel_records = l2_service.create_fdb_records(loadbalancer, members)
+
+        # no records should be created
+        assert len(tunnel_records) == 0
+
+    def test_no_member_records(self, l2_service, service):
+        loadbalancer = service['loadbalancer']
+        network_id = loadbalancer['network_id']
+        loadbalancer['network'] = service['networks'][network_id]
+
+        members = list()
+        tunnel_records = l2_service.create_fdb_records(loadbalancer, members)
+
+        # one network, one set of records
+        assert len(tunnel_records) == 1
+
+        tunnel_name = _get_tunnel_name(loadbalancer['network'])
+        assert tunnel_name == 'tunnel-vxlan-5218'
+        vxlan_records = tunnel_records[tunnel_name]['records']
+        assert len(vxlan_records) == len(loadbalancer.get('vxlan_vteps'))
+
+    def test_no_loadbalancer_records(self, l2_service, service):
+        loadbalancer = None
+        members = list()
+        for member in service['members']:
+            network_id = member['network_id']
+            member['network'] = service['networks'][network_id]
+            members.append(member)
+
+        tunnel_records = l2_service.create_fdb_records(loadbalancer, members)
+
+        # two networks, two sets of records
+        assert len(tunnel_records) == 2
+
+        # vxlan records has only first member
+        tunnel_name = _get_tunnel_name(members[0]['network'])
+        assert tunnel_name == 'tunnel-vxlan-5218'
+        vxlan_records = tunnel_records[tunnel_name]['records']
+        assert len(vxlan_records) == 1
+
+        # gre records has only second member
+        tunnel_name = _get_tunnel_name(members[1]['network'])
+        assert tunnel_name == 'tunnel-gre-2130'
+        gre_records = tunnel_records[tunnel_name]['records']
+        assert len(gre_records) == 1
+
+    def test_add_fdb_entries(self, l2_service, service, bigips):
+        loadbalancer = service['loadbalancer']
+        network_id = loadbalancer['network_id']
+        loadbalancer['network'] = service['networks'][network_id]
+        members = list()
+        for member in service['members']:
+            network_id = member['network_id']
+            member['network'] = service['networks'][network_id]
+            members.append(member)
+
+        with mock.patch('f5_openstack_agent.lbaasv2.drivers.bigip.'
+                        'network_helper.NetworkHelper') as mock_helper:
+
+            l2_service.network_helper = mock_helper
+            l2_service.add_fdb_entries(bigips, loadbalancer, members)
+            assert l2_service.network_helper.add_fdb_entries.called
+
+    def test_delete_fdb_entries(self, l2_service, service, bigips):
+        loadbalancer = service['loadbalancer']
+        network_id = loadbalancer['network_id']
+        loadbalancer['network'] = service['networks'][network_id]
+        members = list()
+        for member in service['members']:
+            network_id = member['network_id']
+            member['network'] = service['networks'][network_id]
+            members.append(member)
+
+        with mock.patch('f5_openstack_agent.lbaasv2.drivers.bigip.'
+                        'network_helper.NetworkHelper') as mock_helper:
+            l2_service.network_helper = mock_helper
+            l2_service.delete_fdb_entries(bigips, loadbalancer, members)
+            assert l2_service.network_helper.delete_fdb_entries.called
+
+    def test_network_helper_add_fdb_entries(self, l2_service, service, bigips):
+        # add first member fdb entry
+        loadbalancer = None
+        members = list()
+        member = service['members'][0]
+        network_id = member['network_id']
+        member['network'] = service['networks'][network_id]
+        members.append(member)
+
+        tunnel_records = l2_service.create_fdb_records(loadbalancer, members)
+
+        network_helper = NetworkHelper()
+        fdb_entry = mock.MagicMock()
+        fdb_entry.modify = mock.MagicMock()
+        bigip = bigips[0]
+        bigip.tm.net.fdb.tunnels.tunnel.load = mock.MagicMock(
+            return_value=fdb_entry)
+        network_helper.add_fdb_entries(bigip, fdb_entries=tunnel_records)
+
+        # expect to modify with first member's VTEP and MAC addr
+        fdb_entry.modify.assert_called_with(
+            records=[{'endpoint': '192.168.130.59',
+                      'name': 'fa:16:3e:0d:fa:c8'}])
+
+        # add second member fdb entry
+        members = list()
+        member = service['members'][1]
+        network_id = member['network_id']
+        member['network'] = service['networks'][network_id]
+        members.append(member)
+
+        tunnel_records = l2_service.create_fdb_records(loadbalancer, members)
+        network_helper.add_fdb_entries(bigip, fdb_entries=tunnel_records)
+
+        # expect to modify with second member's VTEP and MAC addr
+        fdb_entry.modify.assert_called_with(
+            records=[{'endpoint': '192.168.130.60',
+                      'name': 'fa:16:3e:0d:fa:c6'}])
+
+    def test_network_helper_delete_fdb_entries(
+            self, l2_service, service, bigips):
+        # delete member fdb entry
+        loadbalancer = None
+        members = list()
+        member = service['members'][1]
+        network_id = member['network_id']
+        member['network'] = service['networks'][network_id]
+        members.append(member)
+
+        tunnel_records = l2_service.create_fdb_records(loadbalancer, members)
+
+        network_helper = NetworkHelper()
+        fdb_entry = mock.MagicMock()
+        fdb_entry.modify = mock.MagicMock()
+        bigip = bigips[0]
+        bigip.tm.net.fdb.tunnels.tunnel.load = mock.MagicMock(
+            return_value=fdb_entry)
+        network_helper.delete_fdb_entries(bigip, fdb_entries=tunnel_records)
+
+        # expect to modify with no records (i.e, removing entry)
+        fdb_entry.modify.assert_called_with(records=None)


### PR DESCRIPTION
@richbrowne 
DO NOT MERGE

#### What issues does this address?
#963 Refactor fdb updates

#### What's this change do?
Changes how fdb add/deletes are done in post_service_network function. Instead of updating each fdb entry indvidually, collects fdb records for all VTEPs (both loadbalancer and member), then updates each tunnel.  This reduces the number of BIG-IP operations from number of VTEPs to number of tunnels.

#### Where should the reviewer start?
network_service.py

#### Any background context?
Number of VTEPs for a single loadbalancer can be in the hundreds, which is the likely performance bottleneck.

