### PR TITLE
Add ordered dict

### DIFF
--- a/etc/neutron/services/f5/esd/demo.json
+++ b/etc/neutron/services/f5/esd/demo.json
@@ -1,5 +1,5 @@
 {
-  "esd_demo_1": {
+  "f5_ESD_full_8_tag_set": {
     "lbaas_ctcp": "tcp-mobile-optimized",
     "lbaas_stcp": "tcp-lan-optimized",
     "lbaas_cssl_profile": "clientssl",
@@ -10,7 +10,7 @@
     "lbaas_fallback_persist": "source_addr"
   },
 
-  "esd_demo_2": {
+  "f5_ESD_two_irules": {
     "lbaas_irule": [
       "_sys_https_redirect",
       "_sys_APM_ExchangeSupport_helper"

--- a/test/functional/neutronless/esd/test_esd.py
+++ b/test/functional/neutronless/esd/test_esd.py
@@ -89,7 +89,6 @@ def icontrol_driver(icd_config, fake_plugin_rpc):
                          registerOpts=False)
 
     icd.plugin_rpc = fake_plugin_rpc
-
     return icd
 
 
@@ -104,6 +103,7 @@ def esd():
 
 @pytest.fixture
 def setup(request, bigip, services, icd_config, icontrol_driver, esd):
+    icontrol_driver.lbaas_builder.esd.esd_dict = esd
     env_prefix = icd_config['environment_prefix']
     validator = ResourceValidator(bigip, env_prefix)
 

--- a/test/functional/neutronless/testlib/fake_rpc.py
+++ b/test/functional/neutronless/testlib/fake_rpc.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 
 
+import collections
 import netaddr
 
 
@@ -42,10 +43,16 @@ class FakeRPCPlugin(object):
         self._subnets = {}
         self._ports = {}
         self._loadbalancers = {}
-        self._services = services
+        # The following is a bit of a hack, it allows us to handle 
+        # two types of service objects.  For back compatibility we need to
+        # support services-as-lists.
+        if isinstance(services, collections.OrderedDict):
+            self._services = services.values()
+        else:
+            self._services = services[:]
         self._current_service = 0
-        self._initialize_subnets(services)
-        self._initialize_loadbalancers(services)
+        self._initialize_subnets(self._services)
+        self._initialize_loadbalancers(self._services)
         self._calls = {}
 
     def _initialize_loadbalancers(self, services):

--- a/test/functional/neutronless/testlib/resource_validator.py
+++ b/test/functional/neutronless/testlib/resource_validator.py
@@ -148,7 +148,7 @@ class ResourceValidator(object):
 
         if 'lbaas_fallback_persist' in esd:
             assert vs.fallbackPersistence == \
-                   '/Common/' + esd['lbaas_fallback_persist']
+                '/Common/' + esd['lbaas_fallback_persist']
 
         if 'lbaas_irule' in esd:
             for rule in esd['lbaas_irule']:
@@ -187,7 +187,7 @@ class ResourceValidator(object):
             fallback_persist = getattr(vs, 'fallbackPersistence', None)
             if fallback_persist:
                 assert fallback_persist != \
-                       '/Common/' + esd['lbaas_fallback_persist']
+                    '/Common/' + esd['lbaas_fallback_persist']
 
         if 'lbaas_irule' in esd:
             assert not getattr(vs, 'rules', None)

--- a/test/functional/testdata/service_requests/l7_esd.json
+++ b/test/functional/testdata/service_requests/l7_esd.json
@@ -1,4 +1,5 @@
-[{
+{
+ "create_loadbalancer": {
   "healthmonitors": [], 
   "l7policies": [], 
   "l7policy_rules": [], 
@@ -115,7 +116,8 @@
       "updated_at": "2017-03-02T15:28:03"
     }
   }
-},{
+ },
+ "create_listener": {
   "healthmonitors": [], 
   "l7policies": [], 
   "l7policy_rules": [], 
@@ -254,7 +256,8 @@
       "updated_at": "2017-03-02T15:28:03"
     }
   }
-},{
+ },
+ "create_pool": {
   "healthmonitors": [], 
   "l7policies": [], 
   "l7policy_rules": [], 
@@ -424,7 +427,8 @@
       "updated_at": "2017-03-02T15:28:03"
     }
   }
-},{
+ },
+ "apply_full_8_tag_set": {
   "healthmonitors": [], 
   "l7policies": [
     {
@@ -433,7 +437,7 @@
       "description": "", 
       "id": "18105b94-1cd7-41a1-b39c-4d0fbf425060", 
       "listener_id": "dc66bf27-490a-4913-9f4f-12c885afe7a1", 
-      "name": "esd_demo_1", 
+      "name": "f5_ESD_full_8_tag_set", 
       "position": 1, 
       "provisioning_status": "PENDING_CREATE", 
       "redirect_pool_id": null, 
@@ -613,7 +617,8 @@
       "updated_at": "2017-03-02T15:28:03"
     }
   }
-},{
+ },
+ "remove_full_8_tag_set": {
   "healthmonitors": [], 
   "l7policies": [
     {
@@ -622,7 +627,7 @@
       "description": "", 
       "id": "18105b94-1cd7-41a1-b39c-4d0fbf425060", 
       "listener_id": "dc66bf27-490a-4913-9f4f-12c885afe7a1", 
-      "name": "esd_demo_1", 
+      "name": "f5_ESD_full_8_tag_set", 
       "position": 1, 
       "provisioning_status": "PENDING_DELETE", 
       "redirect_pool_id": null, 
@@ -802,7 +807,8 @@
       "updated_at": "2017-03-02T15:28:03"
     }
   }
-},{
+ },
+ "apply_two_irules": {
   "healthmonitors": [], 
   "l7policies": [
     {
@@ -811,7 +817,7 @@
       "description": "", 
       "id": "d2c6f5f1-725f-4ef9-bf9c-de7394d07852", 
       "listener_id": "dc66bf27-490a-4913-9f4f-12c885afe7a1", 
-      "name": "esd_demo_2", 
+      "name": "f5_ESD_two_irules", 
       "position": 1, 
       "provisioning_status": "PENDING_CREATE", 
       "redirect_pool_id": null, 
@@ -991,7 +997,8 @@
       "updated_at": "2017-03-02T15:28:03"
     }
   }
-},{
+ },
+ "remove_two_irules": {
   "healthmonitors": [], 
   "l7policies": [
     {
@@ -1000,7 +1007,7 @@
       "description": "", 
       "id": "d2c6f5f1-725f-4ef9-bf9c-de7394d07852", 
       "listener_id": "dc66bf27-490a-4913-9f4f-12c885afe7a1", 
-      "name": "esd_demo_2", 
+      "name": "f5_ESD_two_irules", 
       "position": 1, 
       "provisioning_status": "PENDING_DELETE", 
       "redirect_pool_id": null, 
@@ -1180,7 +1187,8 @@
       "updated_at": "2017-03-02T15:28:03"
     }
   }
-},{
+ },
+ "delete_pool": {
   "healthmonitors": [], 
   "l7policies": [], 
   "l7policy_rules": [], 
@@ -1350,7 +1358,8 @@
       "updated_at": "2017-03-02T15:28:03"
     }
   }
-},{
+ },
+ "delete_listener": {
   "healthmonitors": [], 
   "l7policies": [], 
   "l7policy_rules": [], 
@@ -1489,7 +1498,8 @@
       "updated_at": "2017-03-02T15:28:03"
     }
   }
-},{
+ },
+ "delete_loadbalancer": {
   "healthmonitors": [], 
   "l7policies": [], 
   "l7policy_rules": [], 
@@ -1606,4 +1616,5 @@
       "updated_at": "2017-03-02T15:28:03"
     }
   }
-}]
+}
+}


### PR DESCRIPTION
@richbrowne this PR continues to refactor and simplify test code.

In particular it makes the `l7_esd.json` service object provide an orderedDict interface so that consuming test code can either refer to the actual script-driven ordered service object list, or can refer to appropriate names, e.g. "delete_listener".


This is a test-only change that is enhancing a particular test suite.   Tests of that suite are being run manually.