### PR TITLE
Fix loadbalancer/disconnected functional tests

### DIFF
--- a/test/functional/neutronless/disconnected_service/oslo_confs.json
+++ b/test/functional/neutronless/disconnected_service/oslo_confs.json
@@ -66,6 +66,7 @@
         "environment_specific_plugin": true, 
         "f5_bigip_lbaas_device_driver": "f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver.iControlDriver", 
         "f5_common_external_networks": true, 
+        "f5_common_networks": false, 
         "f5_device_type": "external", 
         "f5_external_physical_mappings": [
             "default:1.1:true"
@@ -242,6 +243,7 @@
         "environment_specific_plugin": true, 
         "f5_bigip_lbaas_device_driver": "f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver.iControlDriver", 
         "f5_common_external_networks": true, 
+        "f5_common_networks": false, 
         "f5_device_type": "external", 
         "f5_external_physical_mappings": [
             "default:1.1:true"
@@ -418,6 +420,7 @@
         "environment_specific_plugin": true, 
         "f5_bigip_lbaas_device_driver": "f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver.iControlDriver", 
         "f5_common_external_networks": true, 
+        "f5_common_networks": false, 
         "f5_device_type": "external", 
         "f5_external_physical_mappings": [
             "default:1.1:true"
@@ -594,6 +597,7 @@
         "environment_specific_plugin": true, 
         "f5_bigip_lbaas_device_driver": "f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver.iControlDriver", 
         "f5_common_external_networks": true, 
+        "f5_common_networks": false, 
         "f5_device_type": "external", 
         "f5_external_physical_mappings": [
             "default:1.1:true"

--- a/test/functional/neutronless/testlib/fake_rpc.py
+++ b/test/functional/neutronless/testlib/fake_rpc.py
@@ -115,6 +115,27 @@ class FakeRPCPlugin(object):
         return retval
 
     @track_call
+    def create_port_on_network(self,
+                               network_id=None,
+                               mac_address=None,
+                               name=None,
+                               host=None):
+        # Enforce specific call parameters
+        if not network_id:
+            raise InvalidArgumentError
+        if mac_address:
+            raise InvalidArgumentError
+        if not name:
+            raise InvalidArgumentError
+
+        ip_address = "127.0.0.1"
+
+        retval = {'fixed_ips': [{'ip_address': ip_address}]}
+        self._ports[name] = [retval]
+
+        return retval
+
+    @track_call
     def get_port_by_name(self, port_name=None):
         if not port_name:
             raise InvalidArgumentError


### PR DESCRIPTION
The functional tests need fake implementations of a number of RPC call backs to the server.  A new function was added 'create_port_on_network' to support HPB for the Cisco opflex networks.  This commit adds the stub for this function and also adds the configuration item 'f5_common_networks'

Ran:
test/functional/neutronless/loadbalancer
test/functional/neutronless/disconnected_service

All passed.
