### PR TITLE
Liberty.bugfixes from.mitaka external gateway mode

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -27,10 +27,10 @@ from oslo_service import periodic_task
 from oslo_utils import importutils
 
 from neutron.agent import rpc as agent_rpc
-from neutron.plugins.common import constants as plugin_const
 from neutron.common import exceptions as q_exception
 from neutron.common import topics
 from neutron import context as ncontext
+from neutron.plugins.common import constants as plugin_const
 from neutron.plugins.ml2.drivers.l2pop import rpc as l2pop_rpc
 from neutron_lbaas.services.loadbalancer import constants as lb_const
 
@@ -622,10 +622,11 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                 error_status = handle_error(error_status, obj)
             elif expected_tree[item] == list and \
                     isinstance(obj, list):
-                for cnt, obj in enumerate(obj):
-                    if len(obj) == 1:
-                        obj = obj[cnt][obj]
-                    error_status = handle_error(error_status, obj)
+                for item in obj:
+                    if len(item) == 1:
+                        # {'networks': [{'id': {<network_obj>}}]}
+                        item = item[item.keys()[0]]
+                    error_status = handle_error(error_status, item)
         if error_status:
             loadbalancer['provisioning_status'] = plugin_const.ERROR
         return error_status

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -469,30 +469,17 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
         """Sync state of BIG-IP with that of the neutron database."""
         resync = False
 
-        known_services = set()
-        owned_services = set()
-        for lb_id, service in self.cache.services.iteritems():
-            known_services.add(lb_id)
-            if self.agent_host == service.agent_host:
-                owned_services.add(lb_id)
-        now = datetime.datetime.now()
+        known_services, owned_services = self._all_vs_known_services()
 
         try:
             # Get loadbalancers from the environment which are bound to
             # this agent.
-            active_loadbalancers = (
-                self.plugin_rpc.get_active_loadbalancers(host=self.agent_host)
-            )
-            active_loadbalancer_ids = set(
-                [lb['lb_id'] for lb in active_loadbalancers]
-            )
-
-            all_loadbalancers = (
-                self.plugin_rpc.get_all_loadbalancers(host=self.agent_host)
-            )
-            all_loadbalancer_ids = set(
-                [lb['lb_id'] for lb in all_loadbalancers]
-            )
+            active_loadbalancers, active_loadbalancer_ids = \
+                self._get_remote_loadbalancers('get_active_loadbalancers',
+                                               host=self.agent_host)
+            all_loadbalancers, all_loadbalancer_ids = \
+                self._get_remote_loadbalancers('get_all_loadbalancers',
+                                               host=self.agent_host)
 
             LOG.debug("plugin produced the list of active loadbalancer ids: %s"
                       % list(active_loadbalancer_ids))
@@ -505,54 +492,13 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
 
             # Validate each service we own, i.e. loadbalancers to which this
             # agent is bound, that does not exist in our service cache.
-            for lb_id in active_loadbalancer_ids:
-                if not self.cache.get_by_loadbalancer_id(lb_id):
-                    self.validate_service(lb_id)
+            self._validate_services(all_loadbalancer_ids)
 
-            # This produces a list of loadbalancers with pending tasks to
-            # be performed.
-            pending_loadbalancers = (
-                self.plugin_rpc.get_pending_loadbalancers(host=self.agent_host)
-            )
-            pending_lb_ids = set(
-                [lb['lb_id'] for lb in pending_loadbalancers]
-            )
-
-            not_pending_lb_ids = all_loadbalancer_ids - pending_lb_ids
-            for lb_id in not_pending_lb_ids:
-                self.pending_services.pop(lb_id, None)
-
-            LOG.debug(
-                "plugin produced the list of pending loadbalancer ids: %s"
-                % list(pending_lb_ids))
-
-            for lb_id in pending_lb_ids:
-                lb_pending = self.refresh_service(lb_id)
-                if lb_pending:
-                    if lb_id not in self.pending_services:
-                        self.pending_services[lb_id] = now
-
-                    time_added = self.pending_services[lb_id]
-                    time_expired = ((now - time_added).seconds >
-                                    self.conf.f5_pending_services_timeout)
-
-                    if time_expired:
-                        lb_pending = False
-                        self.service_timeout(lb_id)
-
-                if not lb_pending:
-                    del self.pending_services[lb_id]
-
-            # If there are services in the pending cache resync
-            if self.pending_services:
-                resync = True
+            resync = self._refresh_pending_services()
 
             # Get a list of any cached service we now know after
             # refreshing services
-            known_services = set()
-            for (lb_id, service) in self.cache.services.iteritems():
-                if self.agent_host == service.agent_host:
-                    known_services.add(lb_id)
+            owned_services, known_services = self._all_vs_known_services()
             LOG.debug("currently known loadbalancer ids after sync: %s"
                       % list(known_services))
 
@@ -561,6 +507,59 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
             resync = True
 
         return resync
+
+    def _all_vs_known_services(self):
+        all_services = set()
+        known_services = set()
+        for lb_id, service in self.cache.services.iteritems():
+            all_services.add(lb_id)
+            if self.agent_host == service.agent_host:
+                known_services.add(lb_id)
+        return all_services, known_services
+
+    def _refresh_pending_services(self):
+        now = datetime.datetime.now()
+        resync = False
+        # This produces a list of loadbalancers with pending tasks to
+        # be performed.
+        pending_loadbalancers, pending_lb_ids = \
+            self._get_remote_loadbalancers('get_pending_loadbalancers',
+                                           host=self.agent_host)
+        LOG.debug(
+            "plugin produced the list of pending loadbalancer ids: %s"
+            % list(pending_lb_ids))
+
+        for lb_id in list(pending_lb_ids):
+            lb_pending = self.refresh_service(lb_id)
+            if lb_pending:
+                if lb_id not in self.pending_services:
+                    self.pending_services[lb_id] = now
+
+                time_added = self.pending_services[lb_id]
+                has_expired = bool((now - time_added).seconds >
+                                   self.conf.f5_pending_services_timeout)
+
+                if has_expired:
+                    lb_pending = False
+                    self.service_timeout(lb_id)
+
+            if not lb_pending:
+                del self.pending_services[lb_id]
+
+        # If there are services in the pending cache resync
+        if self.pending_services:
+            resync = True
+        return resync
+
+    def _get_remote_loadbalancers(self, plugin_rpc_attr, host=None):
+        loadbalancers = getattr(self.plugin_rpc, plugin_rpc_attr)(host=host)
+        lb_ids = [lb['lb_id'] for lb in loadbalancers]
+        return tuple(loadbalancers), set(lb_ids)
+
+    def _validate_services(self, lb_ids):
+        for lb_id in lb_ids:
+            if not self.cache.get_by_loadbalancer_id(lb_id):
+                self.validate_service(lb_id)
 
     @log_helpers.log_method_call
     def validate_service(self, lb_id):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -27,7 +27,7 @@ from oslo_service import periodic_task
 from oslo_utils import importutils
 
 from neutron.agent import rpc as agent_rpc
-from neutron.common import constants as plugin_const
+from neutron.plugins.common import constants as plugin_const
 from neutron.common import exceptions as q_exception
 from neutron.common import topics
 from neutron import context as ncontext
@@ -569,9 +569,10 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                 lb_id
             )
             self.cache.put(service, self.agent_host)
-            if not self.lbdriver.service_exists(service):
-                LOG.error('active loadbalancer %s is not on BIG-IP...syncing'
-                          % lb_id)
+            if not self.lbdriver.service_exists(service) or \
+                    self.has_provisioning_status_of_error(service):
+                LOG.info("active loadbalancer '{}' is not on BIG-IP"
+                         " or has error state...syncing".format(lb_id))
 
                 if self.lbdriver.service_rename_required(service):
                     self.lbdriver.service_object_teardown(service)
@@ -586,11 +587,48 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
 
                 self.lbdriver.sync(service)
             else:
-                LOG.debug("Found service definition for %s" % (lb_id))
+                LOG.debug("Found service definition for '{}', state is ACTIVE"
+                          " move on.".format(lb_id))
         except q_exception.NeutronException as exc:
             LOG.error("NeutronException: %s" % exc.msg)
         except Exception as exc:
             LOG.exception("Service validation error: %s" % exc.message)
+
+    @staticmethod
+    def has_provisioning_status_of_error(service):
+        """Takes a service and determines if it is in an ERROR status
+
+        This staticmethod will go through a service object and determine if it
+        has an ERROR status anywhere within the object.
+        """
+        expected_tree = dict(loadbalancer=dict, members=list, pools=list,
+                             listeners=list, healthmonitors=list)
+        error_status = False  # assume we're in the clear unless otherwise...
+        loadbalancer = service.get('loadbalancer', dict())
+
+        def handle_error(error_status, obj):
+            provisioning_status = obj.get('provisioning_status')
+            if provisioning_status == plugin_const.ERROR:
+                obj_id = obj.get('id', 'unknown')
+                LOG.warning("Service object has object of type(id) {}({})"
+                            " that is in '{}' status.".format(
+                                item, obj_id, plugin_const.ERROR))
+                error_status = True
+            return error_status
+
+        for item in expected_tree:
+            obj = service.get(item, expected_tree[item]())
+            if expected_tree[item] == dict and isinstance(service[item], dict):
+                error_status = handle_error(error_status, obj)
+            elif expected_tree[item] == list and \
+                    isinstance(obj, list):
+                for cnt, obj in enumerate(obj):
+                    if len(obj) == 1:
+                        obj = obj[cnt][obj]
+                    error_status = handle_error(error_status, obj)
+        if error_status:
+            loadbalancer['provisioning_status'] = plugin_const.ERROR
+        return error_status
 
     @log_helpers.log_method_call
     def refresh_service(self, lb_id):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -310,6 +310,9 @@ def is_connected(method):
 
 class iControlDriver(LBaaSBaseDriver):
     '''gets rpc plugin from manager (which instantiates, via importutils'''
+    positive_plugin_const_state = \
+        tuple([plugin_const.ACTIVE, plugin_const.PENDING_CREATE,
+               plugin_const.PENDING_UPDATE])
 
     def __init__(self, conf, registerOpts=True):
         # The registerOpts parameter allows a test to
@@ -1308,10 +1311,10 @@ class iControlDriver(LBaaSBaseDriver):
             if 'provisioning_status' in member:
                 provisioning_status = member['provisioning_status']
 
-                if (provisioning_status == plugin_const.PENDING_CREATE or
-                        provisioning_status == plugin_const.PENDING_UPDATE):
+                if provisioning_status in self.positive_plugin_const_state:
 
-                    if timed_out:
+                    if timed_out and \
+                            provisioning_status != plugin_const.ACTIVE:
                         member['provisioning_status'] = plugin_const.ERROR
                         operating_status = lb_const.OFFLINE
                     else:
@@ -1337,8 +1340,7 @@ class iControlDriver(LBaaSBaseDriver):
         for health_monitor in health_monitors:
             if 'provisioning_status' in health_monitor:
                 provisioning_status = health_monitor['provisioning_status']
-                if (provisioning_status == plugin_const.PENDING_CREATE or
-                        provisioning_status == plugin_const.PENDING_UPDATE):
+                if provisioning_status in self.positive_plugin_const_state:
                         self.plugin_rpc.update_health_monitor_status(
                             health_monitor['id'],
                             plugin_const.ACTIVE,
@@ -1359,8 +1361,7 @@ class iControlDriver(LBaaSBaseDriver):
         for pool in pools:
             if 'provisioning_status' in pool:
                 provisioning_status = pool['provisioning_status']
-                if (provisioning_status == plugin_const.PENDING_CREATE or
-                        provisioning_status == plugin_const.PENDING_UPDATE):
+                if provisioning_status in self.positive_plugin_const_state:
                         self.plugin_rpc.update_pool_status(
                             pool['id'],
                             plugin_const.ACTIVE,
@@ -1380,8 +1381,7 @@ class iControlDriver(LBaaSBaseDriver):
         for listener in listeners:
             if 'provisioning_status' in listener:
                 provisioning_status = listener['provisioning_status']
-                if (provisioning_status == plugin_const.PENDING_CREATE or
-                        provisioning_status == plugin_const.PENDING_UPDATE):
+                if provisioning_status in self.positive_plugin_const_state:
                         self.plugin_rpc.update_listener_status(
                             listener['id'],
                             plugin_const.ACTIVE,
@@ -1405,8 +1405,7 @@ class iControlDriver(LBaaSBaseDriver):
         provisioning_status = loadbalancer.get('provisioning_status',
                                                plugin_const.ERROR)
 
-        if (provisioning_status == plugin_const.PENDING_CREATE or
-                provisioning_status == plugin_const.PENDING_UPDATE):
+        if provisioning_status in self.positive_plugin_const_state:
             if timed_out:
                 operating_status = (lb_const.OFFLINE)
                 if provisioning_status == plugin_const.PENDING_CREATE:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -965,13 +965,12 @@ class iControlDriver(LBaaSBaseDriver):
     @is_connected
     def sync(self, service):
         """Sync service defintion to device"""
-        # plugin_rpc may not be set when unit testing
-        if self.plugin_rpc:
+        # loadbalancer and plugin_rpc may not be set
+        lb_id = service.get('loadbalancer', dict()).get('id', '')
+        if hasattr(self, 'plugin_rpc') and self.plugin_rpc and lb_id:
             # Get the latest service. It may have changed.
-            service = self.plugin_rpc.get_service_by_loadbalancer_id(
-                service['loadbalancer']['id']
-            )
-        if service['loadbalancer']:
+            service = self.plugin_rpc.get_service_by_loadbalancer_id(lb_id)
+        if service.get('loadbalancer', None):
             return self._common_service_handler(service)
         else:
             LOG.debug("Attempted sync of deleted pool")

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+import traceback
+
 from time import time
 
 from oslo_log import log as logging
@@ -63,6 +65,8 @@ class LBaaSBuilder(object):
         self._assure_members(service, all_subnet_hints)
 
         self._assure_pools_deleted(service)
+
+        self._assure_pools_configured(service)
 
         self._assure_listeners_deleted(service)
 
@@ -159,7 +163,33 @@ class LBaaSBuilder(object):
                         self.pool_builder.create_pool(svc, bigips)
                     else:
                         self.pool_builder.update_pool(svc, bigips)
+                except HTTPError as err:
+                    if err.response.status_code != 409:
+                        pool['provisioning_status'] = plugin_const.ERROR
+                        loadbalancer['provisioning_status'] = \
+                            plugin_const.ERROR
+                        raise f5_ex.PoolCreationException(err.message)
+                except Exception as err:
+                    pool['provisioning_status'] = plugin_const.ERROR
+                    loadbalancer['provisioning_status'] = \
+                        plugin_const.ERROR
+                    raise f5_ex.PoolCreationException(str(err))
 
+    def _assure_pools_configured(self, service):
+        if "pools" not in service:
+            return
+
+        pools = service["pools"]
+        loadbalancer = service["loadbalancer"]
+
+        bigips = self.driver.get_config_bigips()
+
+        for pool in pools:
+            if pool['provisioning_status'] != plugin_const.PENDING_DELETE:
+                svc = {"loadbalancer": loadbalancer,
+                       "pool": pool}
+                svc['members'] = self._get_pool_members(service, pool['id'])
+                try:
                     # assign pool name to virtual
                     pool_name = self.service_adapter.init_pool_name(
                         loadbalancer, pool)
@@ -177,6 +207,7 @@ class LBaaSBuilder(object):
                         )
                         raise f5_ex.PoolCreationException(err.message)
                 except Exception as err:
+                    print traceback.format_exc()
                     pool['provisioning_status'] = plugin_const.ERROR
                     loadbalancer['provisioning_status'] = plugin_const.ERROR
                     raise f5_ex.PoolCreationException(err.message)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-import traceback
-
 from time import time
 
 from oslo_log import log as logging
@@ -116,7 +114,7 @@ class LBaaSBuilder(object):
                                   loadbalancer["network_id"],
                                   all_subnet_hints,
                                   False)
-        self._set_status_as_active(loadbalancer)
+        self._set_status_as_active(loadbalancer, force=True)
 
     def _assure_listeners_created(self, service):
         if 'listeners' not in service:
@@ -230,7 +228,6 @@ class LBaaSBuilder(object):
                         )
                         raise f5_ex.PoolCreationException(err.message)
                 except Exception as err:
-                    print traceback.format_exc()
                     pool['provisioning_status'] = plugin_const.ERROR
                     loadbalancer['provisioning_status'] = plugin_const.ERROR
                     raise f5_ex.PoolCreationException(err.message)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -106,10 +106,14 @@ class LBaaSBuilder(object):
         bigips = self.driver.get_config_bigips()
 
         for listener in listeners:
+            pool = self.get_pool_by_id(
+                service, listener.get('default_pool_id', None))
             svc = {"loadbalancer": loadbalancer,
                    "listener": listener,
                    "networks": networks}
 
+            if pool:
+                svc['pool'] = pool
             if listener['provisioning_status'] == plugin_const.PENDING_UPDATE:
                 try:
                     self.listener_builder.update_listener(svc, bigips)
@@ -378,7 +382,7 @@ class LBaaSBuilder(object):
 
     @staticmethod
     def get_pool_by_id(service, pool_id):
-        if "pools" in service:
+        if pool_id and "pools" in service:
             pools = service["pools"]
             for pool in pools:
                 if pool["id"] == pool_id:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -116,7 +116,7 @@ class LBaaSBuilder(object):
                                   loadbalancer["network_id"],
                                   all_subnet_hints,
                                   False)
-        self._set_status_as_active(loadbalancer, force=True)
+        self._set_status_as_active(loadbalancer)
 
     def _assure_listeners_created(self, service):
         if 'listeners' not in service:
@@ -136,31 +136,28 @@ class LBaaSBuilder(object):
 
             if pool:
                 svc['pool'] = pool
-            if self._is_not_pending_delete(listener) and \
-                    self._is_not_error(listener):
-                if listener['provisioning_status'] == \
-                        plugin_const.PENDING_UPDATE:
-                    try:
-                        self.listener_builder.update_listener(svc, bigips)
-                    except Exception as err:
-                        loadbalancer['provisioning_status'] = \
-                            plugin_const.ERROR
-                        listener['provisioning_status'] = plugin_const.ERROR
-                        raise f5_ex.VirtualServerUpdateException(err.message)
+            if listener['provisioning_status'] == \
+                    plugin_const.PENDING_UPDATE:
+                try:
+                    self.listener_builder.update_listener(svc, bigips)
+                except Exception as err:
+                    loadbalancer['provisioning_status'] = \
+                        plugin_const.ERROR
+                    listener['provisioning_status'] = plugin_const.ERROR
+                    raise f5_ex.VirtualServerUpdateException(err.message)
 
-                elif listener['provisioning_status'] != \
-                        plugin_const.PENDING_DELETE:
-                    try:
-                        # create_listener() will do an update if VS exists
-                        self.listener_builder.create_listener(svc, bigips)
-                        listener['operating_status'] = \
-                            svc['listener']['operating_status']
-                    except Exception as err:
-                        loadbalancer['provisioning_status'] = \
-                            plugin_const.ERROR
-                        listener['provisioning_status'] = plugin_const.ERROR
-                        raise f5_ex.VirtualServerCreationException(err.message)
-                self._set_status_as_active(listener)
+            elif self._is_not_pending_delete(listener):
+                try:
+                    # create_listener() will do an update if VS exists
+                    self.listener_builder.create_listener(svc, bigips)
+                    listener['operating_status'] = \
+                        svc['listener']['operating_status']
+                except Exception as err:
+                    loadbalancer['provisioning_status'] = \
+                        plugin_const.ERROR
+                    listener['provisioning_status'] = plugin_const.ERROR
+                    raise f5_ex.VirtualServerCreationException(err.message)
+            self._set_status_as_active(listener)
 
     def _assure_pools_created(self, service):
         if "pools" not in service:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -114,7 +114,7 @@ class LBaaSBuilder(object):
                                   loadbalancer["network_id"],
                                   all_subnet_hints,
                                   False)
-        self._set_status_as_active(loadbalancer, force=True)
+        self._set_status_as_active(loadbalancer)
 
     def _assure_listeners_created(self, service):
         if 'listeners' not in service:
@@ -209,6 +209,10 @@ class LBaaSBuilder(object):
                 svc = {"loadbalancer": loadbalancer,
                        "pool": pool}
                 svc['members'] = self._get_pool_members(service, pool['id'])
+
+                # get associated listener for pool
+                self.add_listener_pool(service, svc)
+
                 try:
                     # assign pool name to virtual
                     pool_name = self.service_adapter.init_pool_name(

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -64,10 +64,11 @@ class ServiceModelAdapter(object):
         return (network_id in self.conf.common_network_ids)
 
     def init_pool_name(self, loadbalancer, pool):
-        name = self.prefix + pool["id"]
+        partition = self.get_folder_name(loadbalancer['tenant_id'])
+        name = self.prefix + pool["id"] if pool else ''
 
         return {"name": name,
-                "partition": self.get_folder_name(loadbalancer['tenant_id'])}
+                "partition": partition}
 
     def get_resource_description(self, resource):
         if not isinstance(resource, dict):
@@ -87,6 +88,7 @@ class ServiceModelAdapter(object):
     def get_virtual(self, service):
         listener = service["listener"]
         loadbalancer = service["loadbalancer"]
+        pool = service.get('pool', None)
 
         listener["use_snat"] = self.snat_mode()
         if listener["use_snat"] and self.snat_count() > 0:
@@ -98,7 +100,7 @@ class ServiceModelAdapter(object):
             listener["session_persistence"] = \
                 service["pool"]["session_persistence"]
 
-        vip = self._map_virtual(loadbalancer, listener)
+        vip = self._map_virtual(loadbalancer, listener, pool=pool)
         self._add_bigip_items(listener, vip)
         return vip
 
@@ -109,9 +111,14 @@ class ServiceModelAdapter(object):
 
     def _init_virtual_name(self, loadbalancer, listener):
         name = self.prefix + listener["id"]
+        partition = self.get_folder_name(loadbalancer['tenant_id'])
 
-        return {"name": name,
-                "partition": self.get_folder_name(loadbalancer['tenant_id'])}
+        return dict(name=name, partition=partition)
+
+    def _init_virtual_name_with_pool(self, loadbalancer, listener, pool=None):
+        vip = self._init_virtual_name(loadbalancer, listener)
+        vip['pool'] = self.init_pool_name(loadbalancer, pool)
+        return vip
 
     def get_traffic_group(self, service):
         tg = "traffic-group-local-only"
@@ -126,12 +133,8 @@ class ServiceModelAdapter(object):
         listener = service["listener"]
         loadbalancer = service["loadbalancer"]
         pool = service["pool"]
-        vip = self._init_virtual_name(loadbalancer, listener)
-        if "default_pool_id" in listener:
-            p = self.init_pool_name(loadbalancer, pool)
-            vip["pool"] = p["name"]
-        else:
-            vip["pool"] = ""
+        vip = self._init_virtual_name_with_pool(
+            loadbalancer, listener, pool=pool)
 
         return vip
 
@@ -339,8 +342,9 @@ class ServiceModelAdapter(object):
         else:
             return 'round-robin'
 
-    def _map_virtual(self, loadbalancer, listener):
-        vip = self._init_virtual_name(loadbalancer, listener)
+    def _map_virtual(self, loadbalancer, listener, pool=None):
+        vip = self._init_virtual_name_with_pool(
+            loadbalancer, listener, pool=pool)
 
         vip["description"] = self.get_resource_description(listener)
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager_LbaasAgentManager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager_LbaasAgentManager.py
@@ -1,0 +1,261 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import datetime
+import pytest
+
+from mock import Mock
+from mock import patch
+
+import f5_openstack_agent.lbaasv2.drivers.bigip.agent_manager as agent_manager
+import f5_openstack_agent.lbaasv2.drivers.bigip.plugin_rpc as plugin_rpc
+
+
+class TestLbaasAgentManagerConstructor(object):
+    @staticmethod
+    @pytest.fixture
+    @patch('f5_openstack_agent.lbaasv2.drivers.bigip.agent_manager.'
+           'LbaasAgentManager.__init__')
+    def fully_mocked_target(init):
+        """Get target instance without executing the init
+
+        This object method is meant to grab the fully blessed instance of the
+        target code without running any of the target.Target.__init__() method.
+        This can be handy in that the returned target instance is completely
+        free of the __init__'s tasks or overhead.
+
+        SHOULD ONLY BE USED FOR COMPLETELY-ISOLATING WHITE-BOX TESTS!
+        """
+        init.return_value = None
+        cfg = Mock()
+        return agent_manager.LbaasAgentManager(cfg)
+
+    @staticmethod
+    @pytest.fixture
+    @patch('f5_openstack_agent.lbaasv2.drivers.bigip.plugin_rpc.'
+           'LBaaSv2PluginRPC.__init__')
+    def fully_mocked_plugin_rpc(init):
+        init.return_value = None
+        return plugin_rpc.LBaaSv2PluginRPC()
+
+
+class TestLbaasAgentManagerBuilder(TestLbaasAgentManagerConstructor):
+    @pytest.fixture
+    def mock_logger(self, request):
+        request.addfinalizer(self.cleanup)
+        logger = Mock()
+        self.freeze_logger = agent_manager.LOG
+        self.logger = logger
+        agent_manager.LOG = logger
+
+    def cleanup(self):
+        agent_manager.LOG = self.freeze_logger
+
+
+class TestLbaasAgentManager(TestLbaasAgentManagerBuilder):
+    def test_sync_state(self, fully_mocked_target, mock_logger):
+        target = fully_mocked_target
+
+        def populate_target(target):
+            known_services, owned_services = set(), set(['foo'])
+            loadbalancers = tuple([])
+            lb_ids = set()
+            target._all_vs_known_services = \
+                Mock(return_value=tuple([known_services, owned_services]))
+            target._get_remote_loadbalancers = \
+                Mock(return_value=tuple([loadbalancers, lb_ids]))
+            target._validate_services = \
+                Mock()
+            target._refresh_pending_services = Mock(return_value=True)
+            target.agent_host = 'host'
+
+        def positive_path(target, logger):
+            populate_target(target)
+            expected = True
+            assert expected == target.sync_state()
+            assert logger.debug.call_count == 3
+            assert logger.error.called
+            assert target._all_vs_known_services.call_count == 2
+            assert target._get_remote_loadbalancers.call_count == 2
+            target._get_remote_loadbalancers.assert_any_call(
+                'get_active_loadbalancers', host=target.agent_host)
+            target._get_remote_loadbalancers.assert_called_with(
+                'get_all_loadbalancers', host=target.agent_host)
+            target._validate_services.assert_called_once_with(set([]))
+            target._refresh_pending_services.assert_called_once_with()
+
+        def negative_path(target, logger):
+            populate_target(target)
+            expected = 'expected'
+            target._get_remote_loadbalancers.side_effect = \
+                AssertionError(expected)
+            assert target.sync_state() is False
+            logger.error.assert_called_once()
+            assert expected in logger.error.call_args[0][0]
+
+        positive_path(target, self.logger)
+        self.logger.error.reset_mock()
+        self.logger.debug.reset_mock()
+        positive_path(target, self.logger)
+
+    def test_all_vs_known_services(self, fully_mocked_target):
+        target = fully_mocked_target
+        service = Mock()
+        service2 = Mock()
+        lb_id = 'lb_id'
+        lb_id2 = lb_id + '2'
+        agent_host = 'agent_host'
+        target.agent_host = agent_host
+        service.agent_host = agent_host
+        services = tuple([tuple([lb_id, service]), tuple([lb_id2, service2])])
+        target.cache = Mock()
+        target.cache.services.iteritems = Mock(return_value=services)
+        result0, result1 = target._all_vs_known_services()
+        assert set([lb_id, lb_id2]) == result0
+        assert set([lb_id]) == result1
+
+    def test_refresh_pending_services(self, fully_mocked_target):
+
+        def setup_target(target):
+            now = datetime.datetime.now()
+            timeout_val = now - datetime.timedelta(seconds=800)
+            target.agent_host = 'host'
+            lb_id = 'lb_id'
+            lb_id2 = lb_id + '2'
+            lb_id3 = lb_id + '3'
+            lb, lb2, lb3 = Mock(), Mock(), Mock()
+            pending_lbs = tuple([[lb, lb2, lb3], set([lb_id, lb_id2, lb_id3])])
+            target.conf = Mock()
+            target.conf.f5_pending_services_timeout = 100
+            target._get_remote_loadbalancers = Mock(return_value=pending_lbs)
+            target.pending_services = dict(lb_id=timeout_val, lb_id3=now)
+            target.refresh_service = Mock(return_value=True)
+            target.service_timeout = Mock()
+
+        def all_paths(target):
+            setup_target(target)
+            target._refresh_pending_services()
+            target.service_timeout.assert_called_once_with('lb_id')
+            assert 'lb_id' not in target.pending_services
+            assert 'lb_id2' in target.pending_services
+            assert 'lb_id3' in target.pending_services
+
+        all_paths(fully_mocked_target)
+
+    def test_get_remote_loadbalancers(self, fully_mocked_target):
+
+        def setup_target(target):
+            lbs = [dict(lb_id=0), dict(lb_id=2)]
+            expected = tuple([tuple(lbs), set([0, 2])])
+            call_method = Mock(return_value=lbs)
+            target.plugin_rpc = Mock()
+            target.plugin_rpc.call_method = call_method
+            return expected
+
+        def full_path(target):
+            expected = setup_target(fully_mocked_target)
+            host = 'host'
+            assert target._get_remote_loadbalancers('call_method', host=host) \
+                == expected
+
+        full_path(fully_mocked_target)
+
+    def test_validate_services(self, fully_mocked_target):
+        lb_ids = [1, 2]
+        fully_mocked_target.cache = Mock()
+        fully_mocked_target.cache.get_by_loadbalancer_id.side_effect = \
+            [True, False]
+        fully_mocked_target.validate_service = Mock()
+        fully_mocked_target._validate_services(lb_ids)
+        fully_mocked_target.validate_service.assert_called_once_with(2)
+        fully_mocked_target.cache.get_by_loadbalancer_id.assert_any_call(1)
+        fully_mocked_target.cache.get_by_loadbalancer_id.assert_called_with(2)
+        assert fully_mocked_target.cache.get_by_loadbalancer_id.call_count == 2
+
+    def test_lbb_sync_state(self, fully_mocked_target,
+                            fully_mocked_plugin_rpc, mock_logger):
+        """A limited black-box functional test for testing flow of sync_state
+
+        This test method is only meant to orchestrate a functional flow test
+        across a common agent_manager.LbaasAgentManager.sync_state() runtime
+        might actually look like through the many methods it runs through.
+
+        This is also testing very basic, peripheral orchestration events that
+        are expected to occur.
+
+        Where the limits of the test are...
+            Since this is a black-box standalone test, this test does have its
+            limits.  Although it can run in any environment via tox, it cannot
+            touch or be touched by a full openstack system "in the wild".  To
+            fascilitate this, this test is limited to the
+            plugin_rpc.LBaaSv2PluginRPC.__call_rpc_method method call which is
+            heavily mocked as well as the f5_openstack_lbaasv2_driver's code.
+        """
+
+        def setup_test(target, plugin_rpc):
+            host = 'host'
+            now = datetime.datetime.now()
+            timed_out = now + datetime.timedelta(seconds=80)
+            service1 = Mock()
+            service1.agent_host = host
+            service2 = Mock()
+            service2.agent_host = 'host1'
+            # manage target's base...
+            target.pending_services = {1: timed_out}
+            target.conf = Mock()
+            target.conf.f5_pending_services_timeout = 30
+            target.cache = Mock()
+            target.agent_host = host
+            target.cache.get_by_loadbalancer_id.side_effect = \
+                [False, True, True]
+            target.cache.services = dict(one=service1, two=service2)
+            # modify plugin_rpc items...
+            target.plugin_rpc = plugin_rpc
+            target.plugin_rpc.env = Mock()
+            target.plugin_rpc.context = Mock()
+            target.plugin_rpc.topic = Mock()
+            target.plugin_rpc._client = Mock()
+            target.plugin_rpc.host = host
+            caller = Mock()
+            target.plugin_rpc._client.prepare.return_value = caller
+            caller.call.side_effect = \
+                [tuple([dict(lb_id=1), dict(lb_id=2)]),
+                 tuple([dict(lb_id=1), dict(lb_id=2)]), service1,
+                 tuple([dict(lb_id=1), dict(lb_id=3)]), service1, service1,
+                 service1]
+            # target.validate_service protections...
+            target.lbdriver = Mock()
+            target.lbdriver.service_exists.return_value = True
+            return caller.call
+
+        def functional_path(target, plugin_rpc):
+            rpc_call = setup_test(target, plugin_rpc)
+            assert target.sync_state()
+            assert 3 in target.pending_services
+            assert isinstance(target.pending_services[3], datetime.datetime)
+            assert rpc_call.call_count == 7
+            call_args_list = rpc_call.call_args_list
+            call_order = ['get_active_loadbalancers',
+                          'get_all_loadbalancers',
+                          'get_service_by_loadbalancer_id',
+                          'get_pending_loadbalancers',
+                          'get_service_by_loadbalancer_id',
+                          'get_service_by_loadbalancer_id',
+                          'get_service_by_loadbalancer_id']
+            for cnt, expected_call in enumerate(call_order):
+                assert expected_call in call_args_list[cnt][0]
+
+        functional_path(fully_mocked_target, fully_mocked_plugin_rpc)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager_LbaasAgentManager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager_LbaasAgentManager.py
@@ -326,5 +326,16 @@ class TestLbaasAgentManager(TestLbaasAgentManagerBuilder):
             assert svc['loadbalancer']['provisioning_status'] == \
                 plugin_const.ERROR
 
+        def awkward_network_nest(target, svc):
+            reset_svc(svc)
+            svc['loadbalancer']['provisioning_status'] = plugin_const.ERROR
+            listener_id = svc['listeners'][0]['id']
+            awkward = {listener_id: svc['listeners'][0]}
+            svc['listeners'][0] = awkward
+            assert target.has_provisioning_status_of_error(svc)
+            assert svc['loadbalancer']['provisioning_status'] == \
+                plugin_const.ERROR
+
         negative_list_scenario(target_class, svc)
         negative_dict_scenario(target_class, svc)
+        awkward_network_nest(target_class, svc)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_icontrol_driver.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+import uuid
+
+from mock import Mock
+from mock import patch
+
+import neutron.plugins.common.constants as plugin_const
+import neutron_lbaas.services.loadbalancer.constants as lb_const
+
+import f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver as target_mod
+
+
+class TestiControlDriverConstructor(object):
+    @staticmethod
+    @pytest.fixture
+    @patch('f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver.'
+           'iControlDriver.__init__')
+    def fully_mocked_target(init):
+        init.return_value = None
+        return target_mod.iControlDriver()
+
+    @staticmethod
+    @pytest.fixture
+    def new_uuid():
+        return str(uuid.uuid4())
+
+    @staticmethod
+    @pytest.fixture
+    def dumb_svc_obj(new_uuid):
+        return dict(id=new_uuid)
+
+    @classmethod
+    def basic_svc_obj(cls, provisioning_status):
+        svc_obj = dict(provisioning_status=provisioning_status)
+        svc_obj.update(cls.dumb_svc_obj(cls.new_uuid()))
+        return svc_obj
+
+    @classmethod
+    @pytest.fixture
+    def svc_obj_pending_update(cls):
+        svc_obj = cls.basic_svc_obj(plugin_const.PENDING_UPDATE)
+        return [svc_obj]
+
+    @classmethod
+    @pytest.fixture
+    def svc_obj_pending_create(cls):
+        svc_obj = cls.basic_svc_obj(plugin_const.PENDING_CREATE)
+        return [svc_obj]
+
+    @classmethod
+    @pytest.fixture
+    def svc_obj_active(cls):
+        svc_obj = cls.basic_svc_obj(plugin_const.ACTIVE)
+        return [svc_obj]
+
+    @staticmethod
+    @pytest.fixture
+    def positive_svc_obj_list(svc_obj_pending_update,
+                              svc_obj_pending_create, svc_obj_active):
+        positive_members = svc_obj_pending_update
+        positive_members.extend(svc_obj_pending_create)
+        positive_members.extend(svc_obj_active)
+        return positive_members
+
+    @staticmethod
+    def mock_targets_plugin_rpc(target):
+        target.plugin_rpc = Mock()
+
+
+class TestiControlDriverBuilder(TestiControlDriverConstructor):
+    @pytest.fixture
+    def mock_logger(self, request):
+        self.freeze_logger = target_mod.LOG
+        request.addfinalizer(self.cleanup)
+        logger = Mock()
+        self.logger = logger
+        target_mod.LOG = logger
+        return logger
+
+    def cleanup(self):
+        target_mod.LOG = self.freeze_logger
+
+    def update_svc_obj_positive_path(self, target, positive_svc_objs, method,
+                                     test_method, timeout=None):
+        self.mock_targets_plugin_rpc(target)
+        method = getattr(target, method)
+        if isinstance(timeout, type(None)):
+            method(positive_svc_objs)
+        else:
+            method(positive_svc_objs, timeout)
+        if test_method:
+            called_method = getattr(target.plugin_rpc, test_method)
+            args_list = called_method.call_args_list
+            assert called_method.call_count == 3
+            all(map(lambda x: lb_const.ONLINE in x, args_list))
+
+
+class TestiControlDriver(TestiControlDriverBuilder):
+    def test_update_member_status(self, fully_mocked_target,
+                                  positive_svc_obj_list):
+        self.update_svc_obj_positive_path(
+            fully_mocked_target, positive_svc_obj_list,
+            '_update_member_status', 'update_member_status', timeout=False)
+
+    def test_update_health_monitor_status(self, fully_mocked_target,
+                                          positive_svc_obj_list):
+        self.update_svc_obj_positive_path(
+            fully_mocked_target, positive_svc_obj_list,
+            '_update_health_monitor_status', 'update_health_monitor_status')
+
+    def test_update_pool_status(self, fully_mocked_target,
+                                positive_svc_obj_list):
+        self.update_svc_obj_positive_path(
+            fully_mocked_target, positive_svc_obj_list,
+            '_update_pool_status', 'update_pool_status')
+
+    def test_update_listener_status(self, fully_mocked_target,
+                                    positive_svc_obj_list):
+        for svc_obj in positive_svc_obj_list:
+            svc_obj['operating_status'] = Mock()
+        svc = dict(listeners=positive_svc_obj_list)
+        self.update_svc_obj_positive_path(
+            fully_mocked_target, svc, '_update_listener_status',
+            'update_listener_status')

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_lbaas_builder.py
@@ -14,15 +14,15 @@
 # limitations under the License.
 #
 
-from f5_openstack_agent.lbaasv2.drivers.bigip import exceptions as f5_ex
-from f5_openstack_agent.lbaasv2.drivers.bigip.lbaas_builder import \
-    LBaaSBuilder
-
 import copy
 import mock
 import pytest
 
 from requests import HTTPError
+
+from f5_openstack_agent.lbaasv2.drivers.bigip import exceptions as f5_ex
+from f5_openstack_agent.lbaasv2.drivers.bigip.lbaas_builder import \
+    LBaaSBuilder
 
 POOL_BLDR_PATH = 'f5_openstack_agent.lbaasv2.drivers.bigip.pool_service.' \
     'PoolServiceBuilder'
@@ -48,6 +48,21 @@ def service():
             u"sni_containers": [],
             u"tenant_id": u"980e3f914f3e40359c3c2d9470fb2e8a"
         }],
+        u'networks': {
+            'cdf1eb6d-9b17-424a-a054-778f3d3a5490': {
+                "admin_state_up": True,
+                "id": 'cdf1eb6d-9b17-424a-a054-778f3d3a5490',
+                'mtu': 0,
+                'name': 'foodogzoo',
+                'provider:network_type': 'vxlan',
+                'provider:physical_network': None,
+                'router:external': False,
+                'shared': True,
+                'status': 'ACTIVE',
+                'subnets': ['4dc7caad-f9a9-4050-914e-b60eb6cf8ef7'],
+                'tenant_id': '980e3f914f3e40359c3c2d9470fb2e8a',
+                'vlan_transparent': None,
+                     }},
         u'loadbalancer': {
             u'admin_state_up': True,
             u'description': u'',

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_lbaas_builder.py
@@ -279,7 +279,6 @@ class TestLbaasBuilder(object):
         svc['pools'][0]['provisioning_status'] = 'PENDING_CREATE'
         builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
         builder._assure_pools_created(svc)
-        builder._assure_pools_configured(svc)
         assert mock_create.called
         assert not mock_update.called
 
@@ -292,7 +291,6 @@ class TestLbaasBuilder(object):
         svc['pools'][0]['provisioning_status'] = 'PENDING_UPDATE'
         builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
         builder._assure_pools_created(svc)
-        builder._assure_pools_configured(svc)
         assert mock_update.called
         assert not mock_create.called
 
@@ -305,7 +303,6 @@ class TestLbaasBuilder(object):
         svc['pools'][0]['provisioning_status'] = 'ACTIVE'
         builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
         builder._assure_pools_created(svc)
-        builder._assure_pools_configured(svc)
         assert not mock_update.called
         assert mock_create.called
 
@@ -318,6 +315,5 @@ class TestLbaasBuilder(object):
         svc['pools'][0]['provisioning_status'] = 'ERROR'
         builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
         builder._assure_pools_created(svc)
-        builder._assure_pools_configured(svc)
         assert not mock_update.called
         assert mock_create.called

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_lbaas_builder.py
@@ -18,7 +18,13 @@ import copy
 import mock
 import pytest
 
+from mock import Mock
+from mock import patch
 from requests import HTTPError
+
+import neutron.plugins.common.constants
+
+import f5_openstack_agent.lbaasv2.drivers.bigip.lbaas_builder
 
 from f5_openstack_agent.lbaasv2.drivers.bigip import exceptions as f5_ex
 from f5_openstack_agent.lbaasv2.drivers.bigip.lbaas_builder import \
@@ -165,7 +171,90 @@ class MockHTTPErrorResponse409(HTTPError):
         self.status_code = 409
 
 
-class TestLbaasBuilder(object):
+class MockHTTPErrorResponse500(HTTPError):
+    def __init__(self):
+        self.status_code = 500
+
+
+class TestLBaaSBuilderConstructor(object):
+    @staticmethod
+    @pytest.fixture
+    @patch('f5_openstack_agent.lbaasv2.drivers.bigip.lbaas_builder.'
+           'LBaaSBuilder.__init__')
+    def fully_mocked_target(init):
+        init.return_value = None
+        return LBaaSBuilder()
+
+    @staticmethod
+    @pytest.fixture
+    def assure_mocked_target(fully_mocked_target):
+        target = fully_mocked_target
+        target.driver = Mock()
+        target.service_adapter = Mock()
+        target._update_subnet_hints = Mock()
+        target._set_status_as_active = Mock()
+        return target
+
+
+class TestLbaasBuilder(TestLBaaSBuilderConstructor):
+    neutron_plugin_constants = neutron.plugins.common.constants
+
+    @pytest.fixture
+    def create_self(self, request):
+        request.addfinalizer(self.teardown)
+        conf = Mock()
+        driver = Mock()
+        listener_service = \
+            str('f5_openstack_agent.lbaasv2.drivers.bigip.listener_service.'
+                'ListenerServiceBuilder')
+        pool_service = \
+            str('f5_openstack_agent.lbaasv2.drivers.bigip.pool_service.'
+                'PoolServiceBuilder')
+        mock_listener = Mock()
+        mock_pool = Mock()
+        self.log = Mock()
+        f5_openstack_agent.lbaasv2.drivers.bigip.lbaas_builder.LOG = self.log
+        with patch(listener_service, mock_listener, create=True):
+            with patch(pool_service, mock_pool, create=True):
+                self.builder = LBaaSBuilder(conf, driver)
+        self.listener_service = mock_listener
+        self.pool_service = mock_pool
+
+    def teardown(self):
+        neutron.plugins.common.constants = self.neutron_plugin_constants
+        if hasattr(self, 'log'):
+            f5_openstack_agent.lbaasv2.drivers.bigip.lbaas_builder.LOG = \
+                self.log
+
+    def test_assure_listeners_created(self, service, create_self):
+        listener = service.get('listeners')[0]
+        target = self.builder
+        service['listener'] = listener
+        # Test UPDATE case
+        target.listener_builder = Mock()
+        target.listener_builder.update_listener.side_effect = AssertionError
+        target.get_pool_by_id = Mock()
+        pool = target.get_pool_by_id()
+        expected_bigips = target.driver.get_config_bigips()
+        listener['provisioning_status'] = \
+            neutron.plugins.common.constants.PENDING_UPDATE
+        with pytest.raises(f5_ex.VirtualServerUpdateException):
+            target._assure_listeners_created(service)
+        expected_svc = dict(loadbalancer=service['loadbalancer'], pool=pool,
+                            listener=listener, networks=service['networks'])
+        target.listener_builder.update_listener.assert_called_once_with(
+            expected_svc, expected_bigips)
+        target.get_pool_by_id.call_argsassert_called_once()
+        # Test non-DELETE case
+        listener.pop('operating_status')
+        listener['provisioning_status'] = \
+            neutron.plugins.common.constants.PENDING_CREATE
+        create_listener = target.listener_builder.create_listener
+        target.listener_builder.create_listener.clear_mock()
+        with pytest.raises(f5_ex.VirtualServerCreationException):
+            target._assure_listeners_created(service)
+        create_listener.assert_called_once_with(expected_svc, expected_bigips)
+
     """Test _assure_members in LBaaSBuilder"""
     @pytest.mark.skip(reason="Test is not valid without port object")
     def test_assure_members_deleted(self, service):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_lbaas_builder.py
@@ -279,6 +279,7 @@ class TestLbaasBuilder(object):
         svc['pools'][0]['provisioning_status'] = 'PENDING_CREATE'
         builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
         builder._assure_pools_created(svc)
+        builder._assure_pools_configured(svc)
         assert mock_create.called
         assert not mock_update.called
 
@@ -291,6 +292,7 @@ class TestLbaasBuilder(object):
         svc['pools'][0]['provisioning_status'] = 'PENDING_UPDATE'
         builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
         builder._assure_pools_created(svc)
+        builder._assure_pools_configured(svc)
         assert mock_update.called
         assert not mock_create.called
 
@@ -303,6 +305,7 @@ class TestLbaasBuilder(object):
         svc['pools'][0]['provisioning_status'] = 'ACTIVE'
         builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
         builder._assure_pools_created(svc)
+        builder._assure_pools_configured(svc)
         assert not mock_update.called
         assert mock_create.called
 
@@ -315,5 +318,6 @@ class TestLbaasBuilder(object):
         svc['pools'][0]['provisioning_status'] = 'ERROR'
         builder = LBaaSBuilder(mock.MagicMock(), mock.MagicMock())
         builder._assure_pools_created(svc)
+        builder._assure_pools_configured(svc)
         assert not mock_update.called
         assert mock_create.called

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_listener_services.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_listener_services.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+
+from mock import Mock
+
+import neutron.plugins.common.constants as plugin_const
+
+import f5_openstack_agent.lbaasv2.drivers.bigip.listener_service \
+    as listener_service
+import f5_openstack_agent.lbaasv2.drivers.bigip.resource_helper
+
+import f5_openstack_agent.lbaasv2.drivers.bigip.test.conftest as ct
+
+
+class TestListenerServiceBuilderConstructor(ct.TestingWithServiceConstructor):
+    # contains all quick service-related creation items
+    # contains all static, class, or non-intelligent object manipulations
+    @staticmethod
+    def creation_mode_listener(svc, listener):
+        svc['listener'] = listener
+        svc['listener']['provisioning_status'] = plugin_const.PENDING_CREATE
+        svc['loadbalancer']['provisioning_status'] = \
+            plugin_const.PENDING_UPDATE
+
+
+class TestListenerServiceBuilderBuilder(TestListenerServiceBuilderConstructor):
+    # contains all intelligence-based memory manipulations
+    @pytest.fixture
+    def mock_logger(self, request):
+        self.freeze_log = listener_service.LOG
+        listener_service.LOG = Mock()
+        request.addfinalizer(self.cleanup)
+        return listener_service.LOG
+
+    def cleanup(self):
+        listener_service.LOG = self.freeze_log
+        f5_openstack_agent.lbaasv2.drivers.bigip.resource_helper.\
+            BigIPResourceHelper = self.freeze_resource_bigip
+        f5_openstack_agent.lbaasv2.drivers.bigip.resource_helper.\
+            ResourceType = self.freeze_resource_type
+
+    def clean_svc_with_listener(self):
+        svc = self.service_with_network(self.new_id())
+        svc = self.service_with_subnet(self.new_id(), svc)
+        svc = self.service_with_loadbalancer(self.new_id(), svc)
+        svc = self.service_with_listener(self.new_id(), svc)
+        return svc
+
+    @pytest.fixture
+    def target(self, mock_logger):
+        resource_bigip = Mock()
+        resource_type = Mock()
+        self.freeze_resource_bigip = \
+            f5_openstack_agent.lbaasv2.drivers.bigip.resource_helper.\
+            BigIPResourceHelper
+        self.freeze_resource_type = \
+            f5_openstack_agent.lbaasv2.drivers.bigip.resource_helper.\
+            ResourceType
+        f5_openstack_agent.lbaasv2.drivers.bigip.resource_helper.\
+            BigIPResourceHelper = resource_bigip
+        f5_openstack_agent.lbaasv2.drivers.bigip.resource_helper.\
+            ResourceType = resource_type
+        self.resource_bigip = resource_bigip
+        self.resource_type = resource_type
+        self.logger = mock_logger
+        service_adapter = Mock()
+        cert_maanger = Mock()
+        parent_ssl_profile = Mock()
+        parent_ssl_profile.__str__ = Mock(return_value='parent_ssl_profile')
+        target = listener_service.ListenerServiceBuilder(
+            service_adapter, cert_maanger,
+            parent_ssl_profile=parent_ssl_profile)
+        return target
+
+
+class TestListenerServiceBuilder(TestListenerServiceBuilderBuilder):
+    def test__init__(self, target):
+        self.logger.debug.assert_called_once()
+        assert 'ListenerServiceBuilder' in self.logger.debug.call_args[0][0]
+        assert isinstance(target.cert_manager, Mock)
+        assert isinstance(target.parent_ssl_profile, Mock)
+        assert isinstance(target.parent_ssl_profile, Mock)
+        self.resource_bigip.assert_called_once_with(
+            self.resource_type.virtual)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_virtual_address.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_virtual_address.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
+import f5_openstack_agent.lbaasv2.drivers.bigip.virtual_address as \
+    virtual_address
+
 from f5_openstack_agent.lbaasv2.drivers.bigip.service_adapter import \
     ServiceModelAdapter
 from f5_openstack_agent.lbaasv2.drivers.bigip.virtual_address import \
@@ -21,27 +24,36 @@ from f5_openstack_agent.lbaasv2.drivers.bigip.virtual_address import \
 
 import mock
 import pytest
+import uuid
 
 
-class TestVirtualAddress(object):
+class TestVirtualAddressConstructor(object):
 
+    @staticmethod
     @pytest.fixture
-    def bigip(self):
-        bigip = mock.MagicMock()
+    def bigip():
+        bigip = mock.Mock()
 
         return bigip
 
+    @staticmethod
     @pytest.fixture
-    def adapter(self):
+    def adapter():
         conf = mock.MagicMock()
         conf.environment_prefix = "Project"
 
         return ServiceModelAdapter(conf)
 
+    @staticmethod
     @pytest.fixture
-    def loadbalancer(self):
+    def new_uuid():
+        return str(uuid.uuid4())
+
+    @staticmethod
+    @pytest.fixture
+    def loadbalancer(new_uuid):
         loadbalancer = {"name": "lb1",
-                        "tenant_id": "123456789",
+                        "tenant_id": new_uuid,
                         "id": "loadbalancer_id",
                         "traffic_group": "traffic-group-local-only",
                         "vip_address": "192.168.100.5",
@@ -49,13 +61,72 @@ class TestVirtualAddress(object):
 
         return loadbalancer
 
-    def test_create_va(self, bigip, adapter, loadbalancer):
+    @staticmethod
+    @pytest.fixture
+    def virtual_address(adapter, loadbalancer):
         va = VirtualAddress(adapter, loadbalancer)
+        return va
 
-        assert(va is not None)
-        assert(va.name == "Project_loadbalancer_id")
-        assert(va.partition == "Project_123456789")
-        assert(va.address == "192.168.100.5")
-        assert(va.traffic_group == "traffic-group-local-only")
-        assert(va.description == "lb1:")
-        assert(va.enabled == "yes")
+
+class TestVirtualAddressBuilder(TestVirtualAddressConstructor):
+
+    @pytest.fixture
+    def mock_logger(self, request):
+        logger = mock.Mock()
+        request.addfinalizer(self.cleanup)
+        self.freeze_log = virtual_address.LOG
+        virtual_address.LOG = logger
+        self.logger = logger
+        return logger
+
+    def cleanup(self):
+        virtual_address.LOG = self.freeze_log
+
+    @staticmethod
+    def mock_scenario(virtual_address):
+        m_remote = mock.Mock()
+        m_remote.address = virtual_address.model().get('address')
+        virtual_address.load = mock.Mock(return_value=m_remote)
+        virtual_address.virtual_address = mock.Mock()
+        virtual_address.delete = mock.Mock(side_effect=AssertionError)
+        virtual_address.create = mock.Mock(return_value=mock.Mock())
+        virtual_address.virtual_address.update = \
+            mock.Mock(return_value=mock.Mock())
+
+
+class TestVirtualAddress(TestVirtualAddressBuilder):
+
+    def test_create_va(self, virtual_address):
+        assert(virtual_address is not None)
+        assert(virtual_address.name == "Project_loadbalancer_id")
+        assert virtual_address.partition.startswith(
+            virtual_address.adapter.prefix)
+        assert(virtual_address.address == "192.168.100.5")
+        assert(virtual_address.traffic_group == "traffic-group-local-only")
+        assert(virtual_address.description == "lb1:")
+        assert(virtual_address.enabled == "yes")
+
+    def test_iwb_update(self, virtual_address, bigip, mock_logger):
+        def negative_delete_path(virtual_address, bigip):
+            TestVirtualAddressBuilder.mock_scenario(virtual_address)
+            virtual_address.load.return_value.address = 'xx.xx.xx.xx'
+            result = virtual_address.update(bigip)
+            virtual_address.load.assert_called_once_with(bigip)
+            assert result is virtual_address.create.return_value
+            self.logger.error.assert_called_once()
+
+        def positive_update(virtual_address, bigip):
+            TestVirtualAddressBuilder.mock_scenario(virtual_address)
+            result = virtual_address.update(bigip)
+            expected = virtual_address.model()
+            expected.pop('address')
+            virtual_address.virtual_address.update.assert_called_once_with(
+                bigip, expected)
+            assert result is \
+                virtual_address.virtual_address.update.return_value
+
+        negative_delete_path(virtual_address, bigip)
+        virtual_address = \
+            self.virtual_address(self.adapter(),
+                                 self.loadbalancer(self.new_uuid()))
+        positive_update(virtual_address, bigip)

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer_opflex.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer_opflex.py
@@ -55,8 +55,8 @@ def test_create_delete_basic_lb(bigip, services, icd_config, icontrol_driver):
     assert not bigip.folder_exists(folder)
 
     # Create the loadbalancer
-    retval = icontrol_driver._common_service_handler(service)
-    assert retval
+    result = icontrol_driver._common_service_handler(service)
+    assert result
 
     # Assert that update loadbalancer status was not called
     assert fake_rpc.get_call_count('update_loadbalancer_status') == 0


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
This bug addresses several bugs.

#### What's this change do?
Provides the bugfixes as suggested in [this PR](https://github.com/F5Networks/f5-openstack-agent/pull/763) up to [this commit](https://github.com/F5Networks/f5-openstack-agent/pull/763/commits/45e6488088a01bdb0509a9fb96838c19003f0996).

#### Where should the reviewer start?
This is the cherrypick order:
* 6242965802b14146be3edc86d80242c44ac458d1
* a3dee1c77b303c93d58b84e741cd88771f1aea03
* 1f3c3f55f4c80c8222a244ed9baf1b8628176480
* 317a2bf5ba8ce564ff1dc5131bc96d410045b0d0
* b089f7645b1ac7bf42e4102a54b52343155dee0a
* 8f284a571340367283e58a9a4f84acdcc3185e6f
* 60a3ccb42439a9128843f351ca9997ed7d8aa09a
* 1cb674eab06fa1d70fb31af35f1c1925621c8b55
* 309382949d062615a35226cd8c1e093ae07f0e74
* 8d178d943e2af107686acba5b49fcc5b2bdc574c

These each come from the mitaka_external_gateway_mode branch.

#### Any background context?
See above for content source.  This is a refactor and port-back to liberty.