### PR TITLE
 Virtual pool name unit tests assumptions should be updated

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -120,7 +120,9 @@ class ServiceModelAdapter(object):
 
     def _init_virtual_name_with_pool(self, loadbalancer, listener, pool=None):
         vip = self._init_virtual_name(loadbalancer, listener)
-        vip['pool'] = self.init_pool_name(loadbalancer, pool)
+        pool = self.init_pool_name(loadbalancer, pool)
+        if pool['name']:
+            vip['pool'] = pool
         return vip
 
     def get_traffic_group(self, service):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -88,7 +88,6 @@ class ServiceModelAdapter(object):
     def get_virtual(self, service):
         listener = service["listener"]
         loadbalancer = service["loadbalancer"]
-        pool = service.get('pool', None)
 
         listener["use_snat"] = self.snat_mode()
         if listener["use_snat"] and self.snat_count() > 0:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_service_adapter.py
@@ -166,13 +166,17 @@ class TestServiceAdapter(object):
         listener = basic_service['listener']
         pool = basic_service['pools'][0]
         target._init_virtual_name = Mock(return_value=dict())
-        target.init_pool_name = Mock(return_value='pool')
+        target.init_pool_name = Mock(return_value=dict(name='pool'))
         assert target._init_virtual_name_with_pool(
-            loadbalancer, listener, pool) == dict(pool='pool')
+            loadbalancer, listener, pool) == {'pool': dict(name='pool')}
         target._init_virtual_name.assert_called_once_with(
             loadbalancer, listener)
         target.init_pool_name.assert_called_once_with(
             loadbalancer, pool)
+        target.init_pool_name.return_value = dict(name='')
+        target._init_virtual_name.return_value = dict()
+        assert target._init_virtual_name_with_pool(
+            loadbalancer, listener, pool) == dict()
 
     def test_get_vip_default_pool(self, target, basic_service):
         pool = basic_service['pools'][0]


### PR DESCRIPTION
Issues:
Fixes #1010

Problem:
The unit test need to be updated for the fix to remove usage
of _init_virtual_name_with_pool

Analysis:
Removed the usage of _init_virtual_name_with_pool and need to update
the tests of functions that used it.

Tests:
f5_openstack_agent/lbaasv2/drivers/bigip/test/test_service_adapter.py

(cherry picked from commit 1a30c80)