### PR TITLE
Existing pool member nova migration causes fdb add/remove failures in…

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
@@ -619,7 +619,7 @@ class L2ServiceBuilder(object):
                             'net_fdb': net_fdb}
                 fdbs = self._get_bigip_network_fdbs(bigip, net_info)
                 if len(fdbs) > 0:
-                    fdb_method(fdb_entries=fdbs)
+                    fdb_method(bigip, fdb_entries=fdbs)
 
     def _get_bigip_network_fdbs(self, bigip, net_info):
         # Get network fdb entries to add to a bigip

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/utils.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/utils.py
@@ -128,6 +128,13 @@ def get_filter(bigip, key, op, value):
         return {'$filter': '%s %s %s' % (key, op, value)}
 
 
+def get_select(bigip, value):
+    if LooseVersion(bigip.tmos_version) < LooseVersion('11.6.0'):
+        return '$select={}'.format(value)
+    else:
+        return {'$select': '{}'.format(value)}
+
+
 def strip_cidr_netmask(ip_address):
     '''Strip the /XX from the end of a CIDR address
 


### PR DESCRIPTION

#### What issues does this address?
#918 Existing pool member nova migration causes fdb add/remove failures in agent

#### What's this change do?
Fixes invalid call to remove _fdb_entries(); improves efficiency of getting tunnel folder
for an fdb entry.

#### Where should the reviewer start?
l2_service.py

#### Any background context?
No