### PR TITLE
Eleven tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,13 @@ before_install:
     - docker pull f5devcentral/containthedocs:latest
 install:
     - pip install tox
+    - pip install -r requirements.style.txt
 script:
-    - tox -e style,unit
+    - pep257 ./test/functional/neutronless/esd/test_esd.py
+    - flake8 --ignore=H304 ./test/functional/neutronless/esd/test_esd.py
+    - pylint -E -d E1101 test/functional/neutronless/esd/test_esd.py
+    - flake8 ./f5_openstack_agent
+    - tox -e unit
     - python f5-openstack-agent-dist/scripts/universal_truth.py
     - echo "setup.cfg:"
     - cat setup.cfg

--- a/requirements.style.txt
+++ b/requirements.style.txt
@@ -1,3 +1,4 @@
-.
 flake8
 hacking
+pep257
+pylint

--- a/test/functional/neutronless/esd/test_esd.py
+++ b/test/functional/neutronless/esd/test_esd.py
@@ -12,37 +12,75 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+"""These are tests of the ESD (Enhanced Services Definition) feature.
 
+ESDs are defined here:
+
+https://devcentral.f5.com/articles/customizing-openstack-lbaasv2-using-enhanced-services-definitions-25681
+
+Classes of tests in this module include:
+
+* Basic Functionality Tests:
+   These tests load and apply ESDs from an example ESD config:
+    f5-openstack-agent/etc/neutron/services/f5/esd/demo.json
+
+   Each test looks up the specific ESD appended to the "test_esd_" string in
+the test name, it then takes the resulting suffix, and prepends "f5_ESD_" to it
+such that the result matches on of the example ESD names.
+   For example "def test_esd_lbaas_ctcp" is processed in the following way:
+      test_esd_lbaas_ctcp --> lbaas_ctcp --> f5_ESD_lbaas_ctcp
+
+   The final "f5_ESD_${NAME}" string is then used to index into the ESD object.
+
+   The test uses the customized (test specific) name to construct a pair of
+custom service objects "apply_service" and "remove_service" that specify
+the ESD named in the test-name.  That is, the "apply_service" object in the
+"test_esd_lbaas_ctcp" test contains the ESD name "f5_ESD_lbaas_ctcp".
+
+   The "apply_service" is then acted on by passing it as the argument to the
+icontrol_driver._commen_service_handler method.  The effect is validated (or
+the test FAILs), and the "remove_service" is then effected, and validated.
+
+   It's not impossible that a FAIL at this point in the test could cause an
+ERROR in teardown.
+"""
+import collections
 from copy import deepcopy
-from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import \
-    iControlDriver
 import json
 import logging
 import os
+
 import pytest
-import requests
+from requests.packages import urllib3
+urllib3.disable_warnings()
+
+from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import \
+    iControlDriver
 
 from ..testlib.bigip_client import BigIpClient
 from ..testlib.fake_rpc import FakeRPCPlugin
-from ..testlib.service_reader import LoadbalancerReader
 from ..testlib.resource_validator import ResourceValidator
+from ..testlib.service_reader import LoadbalancerReader
 
-requests.packages.urllib3.disable_warnings()
 
 LOG = logging.getLogger(__name__)
 
 
 @pytest.fixture(scope="module")
 def services():
+    """Load testdata services that were produced by scripting neutron."""
     neutron_services_filename = (
         os.path.join(os.path.dirname(os.path.abspath(__file__)),
                      '../../testdata/service_requests/l7_esd.json')
     )
-    return (json.load(open(neutron_services_filename)))
+    s = json.load(open(neutron_services_filename),
+                  object_pairs_hook=collections.OrderedDict)
+    return s
 
 
 @pytest.fixture()
 def icd_config():
+    """Configure the icontrol_driver by mocking an historical oslo confg."""
     oslo_config_filename = (
         os.path.join(os.path.dirname(os.path.abspath(__file__)),
                      '../../config/overcloud_basic_agent_config.json')
@@ -59,7 +97,7 @@ def icd_config():
 
 @pytest.fixture(scope="module")
 def bigip():
-
+    """Return a device-connected, agent-style, BigIpClient."""
     return BigIpClient(pytest.symbols.bigip_mgmt_ip_public,
                        pytest.symbols.bigip_username,
                        pytest.symbols.bigip_password)
@@ -67,7 +105,7 @@ def bigip():
 
 @pytest.fixture
 def fake_plugin_rpc(services):
-
+    """Return an object to patch out the RPC Plugin with."""
     rpcObj = FakeRPCPlugin(services)
 
     return rpcObj
@@ -75,7 +113,10 @@ def fake_plugin_rpc(services):
 
 @pytest.fixture
 def icontrol_driver(icd_config, fake_plugin_rpc):
+    """Return a patched icontrol_driver. Config and RPC_plugin are fakes."""
     class ConfFake(object):
+        """A configuration Fake that matches the oslo conf interface."""
+
         def __init__(self, params):
             self.__dict__ = params
             for k, v in self.__dict__.items():
@@ -89,76 +130,176 @@ def icontrol_driver(icd_config, fake_plugin_rpc):
                          registerOpts=False)
 
     icd.plugin_rpc = fake_plugin_rpc
-
     return icd
 
 
 @pytest.fixture
 def esd():
+    """Return an esd dict containing state specced in demo.json."""
     esd_file = (
         os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                     '../../../../etc/neutron/services/f5/esd/demo.json')
+                     '../../testdata/esds/demo.json')
     )
     return (json.load(open(esd_file)))
 
 
-def test_esd(bigip, services, icd_config, icontrol_driver, esd):
+TESTINFRA = collections.namedtuple(
+    "TESTINFRA", ('apply_service', 'remove_service', 'icontrol_driver', 'esd',
+                  'validator', 'folder', 'listener', 'esd_name')
+)
+
+
+@pytest.fixture
+def setup(request, bigip, services, icd_config, icontrol_driver, esd):
+    """Build/Remove an invariant test environment.
+
+    NOTE:  This fixture is modfiying the state of the BigIP device.  That is
+    it's purpose and the "place" where tests require a constant environment.
+
+    This fixture creates the requisite loadbalancer, listener, and pool, on the
+    device prior to test initiation, and removes them after the ESD test is
+    performed.   It also invokes the introspection necessary to customize test
+    behavior as a function of the function name. The logic for this step is in
+    the _set_esd function.
+    """
+    icontrol_driver.lbaas_builder.esd.esd_dict = esd
     env_prefix = icd_config['environment_prefix']
-    service_iter = iter(services)
     validator = ResourceValidator(bigip, env_prefix)
 
     # create loadbalancer
-    service = service_iter.next()
+    service = services['create_loadbalancer']
     lb_reader = LoadbalancerReader(service)
     folder = '{0}_{1}'.format(env_prefix, lb_reader.tenant_id())
     icontrol_driver._common_service_handler(service)
     assert bigip.folder_exists(folder)
 
     # create listener
-    service = service_iter.next()
+    service = services['create_listener']
     listener = service['listeners'][0]
     icontrol_driver._common_service_handler(service)
     validator.assert_virtual_valid(listener, folder)
 
     # create pool
-    service = service_iter.next()
+    service = services['create_pool']
     pool = service['pools'][0]
     icontrol_driver._common_service_handler(service)
     validator.assert_pool_valid(pool, folder)
 
+    def teardown():
+        """Teardown and verify removal of the testbed."""
+        # delete pool (and member, node)
+        service = services['delete_pool']
+        icontrol_driver._common_service_handler(service)
+        validator.assert_pool_deleted(pool, None, folder)
+
+        # delete listener
+        service = services['delete_listener']
+        icontrol_driver._common_service_handler(service)
+        validator.assert_virtual_deleted(listener, folder)
+
+        # delete loadbalancer
+        service = services['delete_loadbalancer']
+        icontrol_driver._common_service_handler(service, delete_partition=True)
+        assert not bigip.folder_exists(folder)
+
+    request.addfinalizer(teardown)
+    apply_service, remove_service, esd_name = _set_esd(services, request)
+    ti = TESTINFRA(apply_service,
+                   remove_service,
+                   icontrol_driver,
+                   esd,
+                   validator,
+                   folder,
+                   listener,
+                   esd_name)
+    return ti
+
+
+def _set_esd(services, request):
+    """Extract the test name and process it as described above."""
+    literal_esd_name = request.function.__name__.partition('test_esd_')[2]
+    full_esd_name = 'f5_ESD_' + literal_esd_name
+    new_apply_esd = deepcopy(services["apply_ABSTRACT_ESD"])
+    new_remove_esd = deepcopy(services["remove_ABSTRACT_ESD"])
+    new_apply_esd['l7policies'][0]['name'] = full_esd_name
+    new_remove_esd['l7policies'][0]['name'] = full_esd_name
+    return new_apply_esd, new_remove_esd, full_esd_name
+
+
+def _apply_validate_remove_validate(infra):
+    """Apply an ESD, validate application, remove ESD, validate removal."""
+    i = infra
     # apply ESD
-    service = service_iter.next()
-    icontrol_driver._common_service_handler(service)
-    validator.assert_esd_applied(esd['esd_demo_1'], listener, folder)
+    i.icontrol_driver._common_service_handler(i.apply_service)
+    i.validator.assert_esd_applied(i.esd[i.esd_name], i.listener, i.folder)
 
     # remove ESD
-    service = service_iter.next()
-    icontrol_driver._common_service_handler(service)
-    validator.assert_virtual_valid(listener, folder)
-    validator.assert_esd_removed(esd['esd_demo_1'], listener, folder)
+    i.icontrol_driver._common_service_handler(i.remove_service)
+    i.validator.assert_virtual_valid(i.listener, i.folder)
+    i.validator.assert_esd_removed(i.esd[i.esd_name], i.listener, i.folder)
 
-    # apply another ESD
-    service = service_iter.next()
-    icontrol_driver._common_service_handler(service)
-    validator.assert_esd_applied(esd['esd_demo_2'], listener, folder)
 
-    # remove ESD
-    service = service_iter.next()
-    icontrol_driver._common_service_handler(service)
-    validator.assert_virtual_valid(listener, folder)
-    validator.assert_esd_removed(esd['esd_demo_2'], listener, folder)
+def test_setup_teardown(setup):
+    """Stub test that sanity checks setup and teardown."""
+    pass
 
-    # delete pool (and member, node)
-    service = service_iter.next()
-    icontrol_driver._common_service_handler(service)
-    validator.assert_pool_deleted(pool, None, folder)
 
-    # delete listener
-    service = service_iter.next()
-    icontrol_driver._common_service_handler(service)
-    validator.assert_virtual_deleted(listener, folder)
+def test_esd_two_irules(setup):
+    """Refactor of an historical test of a 2 irule ESD."""
+    infrastructure = setup
+    _apply_validate_remove_validate(infrastructure)
 
-    # delete loadbalancer
-    service = service_iter.next()
-    icontrol_driver._common_service_handler(service, delete_partition=True)
-    assert not bigip.folder_exists(folder)
+
+# Single tag tests, each individual tag is tested.
+def test_esd_lbaas_ctcp(setup):
+    """Test a single tag."""
+    infrastructure = setup
+    _apply_validate_remove_validate(infrastructure)
+
+
+def test_esd_lbaas_stcp(setup):
+    """Test a single tag."""
+    infrastructure = setup
+    _apply_validate_remove_validate(infrastructure)
+
+
+def test_esd_lbaas_cssl_profile(setup):
+    """Test a single tag."""
+    infrastructure = setup
+    _apply_validate_remove_validate(infrastructure)
+
+
+def test_esd_lbaas_sssl_profile(setup):
+    """Test a single tag."""
+    infrastructure = setup
+    _apply_validate_remove_validate(infrastructure)
+
+
+def test_esd_lbaas_irule(setup):
+    """Test a single tag."""
+    infrastructure = setup
+    _apply_validate_remove_validate(infrastructure)
+
+
+def test_esd_lbaas_policy(setup):
+    """Test a single tag."""
+    infrastructure = setup
+    _apply_validate_remove_validate(infrastructure)
+
+
+def test_esd_lbaas_persist(setup):
+    """Test a single tag."""
+    infrastructure = setup
+    _apply_validate_remove_validate(infrastructure)
+
+
+def test_esd_lbaas_fallback_persist(setup):
+    """Test a single tag."""
+    infrastructure = setup
+    _apply_validate_remove_validate(infrastructure)
+
+
+def test_esd_full_8_tag_set(setup):
+    """Test of a full tag set.  Tags specifics are historical."""
+    infrastructure = setup
+    _apply_validate_remove_validate(infrastructure)

--- a/test/functional/neutronless/esd/test_esd.py
+++ b/test/functional/neutronless/esd/test_esd.py
@@ -52,7 +52,6 @@ import os
 
 import pytest
 from requests.packages import urllib3
-urllib3.disable_warnings()
 
 from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import \
     iControlDriver
@@ -62,7 +61,7 @@ from ..testlib.fake_rpc import FakeRPCPlugin
 from ..testlib.resource_validator import ResourceValidator
 from ..testlib.service_reader import LoadbalancerReader
 
-
+urllib3.disable_warnings()
 LOG = logging.getLogger(__name__)
 
 

--- a/test/functional/neutronless/esd/test_esd.py
+++ b/test/functional/neutronless/esd/test_esd.py
@@ -51,7 +51,7 @@ import logging
 import os
 
 import pytest
-from requests.packages import urllib3
+import requests
 
 from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import \
     iControlDriver
@@ -61,7 +61,7 @@ from ..testlib.fake_rpc import FakeRPCPlugin
 from ..testlib.resource_validator import ResourceValidator
 from ..testlib.service_reader import LoadbalancerReader
 
-urllib3.disable_warnings()
+requests.packages.urllib3.disable_warnings()
 LOG = logging.getLogger(__name__)
 
 

--- a/test/functional/neutronless/testlib/fake_rpc.py
+++ b/test/functional/neutronless/testlib/fake_rpc.py
@@ -14,6 +14,7 @@
 #   limitations under the License.
 
 
+import collections
 import netaddr
 
 
@@ -42,10 +43,16 @@ class FakeRPCPlugin(object):
         self._subnets = {}
         self._ports = {}
         self._loadbalancers = {}
-        self._services = services
+        # The following is a bit of a hack, it allows us to handle 
+        # two types of service objects.  For back compatibility we need to
+        # support services-as-lists.
+        if isinstance(services, collections.OrderedDict):
+            self._services = services.values()
+        else:
+            self._services = services[:]
         self._current_service = 0
-        self._initialize_subnets(services)
-        self._initialize_loadbalancers(services)
+        self._initialize_subnets(self._services)
+        self._initialize_loadbalancers(self._services)
         self._calls = {}
 
     def _initialize_loadbalancers(self, services):

--- a/test/functional/neutronless/testlib/resource_validator.py
+++ b/test/functional/neutronless/testlib/resource_validator.py
@@ -148,7 +148,7 @@ class ResourceValidator(object):
 
         if 'lbaas_fallback_persist' in esd:
             assert vs.fallbackPersistence == \
-                   '/Common/' + esd['lbaas_fallback_persist']
+                '/Common/' + esd['lbaas_fallback_persist']
 
         if 'lbaas_irule' in esd:
             for rule in esd['lbaas_irule']:
@@ -187,7 +187,7 @@ class ResourceValidator(object):
             fallback_persist = getattr(vs, 'fallbackPersistence', None)
             if fallback_persist:
                 assert fallback_persist != \
-                       '/Common/' + esd['lbaas_fallback_persist']
+                    '/Common/' + esd['lbaas_fallback_persist']
 
         if 'lbaas_irule' in esd:
             assert not getattr(vs, 'rules', None)

--- a/test/functional/testdata/esds/demo.json
+++ b/test/functional/testdata/esds/demo.json
@@ -1,0 +1,28 @@
+{
+  "f5_ESD_full_8_tag_set": {
+    "lbaas_ctcp": "tcp-mobile-optimized",
+    "lbaas_stcp": "tcp-lan-optimized",
+    "lbaas_cssl_profile": "clientssl",
+    "lbaas_sssl_profile": "serverssl",
+    "lbaas_irule": ["_sys_https_redirect"],
+    "lbaas_policy": ["demo_policy"],
+    "lbaas_persist": "hash",
+    "lbaas_fallback_persist": "source_addr"
+  },
+
+  "f5_ESD_two_irules": {
+    "lbaas_irule": [
+      "_sys_https_redirect",
+      "_sys_APM_ExchangeSupport_helper"
+    ]
+  },
+
+  "f5_ESD_lbaas_ctcp":             { "lbaas_ctcp": "tcp-mobile-optimized" },
+  "f5_ESD_lbaas_stcp":             { "lbaas_stcp": "tcp-lan-optimized" },
+  "f5_ESD_lbaas_cssl_profile":     { "lbaas_cssl_profile": "clientssl"},
+  "f5_ESD_lbaas_sssl_profile":     { "lbaas_sssl_profile": "serverssl" },
+  "f5_ESD_lbaas_irule":            { "lbaas_irule": ["_sys_https_redirect"] },
+  "f5_ESD_lbaas_policy":           { "lbaas_policy": ["demo_policy"] },
+  "f5_ESD_lbaas_persist":          { "lbaas_persist": "hash" },
+  "f5_ESD_lbaas_fallback_persist": { "lbaas_fallback_persist": "source_addr" }
+}

--- a/test/functional/testdata/service_requests/l7_esd.json
+++ b/test/functional/testdata/service_requests/l7_esd.json
@@ -1,4 +1,5 @@
-[{
+{
+ "create_loadbalancer": {
   "healthmonitors": [], 
   "l7policies": [], 
   "l7policy_rules": [], 
@@ -115,7 +116,8 @@
       "updated_at": "2017-03-02T15:28:03"
     }
   }
-},{
+ },
+ "create_listener": {
   "healthmonitors": [], 
   "l7policies": [], 
   "l7policy_rules": [], 
@@ -254,7 +256,8 @@
       "updated_at": "2017-03-02T15:28:03"
     }
   }
-},{
+ },
+ "create_pool": {
   "healthmonitors": [], 
   "l7policies": [], 
   "l7policy_rules": [], 
@@ -424,7 +427,8 @@
       "updated_at": "2017-03-02T15:28:03"
     }
   }
-},{
+ },
+ "apply_ABSTRACT_ESD": {
   "healthmonitors": [], 
   "l7policies": [
     {
@@ -433,7 +437,7 @@
       "description": "", 
       "id": "18105b94-1cd7-41a1-b39c-4d0fbf425060", 
       "listener_id": "dc66bf27-490a-4913-9f4f-12c885afe7a1", 
-      "name": "esd_demo_1", 
+      "name": "f5_ESD_ABSTRACT_ESD", 
       "position": 1, 
       "provisioning_status": "PENDING_CREATE", 
       "redirect_pool_id": null, 
@@ -613,7 +617,8 @@
       "updated_at": "2017-03-02T15:28:03"
     }
   }
-},{
+ },
+ "remove_ABSTRACT_ESD": {
   "healthmonitors": [], 
   "l7policies": [
     {
@@ -622,7 +627,7 @@
       "description": "", 
       "id": "18105b94-1cd7-41a1-b39c-4d0fbf425060", 
       "listener_id": "dc66bf27-490a-4913-9f4f-12c885afe7a1", 
-      "name": "esd_demo_1", 
+      "name": "f5_ESD_ABSTRACT_ESD", 
       "position": 1, 
       "provisioning_status": "PENDING_DELETE", 
       "redirect_pool_id": null, 
@@ -802,385 +807,8 @@
       "updated_at": "2017-03-02T15:28:03"
     }
   }
-},{
-  "healthmonitors": [], 
-  "l7policies": [
-    {
-      "action": "REJECT", 
-      "admin_state_up": true, 
-      "description": "", 
-      "id": "d2c6f5f1-725f-4ef9-bf9c-de7394d07852", 
-      "listener_id": "dc66bf27-490a-4913-9f4f-12c885afe7a1", 
-      "name": "esd_demo_2", 
-      "position": 1, 
-      "provisioning_status": "PENDING_CREATE", 
-      "redirect_pool_id": null, 
-      "redirect_url": null, 
-      "rules": [], 
-      "tenant_id": "ba91c2d0dee44bea8f235bed14519a8c"
-    }
-  ], 
-  "l7policy_rules": [], 
-  "listeners": [
-    {
-      "admin_state_up": true, 
-      "connection_limit": -1, 
-      "default_pool_id": "e70cedf7-6305-4f3c-91aa-6a14ae58136c", 
-      "default_tls_container_id": null, 
-      "description": "", 
-      "id": "dc66bf27-490a-4913-9f4f-12c885afe7a1", 
-      "l7_policies": [
-        {
-          "id": "d2c6f5f1-725f-4ef9-bf9c-de7394d07852"
-        }
-      ], 
-      "loadbalancer_id": "ca495325-7bab-4a9d-83e3-1ad922ba88a2", 
-      "name": "listener1", 
-      "operating_status": "ONLINE", 
-      "protocol": "HTTP", 
-      "protocol_port": 80, 
-      "provisioning_status": "ACTIVE", 
-      "sni_containers": [], 
-      "tenant_id": "ba91c2d0dee44bea8f235bed14519a8c"
-    }
-  ], 
-  "loadbalancer": {
-    "admin_state_up": true, 
-    "description": "", 
-    "gre_vteps": [], 
-    "id": "ca495325-7bab-4a9d-83e3-1ad922ba88a2", 
-    "listeners": [
-      {
-        "id": "dc66bf27-490a-4913-9f4f-12c885afe7a1"
-      }
-    ], 
-    "name": "lb1", 
-    "network_id": "f5bd1ecc-b801-4464-a0c9-d4727c9d9e37", 
-    "operating_status": "ONLINE", 
-    "pools": [
-      {
-        "id": "e70cedf7-6305-4f3c-91aa-6a14ae58136c"
-      }
-    ], 
-    "provider": "f5networks", 
-    "provisioning_status": "ACTIVE", 
-    "tenant_id": "ba91c2d0dee44bea8f235bed14519a8c", 
-    "vip_address": "10.2.3.101", 
-    "vip_port": {
-      "admin_state_up": true, 
-      "allowed_address_pairs": [], 
-      "binding:host_id": "host-168.int.lineratesystems.com:66c6c66c-da52-5050-9882-9848208dd8c9", 
-      "binding:profile": {}, 
-      "binding:vif_details": {}, 
-      "binding:vif_type": "binding_failed", 
-      "binding:vnic_type": "normal", 
-      "created_at": "2017-03-02T16:06:57", 
-      "description": null, 
-      "device_id": "55b3b802-8f40-5c25-ad65-d1515799ab4c", 
-      "device_owner": "network:f5lbaasv2", 
-      "dns_name": null, 
-      "extra_dhcp_opts": [], 
-      "fixed_ips": [
-        {
-          "ip_address": "10.2.3.101", 
-          "subnet_id": "1a323a31-be7c-4c82-b511-e83b3ffe09ee"
-        }
-      ], 
-      "id": "d16c9933-14d5-4b4c-9ace-99825fb321e8", 
-      "mac_address": "fa:16:3e:4b:7c:bf", 
-      "name": "loadbalancer-ca495325-7bab-4a9d-83e3-1ad922ba88a2", 
-      "network_id": "f5bd1ecc-b801-4464-a0c9-d4727c9d9e37", 
-      "security_groups": [
-        "6d60808f-ef2b-433c-96e6-6ad823ca6862"
-      ], 
-      "status": "DOWN", 
-      "tenant_id": "ba91c2d0dee44bea8f235bed14519a8c", 
-      "updated_at": "2017-03-02T16:06:57"
-    }, 
-    "vip_port_id": "d16c9933-14d5-4b4c-9ace-99825fb321e8", 
-    "vip_subnet_id": "1a323a31-be7c-4c82-b511-e83b3ffe09ee", 
-    "vxlan_vteps": [
-      "201.0.168.1", 
-      "201.0.169.1", 
-      "201.0.166.1"
-    ]
-  }, 
-  "members": [], 
-  "networks": {
-    "f5bd1ecc-b801-4464-a0c9-d4727c9d9e37": {
-      "admin_state_up": true, 
-      "availability_zone_hints": [], 
-      "availability_zones": [
-        "nova"
-      ], 
-      "created_at": "2017-03-02T15:28:02", 
-      "description": "", 
-      "id": "f5bd1ecc-b801-4464-a0c9-d4727c9d9e37", 
-      "ipv4_address_scope": null, 
-      "ipv6_address_scope": null, 
-      "mtu": 1450, 
-      "name": "testlab-server-network", 
-      "provider:network_type": "vxlan", 
-      "provider:physical_network": null, 
-      "provider:segmentation_id": 58, 
-      "router:external": false, 
-      "shared": false, 
-      "status": "ACTIVE", 
-      "subnets": [
-        "88fad3dd-d977-4000-9c9c-22f6ff640f3e", 
-        "1a323a31-be7c-4c82-b511-e83b3ffe09ee"
-      ], 
-      "tags": [], 
-      "tenant_id": "ba91c2d0dee44bea8f235bed14519a8c", 
-      "updated_at": "2017-03-02T15:28:02", 
-      "vlan_transparent": null
-    }
-  }, 
-  "pools": [
-    {
-      "admin_state_up": true, 
-      "description": "", 
-      "healthmonitor_id": null, 
-      "id": "e70cedf7-6305-4f3c-91aa-6a14ae58136c", 
-      "l7_policies": [], 
-      "lb_algorithm": "ROUND_ROBIN", 
-      "listener_id": "dc66bf27-490a-4913-9f4f-12c885afe7a1", 
-      "listeners": [
-        {
-          "id": "dc66bf27-490a-4913-9f4f-12c885afe7a1"
-        }
-      ], 
-      "loadbalancer_id": "ca495325-7bab-4a9d-83e3-1ad922ba88a2", 
-      "members": [], 
-      "name": "pool1", 
-      "operating_status": "ONLINE", 
-      "protocol": "HTTP", 
-      "provisioning_status": "ACTIVE", 
-      "session_persistence": {
-        "cookie_name": null, 
-        "type": "HTTP_COOKIE"
-      }, 
-      "sessionpersistence": null, 
-      "tenant_id": "ba91c2d0dee44bea8f235bed14519a8c"
-    }
-  ], 
-  "subnets": {
-    "1a323a31-be7c-4c82-b511-e83b3ffe09ee": {
-      "allocation_pools": [
-        {
-          "end": "10.2.3.150", 
-          "start": "10.2.3.100"
-        }
-      ], 
-      "cidr": "10.2.3.0/24", 
-      "created_at": "2017-03-02T15:28:03", 
-      "description": "", 
-      "dns_nameservers": [], 
-      "enable_dhcp": true, 
-      "gateway_ip": null, 
-      "host_routes": [], 
-      "id": "1a323a31-be7c-4c82-b511-e83b3ffe09ee", 
-      "ip_version": 4, 
-      "ipv6_address_mode": null, 
-      "ipv6_ra_mode": null, 
-      "name": "testlab-server-v4-subnet", 
-      "network_id": "f5bd1ecc-b801-4464-a0c9-d4727c9d9e37", 
-      "shared": false, 
-      "subnetpool_id": null, 
-      "tenant_id": "ba91c2d0dee44bea8f235bed14519a8c", 
-      "updated_at": "2017-03-02T15:28:03"
-    }
-  }
-},{
-  "healthmonitors": [], 
-  "l7policies": [
-    {
-      "action": "REJECT", 
-      "admin_state_up": true, 
-      "description": "", 
-      "id": "d2c6f5f1-725f-4ef9-bf9c-de7394d07852", 
-      "listener_id": "dc66bf27-490a-4913-9f4f-12c885afe7a1", 
-      "name": "esd_demo_2", 
-      "position": 1, 
-      "provisioning_status": "PENDING_DELETE", 
-      "redirect_pool_id": null, 
-      "redirect_url": null, 
-      "rules": [], 
-      "tenant_id": "ba91c2d0dee44bea8f235bed14519a8c"
-    }
-  ], 
-  "l7policy_rules": [], 
-  "listeners": [
-    {
-      "admin_state_up": true, 
-      "connection_limit": -1, 
-      "default_pool_id": "e70cedf7-6305-4f3c-91aa-6a14ae58136c", 
-      "default_tls_container_id": null, 
-      "description": "", 
-      "id": "dc66bf27-490a-4913-9f4f-12c885afe7a1", 
-      "l7_policies": [
-        {
-          "id": "d2c6f5f1-725f-4ef9-bf9c-de7394d07852"
-        }
-      ], 
-      "loadbalancer_id": "ca495325-7bab-4a9d-83e3-1ad922ba88a2", 
-      "name": "listener1", 
-      "operating_status": "ONLINE", 
-      "protocol": "HTTP", 
-      "protocol_port": 80, 
-      "provisioning_status": "ACTIVE", 
-      "sni_containers": [], 
-      "tenant_id": "ba91c2d0dee44bea8f235bed14519a8c"
-    }
-  ], 
-  "loadbalancer": {
-    "admin_state_up": true, 
-    "description": "", 
-    "gre_vteps": [], 
-    "id": "ca495325-7bab-4a9d-83e3-1ad922ba88a2", 
-    "listeners": [
-      {
-        "id": "dc66bf27-490a-4913-9f4f-12c885afe7a1"
-      }
-    ], 
-    "name": "lb1", 
-    "network_id": "f5bd1ecc-b801-4464-a0c9-d4727c9d9e37", 
-    "operating_status": "ONLINE", 
-    "pools": [
-      {
-        "id": "e70cedf7-6305-4f3c-91aa-6a14ae58136c"
-      }
-    ], 
-    "provider": "f5networks", 
-    "provisioning_status": "PENDING_UPDATE", 
-    "tenant_id": "ba91c2d0dee44bea8f235bed14519a8c", 
-    "vip_address": "10.2.3.101", 
-    "vip_port": {
-      "admin_state_up": true, 
-      "allowed_address_pairs": [], 
-      "binding:host_id": "host-168.int.lineratesystems.com:66c6c66c-da52-5050-9882-9848208dd8c9", 
-      "binding:profile": {}, 
-      "binding:vif_details": {}, 
-      "binding:vif_type": "binding_failed", 
-      "binding:vnic_type": "normal", 
-      "created_at": "2017-03-02T16:06:57", 
-      "description": null, 
-      "device_id": "55b3b802-8f40-5c25-ad65-d1515799ab4c", 
-      "device_owner": "network:f5lbaasv2", 
-      "dns_name": null, 
-      "extra_dhcp_opts": [], 
-      "fixed_ips": [
-        {
-          "ip_address": "10.2.3.101", 
-          "subnet_id": "1a323a31-be7c-4c82-b511-e83b3ffe09ee"
-        }
-      ], 
-      "id": "d16c9933-14d5-4b4c-9ace-99825fb321e8", 
-      "mac_address": "fa:16:3e:4b:7c:bf", 
-      "name": "loadbalancer-ca495325-7bab-4a9d-83e3-1ad922ba88a2", 
-      "network_id": "f5bd1ecc-b801-4464-a0c9-d4727c9d9e37", 
-      "security_groups": [
-        "6d60808f-ef2b-433c-96e6-6ad823ca6862"
-      ], 
-      "status": "DOWN", 
-      "tenant_id": "ba91c2d0dee44bea8f235bed14519a8c", 
-      "updated_at": "2017-03-02T16:06:57"
-    }, 
-    "vip_port_id": "d16c9933-14d5-4b4c-9ace-99825fb321e8", 
-    "vip_subnet_id": "1a323a31-be7c-4c82-b511-e83b3ffe09ee", 
-    "vxlan_vteps": [
-      "201.0.168.1", 
-      "201.0.169.1", 
-      "201.0.166.1"
-    ]
-  }, 
-  "members": [], 
-  "networks": {
-    "f5bd1ecc-b801-4464-a0c9-d4727c9d9e37": {
-      "admin_state_up": true, 
-      "availability_zone_hints": [], 
-      "availability_zones": [
-        "nova"
-      ], 
-      "created_at": "2017-03-02T15:28:02", 
-      "description": "", 
-      "id": "f5bd1ecc-b801-4464-a0c9-d4727c9d9e37", 
-      "ipv4_address_scope": null, 
-      "ipv6_address_scope": null, 
-      "mtu": 1450, 
-      "name": "testlab-server-network", 
-      "provider:network_type": "vxlan", 
-      "provider:physical_network": null, 
-      "provider:segmentation_id": 58, 
-      "router:external": false, 
-      "shared": false, 
-      "status": "ACTIVE", 
-      "subnets": [
-        "88fad3dd-d977-4000-9c9c-22f6ff640f3e", 
-        "1a323a31-be7c-4c82-b511-e83b3ffe09ee"
-      ], 
-      "tags": [], 
-      "tenant_id": "ba91c2d0dee44bea8f235bed14519a8c", 
-      "updated_at": "2017-03-02T15:28:02", 
-      "vlan_transparent": null
-    }
-  }, 
-  "pools": [
-    {
-      "admin_state_up": true, 
-      "description": "", 
-      "healthmonitor_id": null, 
-      "id": "e70cedf7-6305-4f3c-91aa-6a14ae58136c", 
-      "l7_policies": [], 
-      "lb_algorithm": "ROUND_ROBIN", 
-      "listener_id": "dc66bf27-490a-4913-9f4f-12c885afe7a1", 
-      "listeners": [
-        {
-          "id": "dc66bf27-490a-4913-9f4f-12c885afe7a1"
-        }
-      ], 
-      "loadbalancer_id": "ca495325-7bab-4a9d-83e3-1ad922ba88a2", 
-      "members": [], 
-      "name": "pool1", 
-      "operating_status": "ONLINE", 
-      "protocol": "HTTP", 
-      "provisioning_status": "ACTIVE", 
-      "session_persistence": {
-        "cookie_name": null, 
-        "type": "HTTP_COOKIE"
-      }, 
-      "sessionpersistence": null, 
-      "tenant_id": "ba91c2d0dee44bea8f235bed14519a8c"
-    }
-  ], 
-  "subnets": {
-    "1a323a31-be7c-4c82-b511-e83b3ffe09ee": {
-      "allocation_pools": [
-        {
-          "end": "10.2.3.150", 
-          "start": "10.2.3.100"
-        }
-      ], 
-      "cidr": "10.2.3.0/24", 
-      "created_at": "2017-03-02T15:28:03", 
-      "description": "", 
-      "dns_nameservers": [], 
-      "enable_dhcp": true, 
-      "gateway_ip": null, 
-      "host_routes": [], 
-      "id": "1a323a31-be7c-4c82-b511-e83b3ffe09ee", 
-      "ip_version": 4, 
-      "ipv6_address_mode": null, 
-      "ipv6_ra_mode": null, 
-      "name": "testlab-server-v4-subnet", 
-      "network_id": "f5bd1ecc-b801-4464-a0c9-d4727c9d9e37", 
-      "shared": false, 
-      "subnetpool_id": null, 
-      "tenant_id": "ba91c2d0dee44bea8f235bed14519a8c", 
-      "updated_at": "2017-03-02T15:28:03"
-    }
-  }
-},{
+ },
+ "delete_pool": {
   "healthmonitors": [], 
   "l7policies": [], 
   "l7policy_rules": [], 
@@ -1350,7 +978,8 @@
       "updated_at": "2017-03-02T15:28:03"
     }
   }
-},{
+ },
+ "delete_listener": {
   "healthmonitors": [], 
   "l7policies": [], 
   "l7policy_rules": [], 
@@ -1489,7 +1118,8 @@
       "updated_at": "2017-03-02T15:28:03"
     }
   }
-},{
+ },
+ "delete_loadbalancer": {
   "healthmonitors": [], 
   "l7policies": [], 
   "l7policy_rules": [], 
@@ -1606,4 +1236,5 @@
       "updated_at": "2017-03-02T15:28:03"
     }
   }
-}]
+}
+}


### PR DESCRIPTION
@richbrowne 

This PR adds 11 tests (2 of which are refactored old tests).

I believe this test suite shows 3 different issues, which I will file tomorrow.

To run the tests:

`cd f5-openstack-agent && pytest -v --symbols ${SYM} test/functional/neutronless/esd/test_esd.py`
