### PR TITLE
Enhance test code to support coverage reporting

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
                     ssh-add
 
                     # - run tests
-                    make -C systest $JOB_BASE_NAME
+                    make -C systest ${JOB_BASE_NAME}
 
                     # - record results only if it's not a smoke test
                     if [ -n "${JOB_BASE_NAME##*smoke*}" ]; then

--- a/systest/Makefile
+++ b/systest/Makefile
@@ -156,11 +156,12 @@ run_overcloud_smoke_tests:
 #    singlebigip_f5-openstack-agent_liberty-12.1.1-overcloud
 setup_singlebigip_tests:
 	@echo executing $@
-	echo running testenv create with stack name $${TESTENV_NAME} && \
+	echo running testenv create with stack name $${TESTENV_NAME}_$${TIMESTAMP} && \
 	source /home/jenkins/openrc.sh && \
-	testenv --debug create --name $${TESTENV_NAME} \
+	testenv --debug create --name $${TESTENV_NAME}_$${TIMESTAMP} \
 	        --params bigip_img:$${!DEVICEVERSION} \
-	        $${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${TESTENV_NAME}.log
+	        $${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${TESTENV_NAME}.log && \
+	python ./scripts/poll_for_bigip.py
 
 singlebigip:
 	@echo executing $@
@@ -268,6 +269,7 @@ run_smoke_tests:
 
 cleanup_singlebigip:
 	@echo executing $@
-	echo running testenv delete with stack name $${TESTENV_NAME}
-	testenv --debug delete --name $${TESTENV_NAME} \
+	echo running testenv delete with stack name $${TESTENV_NAME}_$${TIMESTAMP}
+	source /home/jenkins/openrc.sh && \
+	testenv --debug delete --name $${TESTENV_NAME}_$${TIMESTAMP} \
 		$${TESTENV_CONF} &> $(TESTENVLOGDIR)/$@_$${TESTENV_NAME}.log

--- a/systest/scripts/init_env.sh
+++ b/systest/scripts/init_env.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 set -ex
+export PYTHONDONTWRITEBYTECODE=1
 
 # - JOB_NAME is provided by Jenkins (eg. "openstack/agent/liberty/unit-tests")
 export CI_PROGRAM=$(echo $JOB_NAME | cut -d "/" -f 1)
@@ -13,15 +14,35 @@ export build_dirname="${JOB_BASE_NAME}-${BUILD_ID}"
 export CI_RESULTS_DIR="/home/jenkins/results/${job_dirname}/${build_dirname}"
 export CI_BUILD_SUMMARY="${CI_RESULTS_DIR}/ci-build.yaml"
 
+# BEGIN COVERAGE REPORTING SECTION
 # The following logic enables combined coverage reporting.
-covsuffix="${CI_PROJECT}/${CI_BRANCH}/${PROJ_HASH}/${build_dirname}"
-export COVERAGERESULTS=/testlab/openstack/testresults/coverage/${covsuffix}
-export PYTHONDONTWRITEBYTECODE=1
+covbase="/testlab/openstack/testresults/coverage/${CI_PROJECT}/${CI_BRANCH}/${PROJ_HASH}"
+mkdir -p ${covbase}
+COVPREFIX="[paths]\n"\
+"sources = \n"\
+"\t${covbase}/source_code\n"\
+"\t/*/f5-openstack-agent"
+
+if [ ! -f "${covbase}/.coveragerc"  ]; then
+    echo ${COVPREFIX} > ${covbase}/.coveragerc
+fi
+if grep --quiet -e"${JOB_BASE_NAME}" ${covbase}/.coveragerc; then
+    echo "Path already mapped."
+else
+    echo "\t/*/${JOB_BASE_NAME}" >> ${covbase}/.coveragerc
+fi
+if [ ! -d "${covbase}/source_code" ]; then
+    TEMPTAG=temptag_${PROJ_HASH}
+    git tag ${TEMPTAG}
+    git clone -b ${TEMPTAG} --depth=1 --single-branch `pwd` ${covbase}/source_code
+fi
+
+export COVERAGERESULTS="${covbase}/${BUILD_ID}_${JOB_BASE_NAME}"
+
+# END COVERAGE REPORTING SECTION
 
 # - source this job's environment variables
 export CI_ENV_FILE=systest/${JOB_BASE_NAME}.env
 if [ -e $CI_ENV_FILE ]; then
     . $CI_ENV_FILE
 fi
-
-# - print env vars

--- a/systest/scripts/poll_for_bigip.py
+++ b/systest/scripts/poll_for_bigip.py
@@ -5,6 +5,10 @@ import time
 
 from f5.bigip import ManagementRoot
 from icontrol.exceptions import iControlUnexpectedHTTPError
+
+import urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
 SYMBOLS = json.load(open('testenv_symbols/testenv_symbols.json'))
 count = 0
 while True:

--- a/systest/scripts/poll_for_bigip.py
+++ b/systest/scripts/poll_for_bigip.py
@@ -12,7 +12,7 @@ urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 SYMBOLS = json.load(open('testenv_symbols/testenv_symbols.json'))
 count = 0
 while True:
-    print("polling: %s" % count)
+    print("polling for mgmt/tm/sys availability: %s" % count)
     try:
         ManagementRoot(SYMBOLS["bigip_mgmt_ip_public"], "admin", "admin")
         break

--- a/systest/scripts/poll_for_bigip.py
+++ b/systest/scripts/poll_for_bigip.py
@@ -1,0 +1,20 @@
+import json
+import sys
+import time
+
+
+from f5.bigip import ManagementRoot
+from icontrol.exceptions import iControlUnexpectedHTTPError
+SYMBOLS = json.load(open('testenv_symbols/testenv_symbols.json'))
+count = 0
+while True:
+    print("polling: %s" % count)
+    try:
+        ManagementRoot(SYMBOLS["bigip_mgmt_ip_public"], "admin", "admin")
+        break
+    except iControlUnexpectedHTTPError:
+        pass
+    time.sleep(1)
+    count += 1
+    if count > 300:
+        sys.exit(2)

--- a/systest/scripts/unit_test_run_wrapper.sh
+++ b/systest/scripts/unit_test_run_wrapper.sh
@@ -11,5 +11,8 @@ sudo -E docker pull  docker-registry.pdbld.f5net.com/openstack-test-agentunitrun
 sudo -E docker run -u jenkins -v `pwd`:/home/jenkins/f5-openstack-agent \
 docker-registry.pdbld.f5net.com/openstack-test-agentunitrunner-prod/mitaka:latest \
 $STAGENAME $SESSIONLOGDIR
-mkdir -p ${COVERAGERESULTS}-unit
-mv .coverage ${COVERAGERESULTS}-unit
+sudo -E chown -Rf jenkins:jenkins .
+if [ -n "${JOB_BASE_NAME##*smoke*}" ]; then
+    mkdir -p ${COVERAGERESULTS}
+    mv .coverage ${COVERAGERESULTS}/.coverage_unit
+fi


### PR DESCRIPTION
@ssorenso 
What issues does this address?

Fixes #972 #956

What's this change do?

Adds configuration written durng the init_env.sh evaluation that makes it possible to record coverage results in a consistent way.

Where should the reviewer start?

Note the structure of the Jenkinsfile, init_env is where coverage infrastructure is setup.

During test runs the unit_test_run_wrapper stashes the coverage results. For non-unittests this is already accomplished in the Makefile.

Note, these test results:

http://10.190.25.149:49001/job/openstack/job/agent/job/smokebranch/job/12.1.2-overcloud/1/console

The above test run ran all of the tests (not just smoke).

To see the coverage files generated:

`ssh jenkins@10.190.24.144`

and:

`cd agent/smokebranch/352a973ce8c95e329969491ca43ed23ddb3a8ccf/1_12.1.2-overcloud/`
and:

`ls -la .cover*`
