### PR TITLE
Fix docs deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ deploy:
       branch: master
       condition: $TRAVIS_TAG = ""
     script:
-    - ./docs/scripts/deploy-docs.sh publish-product-docs-to-prod openstack/agent newton
+    - ./docs/scripts/deploy-docs.sh publish-product-docs-to-prod openstack/agent $TRAVIS_BRANCH
   # if this is a tagged release, the docs go to /products/openstack/agent/$TRAVIS_BRANCH/vX.Y
   - provider: script
     skip_cleanup: true

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -8,7 +8,7 @@ Glossary
 
    segmentation ID
    segmentation id
-      `VLAN tag <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-routing-administration-12-0-0/5.html#unique_1525090453>`_
+      `VLAN tag <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-routing-administration-12-0-0/5.html>`_
 
    device
       `BIG-IP`_ hardware or virtual edition (VE).

--- a/docs/l2-adjacent-mode.rst
+++ b/docs/l2-adjacent-mode.rst
@@ -12,7 +12,7 @@ L2-adjacent mode is the **default mode of operation** for the |agent-short|.
 
 .. important::
 
-   - All Neutron and external network components should be set up before you deploy the |agent-short| in L2-adjacent mode.
+   - Set up all Neutron and external network components *before* you deploy the |agent-short| in L2-adjacent mode.
    - This mode of deployment may require a BIG-IP `Better or Best license`_ that supports SDN.
 
 .. warning::

--- a/requirements.functest.txt
+++ b/requirements.functest.txt
@@ -2,8 +2,8 @@
 
 # OpenStack dependencies, Za doesn't know how pip-over-git interacts with
 # constraints.txt's .
-git+https://github.com/openstack/neutron@stable/newton
-git+https://github.com/openstack/neutron-lbaas.git@stable/newton
+git+https://github.com/openstack/neutron@newton-eol
+git+https://github.com/openstack/neutron-lbaas.git@newton-eol
 
 # F5 LBaaS dependancies
 git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@stable/newton
@@ -15,7 +15,7 @@ git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@stable/newton
 # misleading to readers of this file.
 -c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/newton
 
-git+https://github.com/openstack/oslo.log.git@stable/newton
+git+https://github.com/openstack/oslo.log.git@newton-eol
 pytest==IGNORED    # See section comment
 mock==IGNORED      # See section comment
 coverage==IGNORED  # See section comment

--- a/requirements.unittest.txt
+++ b/requirements.unittest.txt
@@ -1,9 +1,9 @@
 -e .
 
 # app
-git+https://github.com/openstack/neutron@stable/newton
-git+https://github.com/openstack/oslo.log.git@stable/newton
-git+https://github.com/openstack/neutron-lbaas.git@stable/newton
+git+https://github.com/openstack/neutron@newton-eol
+git+https://github.com/openstack/oslo.log.git@newton-eol
+git+https://github.com/openstack/neutron-lbaas.git@newton-eol
 git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@stable/newton
 
 pytest-cov==2.5.1


### PR DESCRIPTION
@richbrowne 

#### What issues does this address?
Fixes #1067 

#### What's this change do?
Fixes an issue where the docs deploy to the wrong location in clouddocs. They are deploying to newton instead of to master.

#### Where should the reviewer start?

#### Any background context?
- Previous PR with this change ( #1068) was closed without merging (not sure why).
- This PR updates the unit and functest requirements to point to the newton-eol tag in the openstack projects.
