### PR TITLE
Enhance test code to support coverage reporting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,8 +43,8 @@ pipeline {
                     ssh-add
 
                     # - run tests
-                    echo ${JOB_BASE_NAME%$_smoke*}
-                    make -C systest ${JOB_BASE_NAME%$_smoke*}
+                    echo ${JOB_BASE_NAME%$*_smoke*}
+                    make -C systest ${JOB_BASE_NAME%$*_smoke*}
 
                     # - record results only if it's not a smoke test
                     if [ -n "${JOB_BASE_NAME##*smoke*}" ]; then

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,10 +52,4 @@ pipeline {
                 '''}
             }
     }
-    post {
-        always {
-            // cleanup workspace
-            dir("${env.WORKSPACE}") { deleteDir() }
-        }
-    }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
         docker {
             label "docker"
             registryUrl "https://docker-registry.pdbld.f5net.com"
-            image "openstack-test-agenttestrunner-prod/mitaka:latest"
+            image "openstack-test-agenttestrunner-zancas/mitaka:latest"
             args "-v /etc/localtime:/etc/localtime:ro" \
                 + " -v /srv/mesos/trtl/results:/home/jenkins/results" \
                 + " -v /srv/nfs:/testlab" \
@@ -43,7 +43,8 @@ pipeline {
                     ssh-add
 
                     # - run tests
-                    make -C systest $JOB_BASE_NAME
+                    echo ${JOB_BASE_NAME%$_smoke*}
+                    make -C systest ${JOB_BASE_NAME%$_smoke*}
 
                     # - record results only if it's not a smoke test
                     if [ -n "${JOB_BASE_NAME##*smoke*}" ]; then

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,8 +43,7 @@ pipeline {
                     ssh-add
 
                     # - run tests
-                    echo ${JOB_BASE_NAME%$*_smoke*}
-                    make -C systest ${JOB_BASE_NAME%$*_smoke*}
+                    make -C systest ${JOB_BASE_NAME}
 
                     # - record results only if it's not a smoke test
                     if [ -n "${JOB_BASE_NAME##*smoke*}" ]; then

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -155,13 +155,13 @@ run_overcloud_smoke_tests:
 #    singlebigip_f5-openstack-agent_liberty-12.1.1-overcloud
 setup_singlebigip_tests:
 	@echo executing $@
-	echo running testenv create with stack name $${TESTENV_NAME} && \
+	echo running testenv create with stack name $${TESTENV_NAME}_$${TIMESTAMP} && \
 	echo DEVICEVERSION && \
 	echo $${!DEVICEVERSION} && \
 	echo TESTENV_CONF: && \
 	echo $${TESTENV_CONF} && \
 	source /home/jenkins/openrc.sh && \
-	testenv --debug create --name $${TESTENV_NAME} \
+	testenv --debug create --name $${TESTENV_NAME}_$${TIMESTAMP} \
 	        --params bigip_img:$${!DEVICEVERSION} \
 	        $${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${TESTENV_NAME}.log && \
 	sleep 300 && \
@@ -273,7 +273,7 @@ run_smoke_tests:
 
 cleanup_singlebigip:
 	@echo executing $@
-	echo running testenv delete with stack name $${TESTENV_NAME}
+	echo running testenv delete with stack name $${TESTENV_NAME}_$${TIMESTAMP}
 	source /home/jenkins/openrc.sh && \
-	testenv --debug delete --name $${TESTENV_NAME} \
+	testenv --debug delete --name $${TESTENV_NAME}_$${TIMESTAMP} \
 		$${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${TESTENV_NAME}.log

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -160,7 +160,8 @@ setup_singlebigip_tests:
 	source /home/jenkins/openrc.sh && \
 	testenv --debug create --name $${TESTENV_NAME} \
 	        --params bigip_img:$${!DEVICEVERSION} \
-	        $${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${TESTENV_NAME}.log
+	        $${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${TESTENV_NAME}.log && \
+	sleep 30
 
 singlebigip:
 	@echo executing $@
@@ -269,5 +270,6 @@ run_smoke_tests:
 cleanup_singlebigip:
 	@echo executing $@
 	echo running testenv delete with stack name $${TESTENV_NAME}
+	source /home/jenkins/openrc.sh && \
 	testenv --debug delete --name $${TESTENV_NAME} \
 		$${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${TESTENV_NAME}.log

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -156,15 +156,15 @@ run_overcloud_smoke_tests:
 #    singlebigip_f5-openstack-agent_liberty-12.1.1-overcloud
 setup_singlebigip_tests:
 	@echo executing $@
-	echo running testenv create with stack name $${TESTENV_NAME} && \
+	echo running testenv create with stack name $${TESTENV_NAME}a && \
 	echo DEVICEVERSION && \
 	echo $${!DEVICEVERSION} && \
 	echo TESTENV_CONF: && \
 	echo $${TESTENV_CONF} && \
 	source /home/jenkins/openrc.sh && \
-	testenv --debug create --name $${TESTENV_NAME} \
+	testenv --debug create --name $${TESTENV_NAME}a \
 	        --params bigip_img:$${!DEVICEVERSION} \
-	        $${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${TESTENV_NAME}.log && \
+	        $${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${TESTENV_NAME}a.log && \
 	sleep 30
 
 singlebigip:
@@ -273,7 +273,7 @@ run_smoke_tests:
 
 cleanup_singlebigip:
 	@echo executing $@
-	echo running testenv delete with stack name $${TESTENV_NAME}
+	echo running testenv delete with stack name $${TESTENV_NAME}a
 	source /home/jenkins/openrc.sh && \
-	testenv --debug delete --name $${TESTENV_NAME} \
-		$${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${TESTENV_NAME}.log
+	testenv --debug delete --name $${TESTENV_NAME}a \
+		$${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${TESTENV_NAME}a.log

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -163,9 +163,7 @@ setup_singlebigip_tests:
 	source /home/jenkins/openrc.sh && \
 	testenv --debug create --name $${TESTENV_NAME}_$${TIMESTAMP} \
 	        --params bigip_img:$${!DEVICEVERSION} \
-	        $${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${TESTENV_NAME}.log && \
-	sleep 300 && \
-	echo slept 300
+	        $${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${TESTENV_NAME}.log
 
 singlebigip:
 	@echo executing $@

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -164,7 +164,8 @@ setup_singlebigip_tests:
 	testenv --debug create --name $${TESTENV_NAME} \
 	        --params bigip_img:$${!DEVICEVERSION} \
 	        $${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${TESTENV_NAME}.log && \
-	sleep 300
+	sleep 300 && \
+	echo slept 300
 
 singlebigip:
 	@echo executing $@

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -164,7 +164,7 @@ setup_singlebigip_tests:
 	testenv --debug create --name $${TESTENV_NAME} \
 	        --params bigip_img:$${!DEVICEVERSION} \
 	        $${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${TESTENV_NAME}.log && \
-	sleep 30
+	sleep 300
 
 singlebigip:
 	@echo executing $@

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -142,7 +142,6 @@ run_overcloud_smoke_tests:
 	# Run the smoke tests and capture the rc, in case tests fail or error out
 	$(MAKE) -C . setup_singlebigip_tests &&\
 	$(MAKE) -C . smoke ; SMOKE_RC=$$? ;\
-	$(MAKE) -C . cleanup_singlebigip ;\
 	exit $$SMOKE_RC
 
 #### TESTSBYINFRA SECTION

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -155,15 +155,15 @@ run_overcloud_smoke_tests:
 #    singlebigip_f5-openstack-agent_liberty-12.1.1-overcloud
 setup_singlebigip_tests:
 	@echo executing $@
-	echo running testenv create with stack name $${TESTENV_NAME}a && \
+	echo running testenv create with stack name $${TESTENV_NAME} && \
 	echo DEVICEVERSION && \
 	echo $${!DEVICEVERSION} && \
 	echo TESTENV_CONF: && \
 	echo $${TESTENV_CONF} && \
 	source /home/jenkins/openrc.sh && \
-	testenv --debug create --name $${TESTENV_NAME}a \
+	testenv --debug create --name $${TESTENV_NAME} \
 	        --params bigip_img:$${!DEVICEVERSION} \
-	        $${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${TESTENV_NAME}a.log && \
+	        $${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${TESTENV_NAME}.log && \
 	sleep 30
 
 singlebigip:
@@ -272,7 +272,7 @@ run_smoke_tests:
 
 cleanup_singlebigip:
 	@echo executing $@
-	echo running testenv delete with stack name $${TESTENV_NAME}a
+	echo running testenv delete with stack name $${TESTENV_NAME}
 	source /home/jenkins/openrc.sh && \
-	testenv --debug delete --name $${TESTENV_NAME}a \
-		$${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${TESTENV_NAME}a.log
+	testenv --debug delete --name $${TESTENV_NAME} \
+		$${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${TESTENV_NAME}.log

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -157,6 +157,10 @@ run_overcloud_smoke_tests:
 setup_singlebigip_tests:
 	@echo executing $@
 	echo running testenv create with stack name $${TESTENV_NAME} && \
+	echo DEVICEVERSION && \
+	echo $${!DEVICEVERSION} && \
+	echo TESTENV_CONF: && \
+	echo $${TESTENV_CONF} && \
 	source /home/jenkins/openrc.sh && \
 	testenv --debug create --name $${TESTENV_NAME} \
 	        --params bigip_img:$${!DEVICEVERSION} \

--- a/systest/scripts/init_env.sh
+++ b/systest/scripts/init_env.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
+export PYTHONDONTWRITEBYTECODE=1
 
 # - JOB_NAME is provided by Jenkins (eg. "openstack/agent/liberty/unit-tests")
 export CI_PROGRAM=$(echo $JOB_NAME | cut -d "/" -f 1)
@@ -13,15 +14,35 @@ export build_dirname="${JOB_BASE_NAME}-${BUILD_ID}"
 export CI_RESULTS_DIR="/home/jenkins/results/${job_dirname}/${build_dirname}"
 export CI_BUILD_SUMMARY="${CI_RESULTS_DIR}/ci-build.yaml"
 
+# BEGIN COVERAGE REPORTING SECTION
 # The following logic enables combined coverage reporting.
-covsuffix="${CI_PROJECT}/${CI_BRANCH}/${PROJ_HASH}/${build_dirname}"
-export COVERAGERESULTS=/testlab/openstack/testresults/coverage/${covsuffix}
-export PYTHONDONTWRITEBYTECODE=1
+covbase="/testlab/openstack/testresults/coverage/${CI_PROJECT}/${CI_BRANCH}/${PROJ_HASH}"
+mkdir -p ${covbase}
+COVPREFIX="[paths]\n"\
+"sources = \n"\
+"\t${covbase}/source_code\n"\
+"\t/*/f5-openstack-agent"
+
+if [ ! -f "${covbase}/.coveragerc"  ]; then
+    echo ${COVPREFIX} > ${covbase}/.coveragerc
+fi
+if grep --quiet -e"${JOB_BASE_NAME}" ${covbase}/.coveragerc; then
+    echo "Path already mapped."
+else
+    echo "\t/*/${JOB_BASE_NAME}" >> ${covbase}/.coveragerc
+fi
+if [ ! -d "${covbase}/source_code" ]; then
+    TEMPTAG=temptag_${PROJ_HASH}
+    git tag ${TEMPTAG}
+    git clone -b ${TEMPTAG} --depth=1 --single-branch `pwd` ${covbase}/source_code
+fi
+
+export COVERAGERESULTS="${covbase}/${BUILD_ID}_${JOB_BASE_NAME}"
+
+# END COVERAGE REPORTING SECTION
 
 # - source this job's environment variables
 export CI_ENV_FILE=systest/${JOB_BASE_NAME}.env
 if [ -e $CI_ENV_FILE ]; then
     . $CI_ENV_FILE
 fi
-
-# - print env vars

--- a/systest/scripts/unit_test_run_wrapper.sh
+++ b/systest/scripts/unit_test_run_wrapper.sh
@@ -11,5 +11,5 @@ sudo -E docker pull  docker-registry.pdbld.f5net.com/openstack-test-agentunitrun
 sudo -E docker run -u jenkins -v `pwd`:/home/jenkins/f5-openstack-agent \
 docker-registry.pdbld.f5net.com/openstack-test-agentunitrunner-prod/mitaka:latest \
 $STAGENAME $SESSIONLOGDIR
-mkdir -p ${COVERAGERESULTS}-unit
-mv .coverage ${COVERAGERESULTS}-unit
+mkdir -p ${COVERAGERESULTS}
+mv .coverage ${COVERAGERESULTS}/.coverage_unit

--- a/systest/scripts/unit_test_run_wrapper.sh
+++ b/systest/scripts/unit_test_run_wrapper.sh
@@ -11,5 +11,7 @@ sudo -E docker pull  docker-registry.pdbld.f5net.com/openstack-test-agentunitrun
 sudo -E docker run -u jenkins -v `pwd`:/home/jenkins/f5-openstack-agent \
 docker-registry.pdbld.f5net.com/openstack-test-agentunitrunner-prod/mitaka:latest \
 $STAGENAME $SESSIONLOGDIR
-mkdir -p ${COVERAGERESULTS}
-mv .coverage ${COVERAGERESULTS}/.coverage_unit
+if [ -n "${JOB_BASE_NAME##*smoke*}" ]; then
+    mkdir -p ${COVERAGERESULTS}
+    mv .coverage ${COVERAGERESULTS}/.coverage_unit
+fi


### PR DESCRIPTION
@zancas
#### What issues does this address?
Fixes #972 #956 

#### What's this change do?
Adds configuration written durng the `init_env.sh` evaluation that makes it possible to record coverage results in a consistent way.

#### Where should the reviewer start?
Note the structure of the Jenkinsfile, `init_env` is where coverage infrastructure is setup.

During test runs the `unit_test_run_wrapper` stashes the coverage results.  For non-unittests this is already accomplished in the Makefile.

Note, these test results:

http://10.190.25.149:49001/view/all/job/devs/job/za_smoke_four/181/console