### PR TITLE
Ml2 compatibility changes

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
@@ -349,7 +349,9 @@ class LBaaSv2PluginRPC(object):
     def create_port_on_subnet(self, subnet_id=None,
                               mac_address=None, name=None,
                               fixed_address_count=1,
-                              device_id=None, binding_profile={}):
+                              device_id=None,
+                              vnic_type="normal",
+                              binding_profile={}):
         """Add a neutron port to the subnet."""
         port = None
         try:
@@ -362,6 +364,7 @@ class LBaaSv2PluginRPC(object):
                                fixed_address_count=fixed_address_count,
                                host=self.host,
                                device_id=device_id,
+                               vnic_type=vnic_type,
                                binding_profile=binding_profile),
                 topic=self.topic
             )
@@ -373,7 +376,10 @@ class LBaaSv2PluginRPC(object):
 
     @log_helpers.log_method_call
     def create_port_on_network(self, network_id=None, mac_address=None,
-                               name=None, host=None):
+                               name=None, host=None,
+                               device_id=None,
+                               vnic_type="normal",
+                               binding_profile={}):
         """Add a neutron port to the network."""
         port = None
         try:
@@ -383,30 +389,10 @@ class LBaaSv2PluginRPC(object):
                                network_id=network_id,
                                mac_address=mac_address,
                                name=name,
-                               host=self.host),
-                topic=self.topic
-            )
-        except messaging.MessageDeliveryFailure:
-            LOG.error("agent->plugin RPC exception caught: "
-                      "create_port_on_subnet_with_specific_ip")
-
-        return port
-
-    def create_port_on_subnet_with_specific_ip(self, subnet_id=None,
-                                               mac_address=None,
-                                               name=None,
-                                               ip_address=None):
-        """Add a neutron port to the subnet with given IP."""
-        port = None
-        try:
-            port = self._call(
-                self.context,
-                self._make_msg('create_port_on_subnet_with_specific_ip',
-                               subnet_id=subnet_id,
-                               mac_address=mac_address,
-                               name=name,
-                               ip_address=ip_address,
-                               host=self.host),
+                               host=self.host,
+                               device_id=device_id,
+                               vnic_type=vnic_type,
+                               binding_profile=binding_profile),
                 topic=self.topic
             )
         except messaging.MessageDeliveryFailure:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
@@ -153,7 +153,8 @@ class BigipSelfIpManager(object):
                 mac_address=None,
                 name=selfip_name,
                 fixed_address_count=1,
-                device_id=device_id
+                device_id=device_id,
+                vnic_type="baremetal"
             )
 
         if port and 'fixed_ips' in port:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
@@ -85,7 +85,9 @@ class BigipSnatManager(object):
                     subnet_id=subnet['id'],
                     mac_address=None,
                     name=index_snat_name,
-                    fixed_address_count=1, device_id=lb_id)
+                    fixed_address_count=1, device_id=lb_id,
+                    vnic_type="baremetal"
+                )
                 if new_port is not None:
                     ip_address = new_port['fixed_ips'][0]['ip_address']
 

--- a/test/functional/neutronless/testlib/fake_rpc.py
+++ b/test/functional/neutronless/testlib/fake_rpc.py
@@ -97,6 +97,7 @@ class FakeRPCPlugin(object):
                               name=None,
                               fixed_address_count=1,
                               device_id=None,
+                              vnic_type=None,
                               binding_profile={}):
 
         # Enforce specific call parameters
@@ -108,6 +109,8 @@ class FakeRPCPlugin(object):
             raise InvalidArgumentError
         if fixed_address_count != 1:
             raise InvalidArgumentError
+        if vnic_type != "baremetal":
+            raise InvalideArgumentError
 
         ip_address = next(self._subnets[subnet_id])
 


### PR DESCRIPTION
In order for the driver/agent to utilize the ML2 driver, some changes to the port creation logic need to be made.

The ML2 driver will only bind ports that are of type 'baremetal', for the BIG-IP. There needs to be a way for the agent to communicate whether or not to create 'baremetal' vs. 'normal' ports. Also, there are a couple of issues with the way that we specify attributes for port creation:

device_id --> is the loadbalancer id
host_id --> is the agent host name
vnic_type --> will be baremetal for compatibility with the ML2 driver.
binding_profile --> we have this but it is currently unused.

There a corresponding Agent change