### PR TITLE
lbb test raises unexpected swallowed TypeError

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager_LbaasAgentManager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager_LbaasAgentManager.py
@@ -228,6 +228,7 @@ class TestLbaasAgentManager(TestLbaasAgentManagerBuilder):
         fully_mocked_target.cache.get_by_loadbalancer_id.assert_called_with(2)
         assert fully_mocked_target.cache.get_by_loadbalancer_id.call_count == 2
 
+    @pytest.mark.skip(reason="TypeError from mock redirecting rpc_calls.")
     def test_lbb_sync_state(self, fully_mocked_target,
                             fully_mocked_plugin_rpc, mock_logger):
         """A limited black-box functional test for testing flow of sync_state


### PR DESCRIPTION
Issues:
Fixes #1073

Problem:  The test was not testing the behavior we expected it to.

Analysis:  A mock used in the test was generating a TypeError which was
swallowed by a Scantily-Clad except statement:  i.e.

"except Except"

The Scantily-Clad Exception caused the test author to be confused about the
correct behavior of the agent.

Tests:  N/A

NOTE:  Please see issue #1073 for a suggested reproduction approach.