### PR TITLE
Fixes unexpected pool name of empty str

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -120,7 +120,9 @@ class ServiceModelAdapter(object):
 
     def _init_virtual_name_with_pool(self, loadbalancer, listener, pool=None):
         vip = self._init_virtual_name(loadbalancer, listener)
-        vip['pool'] = self.init_pool_name(loadbalancer, pool)
+        pool = self.init_pool_name(loadbalancer, pool)
+        if pool['name']:
+            vip['pool'] = pool
         return vip
 
     def get_traffic_group(self, service):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_service_adapter.py
@@ -166,13 +166,17 @@ class TestServiceAdapter(object):
         listener = basic_service['listener']
         pool = basic_service['pools'][0]
         target._init_virtual_name = Mock(return_value=dict())
-        target.init_pool_name = Mock(return_value='pool')
+        target.init_pool_name = Mock(return_value=dict(name='pool'))
         assert target._init_virtual_name_with_pool(
-            loadbalancer, listener, pool) == dict(pool='pool')
+            loadbalancer, listener, pool) == {'pool': dict(name='pool')}
         target._init_virtual_name.assert_called_once_with(
             loadbalancer, listener)
         target.init_pool_name.assert_called_once_with(
             loadbalancer, pool)
+        target.init_pool_name.return_value = dict(name='')
+        target._init_virtual_name.return_value = dict()
+        assert target._init_virtual_name_with_pool(
+            loadbalancer, listener, pool) == dict()
 
     def test_get_vip_default_pool(self, target, basic_service):
         pool = basic_service['pools'][0]


### PR DESCRIPTION
Issues:
Fixes #1010

Problem:
* Empty pool name sent when no pool for vip

Analysis:
* This adds a check as ot whether or not a pool should be added to vip

Tests:
Driver tests ran into this bug for 11.5.4.  See github issue.

@richbrowne @pjbreaux - Whoever is the first to review, please do not block this change and assure that it goes into nightly tonight for tomorrow's release.
#### What issues does this address?
Fixes #1010

#### What's this change do?
makes it so that if there is no `pool['name']` from `service_adapater.ServiceAdapter.init_pool_name()` returned, then it will skip putting the 'pool' KVP in the returned vip dict.
#### Where should the reviewer start?
`service_adapter.py`
#### Any background context?
just issue #1010.  Essentially without a pool name, the REST API rejects the vip.