### PR TITLE
Migrate stable/newton references to newton-eol

### DIFF
--- a/requirements.functest.txt
+++ b/requirements.functest.txt
@@ -2,8 +2,8 @@
 
 # OpenStack dependencies, Za doesn't know how pip-over-git interacts with
 # constraints.txt's .
-git+https://github.com/openstack/neutron@stable/newton
-git+https://github.com/openstack/neutron-lbaas.git@stable/newton
+git+https://github.com/openstack/neutron@newton-eol
+git+https://github.com/openstack/neutron-lbaas.git@newton-eol
 
 # F5 LBaaS dependancies
 git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@stable/newton
@@ -13,9 +13,12 @@ git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@stable/newton
 # version.  The versions of these packages are specified at the constraints
 # URL.  If you add a version here it will be ignored, and therefore be
 # misleading to readers of this file.
+#
+# NOTE: As of 26-OCT-2017, upper-constraints is still at stable/newton, not newton-eol. This
+# is likely to change.
 -c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/newton
 
-git+https://github.com/openstack/oslo.log.git@stable/newton
+git+https://github.com/openstack/oslo.log.git@newton-eol
 pytest==IGNORED    # See section comment
 mock==IGNORED      # See section comment
 coverage==IGNORED  # See section comment

--- a/requirements.unittest.txt
+++ b/requirements.unittest.txt
@@ -1,9 +1,9 @@
 -e .
 
 # app
-git+https://github.com/openstack/neutron@stable/newton
-git+https://github.com/openstack/oslo.log.git@stable/newton
-git+https://github.com/openstack/neutron-lbaas.git@stable/newton
+git+https://github.com/openstack/neutron@newton-eol
+git+https://github.com/openstack/oslo.log.git@newton-eol
+git+https://github.com/openstack/neutron-lbaas.git@newton-eol
 git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@stable/newton
 
 pytest-cov==2.5.1
@@ -14,6 +14,9 @@ python-coveralls==2.9.1
 # version.  The versions of these packages are specified at the constraints
 # URL.  If you add a version here it will be ignored, and therefore be
 # misleading to readers of this file.
+#
+# NOTE: As of 26-OCT-2017, upper-constraints is still at stable/newton, not newton-eol. This
+# is likely to change.
 -c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/newton
 
 mock==IGNORED      # See section comment


### PR DESCRIPTION
#### What issues does this address?
Fixes #1058

#### What's this change do?
Newton branches of openstack/neutron and openstack/neutron-lbaas
have moved to end-of-life. Changes requirements from stable/newton to newton-eol.

Tests: virtualenv setup
