### PR TITLE
Virtual pool name assigned a dictionary not string.

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -88,7 +88,6 @@ class ServiceModelAdapter(object):
     def get_virtual(self, service):
         listener = service["listener"]
         loadbalancer = service["loadbalancer"]
-        pool = service.get('pool', None)
 
         listener["use_snat"] = self.snat_mode()
         if listener["use_snat"] and self.snat_count() > 0:


### PR DESCRIPTION
Issues:
Fixes #1010

Problem:
Empty pool name sent when no pool for vip

Analysis:
This adds a check as ot whether or not a pool should be added to vip

Tests:
Manual
