### PR TITLE
test issue 1047 conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ install:
 script:
     - pep257 ./test/functional/neutronless/esd/test_esd.py
     - flake8 --ignore=H304 ./test/functional/neutronless/esd/test_esd.py
-    - pylint -E -d E1101 test/functional/neutronless/esd/test_esd.py
     - pep257 ./test/functional/neutronless/esd/conftest.py
     - flake8 --ignore=H304 ./test/functional/neutronless/esd/conftest.py
     - pep257 ./test/functional/neutronless/esd/test_esd_pairs.py

--- a/test/functional/neutronless/esd/test_esd.py
+++ b/test/functional/neutronless/esd/test_esd.py
@@ -74,3 +74,29 @@ def test_esd_lbaas_fallback_persist(ESD_Experiment):
 def test_esd_full_8_tag_set(ESD_Experiment):
     """Test of a full tag set.  Tags specifics are historical."""
     apply_validate_remove_validate(ESD_Experiment)
+
+
+def test_esd_issue_1047_basic(ESD_Experiment, bigip):
+    """Test behavior of l7policy removal as documented in github issue.
+
+    https://github.com/F5Networks/f5-openstack-agent/issues/1047
+    """
+    test_virtual = bigip.bigip.tm.ltm.virtuals.get_collection()[0]
+    assert test_virtual.vlansEnabled is True
+    assert test_virtual.vlans != []
+    apply_validate_remove_validate(ESD_Experiment)
+    assert test_virtual.vlansEnabled is True
+    assert test_virtual.vlans != []
+
+
+def test_esd_dmzmobile(ESD_Experiment, bigip):
+    """Test behavior of l7policy removal as documented in github issue.
+
+    https://github.com/F5Networks/f5-openstack-agent/issues/1047
+    """
+    test_virtual = bigip.bigip.tm.ltm.virtuals.get_collection()[0]
+    assert test_virtual.vlansEnabled is True
+    assert test_virtual.vlans != []
+    apply_validate_remove_validate(ESD_Experiment)
+    assert test_virtual.vlansEnabled is True
+    assert test_virtual.vlans == ["REPLACE ME WITH A REAL VALUE!"]

--- a/test/functional/testdata/esds/demo.json
+++ b/test/functional/testdata/esds/demo.json
@@ -24,5 +24,22 @@
   "f5_ESD_lbaas_irule":            { "lbaas_irule": ["_sys_https_redirect"] },
   "f5_ESD_lbaas_policy":           { "lbaas_policy": ["demo_policy"] },
   "f5_ESD_lbaas_persist":          { "lbaas_persist": "hash" },
-  "f5_ESD_lbaas_fallback_persist": { "lbaas_fallback_persist": "source_addr" }
+  "f5_ESD_lbaas_fallback_persist": { "lbaas_fallback_persist": "source_addr" },
+
+  "f5_ESD_issue_1047_basic":             { "lbaas_ctcp": "tcp-mobile-optimized" },
+  "f5_ESD_dmzmobile": {
+    "lbaas_ctcp": "tcp-mobile-optimized",
+    "lbaas_stcp": "tcp-lan-optimized",
+    "lbaas_cssl_profile": "clientssl-secure",
+    "lbaas_sssl_profile": "serverssl",
+    "lbaas_irule": ["server_header_scrub","cve-2017-5638","cve-2015-1635","cve-2013-0156"],
+    "lbaas_policy": ["dmz"],
+    "lbaas_persist": "cookie",
+    "lbaas_fallback_persist": "source_addr"
+    },
+
+  "f5_ESD_issue_1046_basic": {
+    "lbaas_persist": "cookie",
+    "lbaas_fallback_persist": "source_addr"
+    }
 }


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
WIP #1047 (TEST ONLY)
...

#### What's this change do?

I added two tests, one tests a base case, single tag ESD, the other tests the verbatim ESD mentioned in the issue.


#### Where should the reviewer start?

A sanity check with a manual invocation of `l7policy create` against a real neutron will verify that the service object from the `testdata` directory is valid or not.   This will eliminate the possibility of a bad-data test bug.

#### Any background context?

#1047 

Upon investigation of this issue we determined that tests using the service objects in the testdata library create virtuals with `vlansDisabled=True` and no `vlans` element.  This configures the virtual in question to listen to ALL vlans.

As mentioned above this may be a testdata bug, in which case manual confirmation will detect the issue.   In that case the fix is to simply update the service object in the testdata lib.

More likely is that there is a bug in the agent, in which case ensuring proper behavior with respect to the `vlans` element will probably also fix #1047 .
