### PR TITLE
Get vcmp tests running on all branches

### DIFF
--- a/test/functional/neutronless/vcmp/Dockerfile
+++ b/test/functional/neutronless/vcmp/Dockerfile
@@ -1,36 +1,19 @@
 From ubuntu:16.04
 
-# To build this, do docker build -t vcmp_tests --build-arg BRANCH=liberty --build-arg AGENT_REPO_FORK=F5Networks --build-arg AGENT_TEST_BRANCH=liberty -f Dockerfile .
+# To build this, do docker build -t vcmp_tests -v <path_to_local_agent_repo>:/root/devenv/f5-openstack-agent -f Dockerfile .
 # Then do docker run vcmp_tests
 
-ARG BRANCH
-ARG AGENT_REPO_FORK
-ARG AGENT_TEST_BRANCH
 RUN apt-get -y update
 RUN apt-get install -y git
-RUN apt-get install -y vim
 RUN apt-get install -y python-pip
 RUN apt-get install -y python-dev
 RUN apt-get install -y build-essential
 RUN apt-get install -y libssl-dev
 RUN apt-get install -y libffi-dev
 RUN pip install --upgrade pip
-RUN pip install cryptography
-RUN pip install hacking
-RUN pip install mock
-RUN pip install pytest
-RUN pip install pytest-cov
-RUN pip install paramiko
-RUN pip install decorator
-RUN pip install git+https://github.com/openstack/neutron@stable/$BRANCH
-RUN pip install git+https://github.com/openstack/neutron-lbaas.git@stable/$BRANCH
-RUN pip install git+https://github.com/openstack/oslo.log.git@stable/$BRANCH
-RUN pip install git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@$BRANCH
 RUN pip install git+https://github.com/F5Networks/pytest-symbols.git
+
 # Enter your fork and branch below
-RUN mkdir -p /root/devenv
-RUN git clone -b $AGENT_TEST_BRANCH https://github.com/$AGENT_REPO_FORK/f5-openstack-agent.git /root/devenv/f5-openstack-agent
+RUN mkdir -p /root/devenv/f5-openstack-agent
 WORKDIR /root/devenv/f5-openstack-agent
-RUN pip install -r /root/devenv/f5-openstack-agent/requirements.functest.txt
-RUN py.test --cov=f5_openstack_agent f5_openstack_agent/
-CMD py.test --symbols=/root/devenv/f5-openstack-agent/test/functional/neutronless/vcmp/common_service_handler_env.json -v /root/devenv/f5-openstack-agent/test/functional/neutronless/vcmp/test_vcmp.py
+CMD pip install -r /root/devenv/f5-openstack-agent/requirements.functest.txt && py.test --symbols=/root/devenv/f5-openstack-agent/test/functional/neutronless/vcmp/common_service_handler_env.json -vvv /root/devenv/f5-openstack-agent/test/functional/neutronless/vcmp/test_vcmp.py

--- a/test/functional/neutronless/vcmp/vcmp_oslo_confs.json
+++ b/test/functional/neutronless/vcmp/vcmp_oslo_confs.json
@@ -63,8 +63,10 @@
         "environment_group_number": 1, 
         "environment_prefix": "TEST", 
         "environment_specific_plugin": true, 
+        "external_gateway_mode": false,
         "f5_bigip_lbaas_device_driver": "f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver.iControlDriver", 
         "f5_common_external_networks": true, 
+        "f5_common_networks": false,
         "f5_device_type": "external", 
         "f5_external_physical_mappings": [
             "default:1.1:true"
@@ -158,6 +160,7 @@
         "static_agent_configuration_data": null, 
         "syslog_log_facility": "LOG_USER", 
         "tcp_keepidle": 600, 
+        "trace_service_requests": false,
         "transport_url": null, 
         "use_namespaces": true, 
         "use_ssl": false, 
@@ -236,7 +239,9 @@
         "environment_group_number": 1, 
         "environment_prefix": "TEST", 
         "environment_specific_plugin": true, 
+        "external_gateway_mode": false,
         "f5_bigip_lbaas_device_driver": "f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver.iControlDriver", 
+        "f5_common_networks": false,
         "f5_common_external_networks": true, 
         "f5_device_type": "external", 
         "f5_external_physical_mappings": [
@@ -331,6 +336,7 @@
         "static_agent_configuration_data": null, 
         "syslog_log_facility": "LOG_USER", 
         "tcp_keepidle": 600, 
+        "trace_service_requests": false,
         "transport_url": null, 
         "use_namespaces": true, 
         "use_ssl": false, 


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
Fixes #1030 

#### What's this change do?
Fixed up a few changes made in the way these tests setup and one change
in the expectations they make about the disconnected networks.

#### Where should the reviewer start?

#### Any background context?
The vcmp tests have strayed in various ways, and since these tests are
not running nightly, we need to get them back in shape. This includes
running them to ensure no functionality was broken. If anything is
found, we'll file additional bugs and fix them.