### PR TITLE
Add support for deleting orphaned objects

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -438,6 +438,9 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                 self.needs_resync = True
             if self.sync_state():
                 self.needs_resync = True
+            # clean any objects orphaned on devices and persist configs
+            if self.clean_orphaned_objects_and_save_device_config():
+                self.needs_resync = True
 
     @periodic_task.periodic_task(spacing=30)
     def update_operating_status(self, context):
@@ -646,12 +649,113 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
         self.cache.remove_by_loadbalancer_id(lb_id)
 
     @log_helpers.log_method_call
-    def remove_orphans(self, all_loadbalancers):
+    def clean_orphaned_objects_and_save_device_config(self):
+
+        cleaned = False
 
         try:
-            self.lbdriver.remove_orphans(all_loadbalancers)
-        except Exception as exc:
-            LOG.error("Exception: removing orphans: %s" % exc.message)
+            #
+            # Global cluster refresh tasks
+            #
+
+            global_agent = self.plugin_rpc.get_clusterwide_agent(
+                self.conf.environment_prefix,
+                self.conf.environment_group_number
+            )
+
+            if 'host' not in global_agent:
+                LOG.debug('No global agent available to sync config')
+                return True
+
+            if global_agent['host'] == self.agent_host:
+                LOG.debug('this agent is the global config agent')
+                # We're the global agent perform global cluster tasks
+
+                # There are two independent types of service objects
+                # the LBaaS implments: 1) loadbalancers + 2) pools
+                # We will first try to find any orphaned pools
+                # and remove them.
+
+                # Ask the BIG-IP for all deployed pools not associated
+                # to a virtual server
+                pools = self.lbdriver.get_all_deployed_pools()
+                if pools:
+                    # Ask Neutron for the status of all deployed pools
+                    pools_status = self.plugin_rpc.validate_pools_state(
+                        list(pools.keys()))
+                    LOG.debug('validated_pools_state returned: %s'
+                              % pools_status)
+                    for poolid in pools_status:
+                        # If the pool status is Unknown, it no longer exists
+                        # in Neutron and thus should be removed from BIG-IP
+                        if pools_status[poolid] in ['Unknown']:
+                            LOG.debug('removing orphaned pool %s' % poolid)
+                            self.lbdriver.purge_orphaned_pool(
+                                tenant_id=pools[poolid]['tenant_id'],
+                                pool_id=poolid,
+                                hostnames=pools[poolid]['hostnames'])
+
+                # Ask the BIG-IP for all deployed listeners to make
+                # sure we are not orphaning listeners which have
+                # valid loadbalancers in a OK state
+                listeners = self.lbdriver.get_all_deployed_listeners()
+                if listeners:
+                    # Ask Neutron for the status of all deployed listeners
+                    listener_status = self.plugin_rpc.validate_listeners_state(
+                        list(listeners.keys()))
+                    LOG.debug('validated_pools_state returned: %s'
+                              % listener_status)
+                    for listenerid in listener_status:
+                        # If the pool status is Unknown, it no longer exists
+                        # in Neutron and thus should be removed from BIG-IP
+                        if listener_status[listenerid] in ['Unknown']:
+                            LOG.debug('removing orphaned listener %s'
+                                      % listenerid)
+                            self.lbdriver.purge_orphaned_listener(
+                                tenant_id=listeners[listenerid]['tenant_id'],
+                                listener_id=listenerid,
+                                hostnames=listeners[listenerid]['hostnames'])
+
+                # Ask BIG-IP for all deployed loadbalancers (virtual addresses)
+                lbs = self.lbdriver.get_all_deployed_loadbalancers(
+                    purge_orphaned_folders=True)
+                if lbs:
+                    # Ask Neutron for the status of each deployed loadbalancer
+                    lbs_status = self.plugin_rpc.validate_loadbalancers_state(
+                        list(lbs.keys()))
+                    LOG.debug('validate_loadbalancers_state returned: %s'
+                              % lbs_status)
+                    lbs_removed = False
+                    for lbid in lbs_status:
+                        # If the statu is Unknown, it no longer exists
+                        # in Neutron and thus should be removed from the BIG-IP
+                        if lbs_status[lbid] in ['Unknown']:
+                            LOG.debug('removing orphaned loadbalancer %s'
+                                      % lbid)
+                            # This will remove pools, virtual servers and
+                            # virtual addresses
+                            self.lbdriver.purge_orphaned_loadbalancer(
+                                tenant_id=lbs[lbid]['tenant_id'],
+                                loadbalancer_id=lbid,
+                                hostnames=lbs[lbid]['hostnames'])
+                            lbs_removed = True
+                    if lbs_removed:
+                        # If we have removed load balancers, then scrub
+                        # for tenant folders we can delete because they
+                        # no longer contain loadbalancers.
+                        self.lbdriver.get_all_deployed_loadbalancers(
+                            purge_orphaned_folders=True)
+
+            else:
+                LOG.debug('the global agent is %s' % (global_agent['host']))
+                return True
+            # serialize config and save to disk
+            self.lbdriver.backup_configuration()
+        except Exception as e:
+            LOG.error("Unable to sync state: %s" % e.message)
+            cleaned = True
+
+        return cleaned
 
     @log_helpers.log_method_call
     def create_loadbalancer(self, context, loadbalancer, service):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/cluster_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/cluster_manager.py
@@ -61,8 +61,12 @@ class ClusterManager(object):
 
     def save_config(self, bigip):
         try:
-            c = bigip.tm.sys.config
-            c.save()
+            # c = bigip.tm.sys.config
+            # c.save()
+            bigip.tm.util.bash.exec_cmd(
+                command='run',
+                utilCmdArgs="-c 'tmsh save sys config'"
+            )
         except HTTPError as err:
             LOG.error("Error saving config."
                       "Repsponse status code: %s. Response "

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -26,6 +26,8 @@ from eventlet import greenthread
 from time import strftime
 from time import time
 
+from requests import HTTPError
+
 from neutron.common.exceptions import InvalidConfigurationOption
 from neutron.common.exceptions import NeutronException
 from neutron.plugins.common import constants as plugin_const
@@ -750,6 +752,192 @@ class iControlDriver(LBaaSBaseDriver):
             bigip.assured_tenant_snat_subnets = {}
             bigip.assured_gateway_subnets = []
 
+    @serialized('get_all_deployed_loadbalancers')
+    @is_connected
+    def get_all_deployed_loadbalancers(self, purge_orphaned_folders=False):
+        LOG.debug('getting all deployed loadbalancers on BIG-IPs')
+        deployed_lb_dict = {}
+        for bigip in self.get_all_bigips():
+            folders = self.system_helper.get_folders(bigip)
+            for folder in folders:
+                tenant_id = folder[len(self.service_adapter.prefix):]
+                if str(folder).startswith(self.service_adapter.prefix):
+                    resource = resource_helper.BigIPResourceHelper(
+                        resource_helper.ResourceType.virtual_address)
+                    deployed_lbs = resource.get_resources(bigip, folder)
+                    if deployed_lbs:
+                        for lb in deployed_lbs:
+                            lb_id = lb.name[len(self.service_adapter.prefix):]
+                            if lb_id in deployed_lb_dict:
+                                deployed_lb_dict[lb_id][
+                                    'hostnames'].append(bigip.hostname)
+                            else:
+                                deployed_lb_dict[lb_id] = {
+                                    'id': lb_id,
+                                    'tenant_id': tenant_id,
+                                    'hostnames': [bigip.hostname]
+                                }
+                    else:
+                        # delay to assure we are not in the tenant creation
+                        # process before a virtual address is created.
+                        greenthread.sleep(10)
+                        deployed_lbs = resource.get_resources(bigip, folder)
+                        if deployed_lbs:
+                            for lb in deployed_lbs:
+                                lb_id = lb.name[
+                                    len(self.service_adapter.prefix):]
+                                deployed_lb_dict[lb_id] = \
+                                    {'id': lb_id, 'tenant_id': tenant_id}
+                        else:
+                            # Orphaned folder!
+                            if purge_orphaned_folders:
+                                try:
+                                    self.system_helper.purge_folder_contents(
+                                        bigip, folder)
+                                    self.system_helper.purge_folder(
+                                        bigip, folder)
+                                    LOG.error('orphaned folder %s on %s' %
+                                              (folder, bigip.hostname))
+                                except Exception as exc:
+                                    LOG.error('error purging folder %s: %s' %
+                                              (folder, str(exc)))
+        return deployed_lb_dict
+
+    @serialized('get_all_deployed_listeners')
+    @is_connected
+    def get_all_deployed_listeners(self):
+        LOG.debug('getting all deployed listeners on BIG-IPs')
+        deployed_virtual_dict = {}
+        for bigip in self.get_all_bigips():
+            folders = self.system_helper.get_folders(bigip)
+            for folder in folders:
+                tenant_id = folder[len(self.service_adapter.prefix):]
+                if str(folder).startswith(self.service_adapter.prefix):
+                    resource = resource_helper.BigIPResourceHelper(
+                        resource_helper.ResourceType.virtual)
+                    deployed_listeners = resource.get_resources(bigip, folder)
+                    if deployed_listeners:
+                        for virtual in deployed_listeners:
+                            virtual_id = \
+                                virtual.name[len(self.service_adapter.prefix):]
+                            if virtual_id in deployed_virtual_dict:
+                                deployed_virtual_dict[virtual_id][
+                                    'hostnames'].append(bigip.hostname)
+                            else:
+                                deployed_virtual_dict[virtual_id] = {
+                                    'id': virtual_id,
+                                    'tenant_id': tenant_id,
+                                    'hostnames': [bigip.hostname]
+                                }
+        return deployed_virtual_dict
+
+    @serialized('get_all_deployed_pools')
+    @is_connected
+    def get_all_deployed_pools(self):
+        LOG.debug('getting all deployed pools on BIG-IPs')
+        deployed_pool_dict = {}
+        for bigip in self.get_all_bigips():
+            folders = self.system_helper.get_folders(bigip)
+            for folder in folders:
+                tenant_id = folder[len(self.service_adapter.prefix):]
+                if str(folder).startswith(self.service_adapter.prefix):
+                    resource = resource_helper.BigIPResourceHelper(
+                        resource_helper.ResourceType.pool)
+                    deployed_pools = resource.get_resources(bigip, folder)
+                    if deployed_pools:
+                        for pool in deployed_pools:
+                            pool_id = \
+                                pool.name[len(self.service_adapter.prefix):]
+                            if pool_id in deployed_pool_dict:
+                                deployed_pool_dict[pool_id][
+                                    'hostnames'].append(bigip.hostname)
+                            else:
+                                deployed_pool_dict[pool_id] = {
+                                    'id': pool_id,
+                                    'tenant_id': tenant_id,
+                                    'hostnames': [bigip.hostname]
+                                }
+        return deployed_pool_dict
+
+    @serialized('purge_orphaned_pool')
+    @is_connected
+    def purge_orphaned_pool(self, tenant_id=None, pool_id=None, hostnames=[]):
+        for bigip in self.get_all_bigips():
+            if bigip.hostname in hostnames:
+                try:
+                    pool_name = self.service_adapter.prefix + pool_id
+                    partition = self.service_adapter.prefix + tenant_id
+                    pool = resource_helper.BigIPResourceHelper(
+                        resource_helper.ResourceType.pool).load(
+                            bigip, pool_name, partition)
+                    pool.delete()
+                except HTTPError as err:
+                    if err.response.status_code == 404:
+                        LOG.debug('pool %s not on BIG-IP %s.'
+                                  % (pool_id, bigip.hostname))
+                except Exception as exc:
+                    LOG.exception('Exception purging pool %s' % str(exc))
+
+    @serialized('purge_orphaned_pool')
+    @is_connected
+    def purge_orphaned_listener(
+            self, tenant_id=None, listener_id=None, hostnames=[]):
+        for bigip in self.get_all_bigips():
+            if bigip.hostname in hostnames:
+                try:
+                    listener_name = self.service_adapter.prefix + listener_id
+                    partition = self.service_adapter.prefix + tenant_id
+                    listener = resource_helper.BigIPResourceHelper(
+                        resource_helper.ResourceType.virtual).load(
+                            bigip, listener_name, partition)
+                    listener.delete()
+                except HTTPError as err:
+                    if err.response.status_code == 404:
+                        LOG.debug('listener %s not on BIG-IP %s.'
+                                  % (listener_id, bigip.hostname))
+                except Exception as exc:
+                    LOG.exception('Exception purging listener %s' % str(exc))
+
+    @serialized('purge_orphaned_loadbalancer')
+    @is_connected
+    def purge_orphaned_loadbalancer(self, tenant_id=None,
+                                    loadbalancer_id=None, hostnames=[]):
+        for bigip in self.get_all_bigips():
+            if bigip.hostname in hostnames:
+                try:
+                    va_name = self.service_adapter.prefix + loadbalancer_id
+                    partition = self.service_adapter.prefix + tenant_id
+                    va = resource_helper.BigIPResourceHelper(
+                        resource_helper.ResourceType.virtual_address).load(
+                            bigip, va_name, partition)
+                    # get virtual services (listeners)
+                    # referencing this virtual address
+                    vses = resource_helper.BigIPResourceHelper(
+                        resource_helper.ResourceType.virtual).get_resources(
+                            bigip, partition)
+                    vs_dest_compare = '/' + partition + '/' + va.name
+                    for vs in vses:
+                        if str(vs.destination).startswith(vs_dest_compare):
+                            if hasattr(vs, 'pool'):
+                                pool = resource_helper.BigIPResourceHelper(
+                                    resource_helper.ResourceType.pool).load(
+                                    bigip, os.path.basename(vs.pool),
+                                    partition)
+                                vs.delete()
+                                pool.delete()
+                            else:
+                                vs.delete()
+                    resource_helper.BigIPResourceHelper(
+                        resource_helper.ResourceType.virtual_address).delete(
+                            bigip, va_name, partition)
+                except HTTPError as err:
+                    if err.response.status_code == 404:
+                        LOG.debug('loadbalancer %s not on BIG-IP %s.'
+                                  % (loadbalancer_id, bigip.hostname))
+                except Exception as exc:
+                    LOG.exception('Exception purging loadbalancer %s'
+                                  % str(exc))
+
     @serialized('create_loadbalancer')
     @is_connected
     def create_loadbalancer(self, loadbalancer, service):
@@ -890,23 +1078,6 @@ class iControlDriver(LBaaSBaseDriver):
 
         finally:
             return lb_stats
-
-    @serialized('remove_orphans')
-    def remove_orphans(self, all_loadbalancers):
-        """Remove out-of-date configuration on big-ips """
-        existing_tenants = []
-        existing_lbs = []
-        for loadbalancer in all_loadbalancers:
-            existing_tenants.append(loadbalancer['tenant_id'])
-            existing_lbs.append(loadbalancer['lb_id'])
-
-        for bigip in self.get_all_bigips():
-            bigip.pool.purge_orphaned_pools(existing_lbs)
-        for bigip in self.get_all_bigips():
-            bigip.system.purge_orphaned_folders_contents(existing_tenants)
-
-        for bigip in self.get_all_bigips():
-            bigip.system.purge_orphaned_folders(existing_tenants)
 
     def fdb_add(self, fdb):
         # Add (L2toL3) forwarding database entries

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py
@@ -60,16 +60,20 @@ class LBaaSBaseDriver(object):
         """Get Stats for a loadbalancer Service """
         raise NotImplementedError()
 
+    def get_all_deployed_loadbalancers(self, purge_orphaned_folders=True):
+        """Get all Loadbalancers defined on devices"""
+        raise NotImplemented
+
+    def purge_orphaned_loadbalancer(self, tenant_id, loadbalancer_id):
+        """Remove all loadbalancers without references in Neutron"""
+        raise NotImplemented
+
     def exists(self, service):
         """Check If LBaaS Service is Defined on Driver Target """
         raise NotImplementedError()
 
     def sync(self, service):
         """Force Sync a Service on Driver Target """
-        raise NotImplementedError()
-
-    def remove_orphans(self, known_services):
-        """Remove Unknown Service from Driver Target """
         raise NotImplementedError()
 
     def create_vip(self, vip, service):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
@@ -221,6 +221,36 @@ class ListenerServiceBuilder(object):
         else:
             self.remove_session_persistence(service, bigips)
 
+    def delete_orphaned_listeners(self, service, bigips):
+        if 'listeners' not in service:
+            ip_address = service['loadbalancer']['vip_address']
+            if str(ip_address).endswith('%0'):
+                ip_address = ip_address[:-2]
+            for bigip in bigips:
+                vses = bigip.tm.ltm.virtuals.get_collection()
+                for vs in vses:
+                    if str(vs.destination).startswith(ip_address):
+                        vs.delete()
+        else:
+            listeners = service['listeners']
+            for listener in listeners:
+                svc = {"loadbalancer": service["loadbalancer"],
+                       "listener": listener}
+                vip = self.service_adapter.get_virtual(svc)
+                for bigip in bigips:
+                    vses = bigip.tm.ltm.virtuals.get_collection()
+                    orphaned = True
+                    for vs in vses:
+                        if vip['destination'] == vs.destination:
+                            if vip['name'] == vs.name:
+                                orphaned = False
+                        else:
+                            orphaned = False
+                    if orphaned:
+                        for vs in vses:
+                            if vip['name'] == vs.name:
+                                vs.delete()
+
     def _add_profile(self, vip, profile_name, bigip, context='all'):
         """Add profile to virtual server instance. Assumes Common.
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
@@ -406,6 +406,79 @@ class LBaaSv2PluginRPC(object):
         return service
 
     @log_helpers.log_method_call
+    def validate_loadbalancers_state(self, loadbalancers):
+        """Get the status of a list of loadbalancers IDs in Neutron"""
+        service = {}
+        try:
+            service = self._call(
+                self.context,
+                self._make_msg('validate_loadbalancers_state',
+                               loadbalancers=loadbalancers,
+                               host=self.host),
+                topic=self.topic
+            )
+        except messaging.MessageDeliveryFailure:
+            LOG.error("agent->plugin RPC exception caught: ",
+                      "validate_loadbalancers_state")
+
+        return service
+
+    @log_helpers.log_method_call
+    def validate_listeners_state(self, listeners):
+        """Get the status of a list of listener IDs in Neutron"""
+        service = {}
+        try:
+            service = self._call(
+                self.context,
+                self._make_msg('validate_listeners_state',
+                               listeners=listeners,
+                               host=self.host),
+                topic=self.topic
+            )
+        except messaging.MessageDeliveryFailure:
+            LOG.error("agent->plugin RPC exception caught: ",
+                      "validate_listeners_state")
+
+        return service
+
+    @log_helpers.log_method_call
+    def validate_pools_state(self, pools):
+        """Get the status of a list of pools IDs in Neutron"""
+        service = {}
+        try:
+            service = self._call(
+                self.context,
+                self._make_msg('validate_pools_state',
+                               pools=pools,
+                               host=self.host),
+                topic=self.topic
+            )
+        except messaging.MessageDeliveryFailure:
+            LOG.error("agent->plugin RPC exception caught: ",
+                      "validate_pool_state")
+
+        return service
+
+    @log_helpers.log_method_call
+    def get_clusterwide_agent(self, env, group):
+        """Determin which agent performce global tasks for the cluster"""
+        service = {}
+        try:
+            service = self._call(
+                self.context,
+                self._make_msg('get_clusterwide_agent',
+                               env=env,
+                               group=group,
+                               host=self.host),
+                topic=self.topic
+            )
+        except messaging.MessageDeliveryFailure:
+            LOG.error("agent->plugin RPC exception caught: ",
+                      "scrub_dead_agents")
+
+        return service
+
+    @log_helpers.log_method_call
     def get_all_loadbalancers(self, env=None, group=None, host=None):
         """Retrieve a list of loadbalancers in Neutron."""
         loadbalancers = []

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
@@ -185,6 +185,37 @@ class PoolServiceBuilder(object):
                 member.pop("address", None)
                 m.modify(**member)
 
+    def delete_orphaned_members(self, service, bigips):
+        pool = self.service_adapter.get_pool(service)
+        srv_members = service['members']
+        part = pool['partition']
+        for bigip in bigips:
+            p = self.pool_helper.load(bigip, name=pool['name'], partition=part)
+            deployed_members = p.members_s.get_collection()
+            for dm in deployed_members:
+                orphaned = True
+                for sm in srv_members:
+                    svc = {"loadbalancer": service["loadbalancer"],
+                           "pool": service["pool"],
+                           "member": sm}
+                    member = self.service_adapter.get_member(svc)
+                    if member['name'] == dm.name:
+                        orphaned = False
+                if orphaned:
+                    node_name = dm.address
+                    dm.delete()
+                    try:
+                        self.node_helper.delete(bigip,
+                                                name=urllib.quote(node_name),
+                                                partition=part)
+                    except HTTPError as err:
+                        # Possilbe error if node is shared with another member.
+                        # If so, ignore the error.
+                        if err.response.status_code == 400:
+                            LOG.debug(err.message)
+                        else:
+                            raise
+
     def _get_monitor_helper(self, service):
         monitor_type = self.service_adapter.get_monitor_type(service)
         if monitor_type == "HTTPS":


### PR DESCRIPTION
Issues:
Fixes #954

Problem: Need to add support for deleting orphaned objects.

Analysis:
Implements a periodic task that will scan the BIG-IP for objects
owned by the agent that are not present in the Neutron DB and
deletes them from the BIG-IP.

Tests:
Manual

