### PR TITLE
fix path name for test runs

### DIFF
--- a/.coveragerc_bak
+++ b/.coveragerc_bak
@@ -1,9 +1,0 @@
-[run]
-source = 
-    */lbaasv2/*
-
-[paths]
-source =
-    f5_openstack_agent/
-    /usr/lib/python2.7/site-packages/f5_openstack_agent/
-    /root/devenv/f5-openstack-agent/f5_openstack_agent/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,8 +10,7 @@ pipeline {
                 + " -v /srv/mesos/trtl/results:/home/jenkins/results" \
                 + " -v /srv/nfs:/testlab" \
                 + " -v /var/run/docker.sock:/var/run/docker.sock" \
-                + " --env-file /srv/kubernetes/infra/jenkins-worker/config/openstack-test.env" \
-                + " -u jenkins"
+                + " --env-file /srv/kubernetes/infra/jenkins-worker/config/openstack-test.env"
         }
     }
     options {

--- a/f5_openstack_agent/.coveragerc_bak
+++ b/f5_openstack_agent/.coveragerc_bak
@@ -1,5 +1,0 @@
-[run]
-include =
-    lbaasv2/*
-
-data_file = .coverage.f5-openstack-agent.unit

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -188,7 +188,8 @@ run_neutronless_loadbalancer_tests:
 		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
 		--autolog-outputdir $${GUMBALLS_PROJECT} \
 		--autolog-session $${GUMBALLS_SESSION} \
-	    ./test/functional/neutronless/loadbalancer/
+	    ./test/functional/neutronless/loadbalancer/ && \
+	mv $(PROJDIR)/.coverage $(PROJDIR)/.coverage_$@
 	
 
 run_neutronless_listener_tests:
@@ -198,7 +199,8 @@ run_neutronless_listener_tests:
 		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
 		--autolog-outputdir $${GUMBALLS_PROJECT} \
 		--autolog-session $${GUMBALLS_SESSION} \
-	    ../test/functional/neutronless/listener/
+	    ./test/functional/neutronless/listener/ && \
+	mv $(PROJDIR)/.coverage $(PROJDIR)/.coverage_$@
 
 run_neutronless_member_tests:
 	@echo executing $@
@@ -207,7 +209,8 @@ run_neutronless_member_tests:
 		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
 		--autolog-outputdir $${GUMBALLS_PROJECT} \
 		--autolog-session $${GUMBALLS_SESSION} \
-	    ../test/functional/neutronless/member/
+	    ./test/functional/neutronless/member/ && \
+	mv $(PROJDIR)/.coverage $(PROJDIR)/.coverage_$@
 
 run_neutronless_pool_tests:
 	@echo executing $@
@@ -216,7 +219,8 @@ run_neutronless_pool_tests:
 		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
 		--autolog-outputdir $${GUMBALLS_PROJECT} \
 		--autolog-session $${GUMBALLS_SESSION} \
-	    ../test/functional/neutronless/pool/
+	    ./test/functional/neutronless/pool/ && \
+	mv $(PROJDIR)/.coverage $(PROJDIR)/.coverage_$@
 
 run_neutronless_esd_tests:
 	@echo executing $@
@@ -225,7 +229,8 @@ run_neutronless_esd_tests:
 		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
 		--autolog-outputdir $${GUMBALLS_PROJECT} \
 		--autolog-session $${GUMBALLS_SESSION} \
-	    ../test/functional/neutronless/esd/
+	    ./test/functional/neutronless/esd/ && \
+	mv $(PROJDIR)/.coverage $(PROJDIR)/.coverage_$@
 
 run_singlebigip_tests:
 	@echo executing $@
@@ -234,7 +239,8 @@ run_singlebigip_tests:
 		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
 		--autolog-outputdir $${GUMBALLS_PROJECT} \
 		--autolog-session $${GUMBALLS_SESSION} \
-	    ../test/functional/singlebigip/
+	    ./test/functional/singlebigip/ && \
+	mv $(PROJDIR)/.coverage $(PROJDIR)/.coverage_$@
 
 # disconnected_singlebigip_f5-openstack-agent_liberty-12_1_1-overcloud
 run_disconnected_service_tests:
@@ -246,7 +252,8 @@ run_disconnected_service_tests:
 		--symbols $(MAKEFILE_DIR)/testenv_symbols/testenv_symbols.json \
 		--autolog-outputdir $${GUMBALLS_PROJECT} \
 		--autolog-session $${GUMBALLS_SESSION} \
-	    ../test/functional/neutronless/disconnected_service/
+	    ./test/functional/neutronless/disconnected_service/ && \
+	mv $(PROJDIR)/.coverage $(PROJDIR)/.coverage_$@
 
 run_smoke_tests:
 	@echo executing $@

--- a/systest/scripts/init_env.sh
+++ b/systest/scripts/init_env.sh
@@ -10,10 +10,12 @@ export PROJ_HASH=$(git rev-parse HEAD | xargs)
 
 job_dirname="${CI_PROGRAM}.${CI_PROJECT}.${CI_BRANCH}.${JOB_BASE_NAME}"
 export build_dirname="${JOB_BASE_NAME}-${BUILD_ID}"
-covsuffix="${CI_PROJECT}/${CI_BRANCH}/${PROJ_HASH}/${build_dirname}"
-export COVERAGERESULTS=/testlab/openstack/testresults/coverage/${covsuffix}
 export CI_RESULTS_DIR="/home/jenkins/results/${job_dirname}/${build_dirname}"
 export CI_BUILD_SUMMARY="${CI_RESULTS_DIR}/ci-build.yaml"
+
+# The following logic enables combined coverage reporting.
+covsuffix="${CI_PROJECT}/${CI_BRANCH}/${PROJ_HASH}/${build_dirname}"
+export COVERAGERESULTS=/testlab/openstack/testresults/coverage/${covsuffix}
 export PYTHONDONTWRITEBYTECODE=1
 
 # - source this job's environment variables

--- a/systest/scripts/record_results.sh
+++ b/systest/scripts/record_results.sh
@@ -7,4 +7,4 @@ set -ex
 mkdir -p $CI_RESULTS_DIR/
 cp -r $WORKSPACE/systest/test_results/* $CI_RESULTS_DIR/
 mkdir -p ${COVERAGERESULTS}
-mv .coverage ${COVERAGERESULTS}
+mv .coverage* ${COVERAGERESULTS}

--- a/test/.coveragerc_bak
+++ b/test/.coveragerc_bak
@@ -1,3 +1,0 @@
-[run]
-include =
-    */f5_openstack_agent/*

--- a/test/functional/neutronless/disconnected_service/.coveragerc_bak
+++ b/test/functional/neutronless/disconnected_service/.coveragerc_bak
@@ -1,5 +1,0 @@
-[run]
-include =
-    */f5-openstack-agent/*
-
-data_file = .coverage.f5-openstack-agent.l2adjacent


### PR DESCRIPTION
@ssorenso 

Fixes: #972

I believe this is the reason (or reasons) the nightly run failed.

When developing I was only testing against a single test run "run_neutronless_loadbalancer".  I forgot to modify the paths for the other test runs when I reverted from dev code to prod code.   DRYer code would make this kind of error less likely.

Additionally I note that the complete set of parameters passed to the test runner is _NOT_ specified in the Jenkinsfile.

This commit fixes two errors:
   1) each py.test invocation was overwriting .coverage from the previous invocation.
   2) py.test paths were incorrect

I also remove unused "coveragerc_bak" files.
