### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ deploy:
   - provider: script
     skip_cleanup: true
     env:
-    - RELEASE_TAG="$(echo $TRAVIS_TAG |cut -c1-4)"
+    - RELEASE_TAG="$(echo $TRAVIS_TAG |cut -c1-5)"
     on:
       tags: true
       repo: F5Networks/f5-openstack-agent


### PR DESCRIPTION
Problem:
Docs did not deploy for v10.1 because the `cut` command in the deploy script resulted in an incorrectly formatted version number (`v10.`).
Solution:
I updated the `cut` command to result in a correctly-formatted string (e.g., `v10.1`).

@<reviewer_id>
#### What issues does this address?
Fixes #<issueid>
