### PR TITLE
test fixup of unittest reporting

### DIFF
--- a/systest/scripts/unit_test_run_wrapper.sh
+++ b/systest/scripts/unit_test_run_wrapper.sh
@@ -4,8 +4,7 @@ export TIMESTAMP=`date +"%Y%m%d-%H%M%S"`
 # This is approximately the same as GUMBALLS_SESSION
 export SESSIONLOGDIR=${TAGINFO}_$TIMESTAMP
 
-export STAGENAME=f5-openstack-agent_mitaka-unit
-export TRTLRESULTSDIR=${SESSIONLOGDIR}/${STAGENAME}
+export TRTLRESULTSDIR=`pwd`/systest/test_results/f5-openstack-agent_mitaka-unit
 pwd
 ls -l
 sudo -E docker pull  docker-registry.pdbld.f5net.com/openstack-test-agentunitrunner-prod/mitaka


### PR DESCRIPTION
@pjbreaux 

Fixes:  #1021 
This is an experimental fix of unit test results-to-TRTL reporting.

Opening this PR will run smoke tests which should not affect TRTL.   Once those tests pass I will kick a test run that should affect nightly.