### PR TITLE
Remove implementation of track_bigip_cfg until it can use pytest.symb…

### DIFF
--- a/test/functional/neutronless/conftest.py
+++ b/test/functional/neutronless/conftest.py
@@ -241,8 +241,9 @@ def bigip(request):
 
 @pytest.fixture
 def track_bigip_cfg(request):
-    request.addfinalizer(BigIpInteraction.check_resulting_cfg)
-    BigIpInteraction.backup_bigip_cfg()
+    # request.addfinalizer(BigIpInteraction.check_resulting_cfg)
+    # BigIpInteraction.backup_bigip_cfg()
+    pass
 
 
 def debug_msg(status):


### PR DESCRIPTION
The agent tests do not need a bastion to run; therefore, the fixture that captures the state of the BigIP under test needs to be implemented to use the credentials in a symbol file.