### PR TITLE
Test had erroneous 'gbigip' argument instead of bigip

### DIFF
--- a/test/functional/neutronless/loadbalancer/test_f5_common_networks.py
+++ b/test/functional/neutronless/loadbalancer/test_f5_common_networks.py
@@ -86,7 +86,7 @@ def icontrol_driver(icd_config, fake_plugin_rpc):
     return icd
 
 
-def test_tentant(track_bigip_cfg, gbigip, services, icd_config,
+def test_tenant(track_bigip_cfg, bigip, services, icd_config,
                  icontrol_driver):
     """Test creating and deleting SNAT pools with common network listener.
 


### PR DESCRIPTION
Problem:
* When previously adding fixtures, the 'cfg' string becam 'cf, g'
  * This results in a gbigip not being recognized
  * Later fix scrubbed the 'cf' to 'cfg'

Solution:
* Fixed the typo
* Also fixed other typo in the test name

Test:
This is a typo fix in a test

@richbrowne 
#### What issues does this address?
WIP #863 

#### What's this change do?
Fixes typos

#### Where should the reviewer start?
The one test module

#### Any background context?
The /tentant/tenant/ typo comes from a different time.