### PR TITLE
This commit  has a few minor fixups to ease test.

### DIFF
--- a/test/functional/neutronless/testlib/resource_validator.py
+++ b/test/functional/neutronless/testlib/resource_validator.py
@@ -148,7 +148,7 @@ class ResourceValidator(object):
 
         if 'lbaas_fallback_persist' in esd:
             assert vs.fallbackPersistence == \
-                   '/Common/' + esd['lbaas_fallback_persist']
+                '/Common/' + esd['lbaas_fallback_persist']
 
         if 'lbaas_irule' in esd:
             for rule in esd['lbaas_irule']:
@@ -187,7 +187,7 @@ class ResourceValidator(object):
             fallback_persist = getattr(vs, 'fallbackPersistence', None)
             if fallback_persist:
                 assert fallback_persist != \
-                       '/Common/' + esd['lbaas_fallback_persist']
+                    '/Common/' + esd['lbaas_fallback_persist']
 
         if 'lbaas_irule' in esd:
             assert not getattr(vs, 'rules', None)


### PR DESCRIPTION
The changes in test_esd remove the use of the
'Iterator.next()' in favor of the simpler pattern
of indexing into the list of services.

The practical effect is that test developers can now
remove sections of test code without changing the
meaning of the "service" variable in subsequent
portions of the code.

The only other change is dedentation of a few lines
to shut flake8 up.

The third commit (now squashed) built on the previous
two to refactor the tests such that they have conventional
setup and teardown functionality. These setups and
teardowns are not the ideal of booting snapshotted vms,
but they do modularize the tests and speed development in the short term.

ORIGNAL COMMIT MESSAGES BELOW:
fix flake8 violations

simplify loading of service replays in test

refactor tests to be more modular to speed test development

@<reviewer_id>
#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?
