### PR TITLE
the disconnected service tests weren't running

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ deps = -r{toxinidir}/requirements.unittest.txt
 commands = py.test --ignore {toxinidir}/f5_openstack_agent/tests/functional --cov {toxinidir}/f5_openstack_agent {toxinidir}/f5_openstack_agent
 
 [testenv:disconnected_service]
-changedir = {toxinidir}/test/functional/neutronless/disconnected_service/
 deps = -r{toxinidir}/requirements.functest.txt
 commands = py.test {posargs}
 


### PR DESCRIPTION
Issues:
Fixes #1004

Problem: The py.test invocation wasn't running in the correct location.
This is because there was a "changedir" directive in tox.ini, AND a path
specifier in the Makefile.

Analysis:  I removed path manipulation from the tox.ini.

Tests: disconnected_service.
