### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ deploy:
       branch: master
       condition: $TRAVIS_TAG = ""
     script:
-    - ./docs/scripts/deploy-docs.sh publish-product-docs-to-prod openstack/agent newton
+    - ./docs/scripts/deploy-docs.sh publish-product-docs-to-prod openstack/agent $TRAVIS_BRANCH
   # if this is a tagged release, the docs go to /products/openstack/agent/$TRAVIS_BRANCH/vX.Y
   - provider: script
     skip_cleanup: true

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -8,7 +8,7 @@ Glossary
 
    segmentation ID
    segmentation id
-      `VLAN tag <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-routing-administration-12-0-0/5.html#unique_1525090453>`_
+      `VLAN tag <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-routing-administration-12-0-0/5.html>`_
 
    device
       `BIG-IP`_ hardware or virtual edition (VE).

--- a/docs/l2-adjacent-mode.rst
+++ b/docs/l2-adjacent-mode.rst
@@ -12,7 +12,7 @@ L2-adjacent mode is the **default mode of operation** for the |agent-short|.
 
 .. important::
 
-   - All Neutron and external network components should be set up before you deploy the |agent-short| in L2-adjacent mode.
+   - Set up all Neutron and external network components *before* you deploy the |agent-short| in L2-adjacent mode.
    - This mode of deployment may require a BIG-IP `Better or Best license`_ that supports SDN.
 
 .. warning::


### PR DESCRIPTION
Fixes #1067

@jlongstaf 

#### What issues does this address?
Fixes #1067 

#### What's this change do?
Fixes the target location in clouddocs for the docs on the master branch. They need to go to /master, not /newton.

#### Where should the reviewer start?

#### Any background context?

This PR includes 2 fixes for docs build issues (see [travis-ci build 1913](https://travis-ci.org/F5Networks/f5-openstack-agent/builds/295379589#L5921). I have included them as separate commits because each needs to be cherry-picked back to different branches. 

- d2a78b5 should be cherry-picked all the way back to liberty
- 9fa82e77 should be cherry-picked back to stable/newton.
 
