### PR TITLE
Refactor single member tests

### DIFF
--- a/test/functional/neutronless/member/test_single_member.py
+++ b/test/functional/neutronless/member/test_single_member.py
@@ -30,7 +30,6 @@ requests.packages.urllib3.disable_warnings()
 
 LOG = logging.getLogger(__name__)
 
-
 @pytest.fixture(scope="module")
 def services():
     neutron_services_filename = (
@@ -40,246 +39,104 @@ def services():
     return (json.load(open(neutron_services_filename)))
 
 
-@pytest.fixture()
-def service_create_member_up_down():
+def get_service_file(relative_path):
+    test_file_path = os.path.dirname(os.path.abspath(__file__))
     neutron_services_filename = (
-        os.path.join(
-            os.path.dirname(os.path.abspath(__file__)),
-            '../../testdata/service_requests/create_single_member_up_down.json')
+        os.path.join(test_file_path,relative_path)
     )
     return (json.load(open(neutron_services_filename)))
 
-
-@pytest.fixture()
-def service_create_member_down_up():
-    neutron_services_filename = (
-        os.path.join(
-            os.path.dirname(os.path.abspath(__file__)),
-            '../../testdata/service_requests/create_single_member_down_up.json')
-    )
-    return (json.load(open(neutron_services_filename)))
-
-
-def lbaas_service_one_member(request,
-                             bigip,
-                             services,
-                             icd_config,
-                             icontrol_driver):
-    env_prefix = icd_config['environment_prefix']
-    service_iter = iter(services)
-    validator = ResourceValidator(bigip, env_prefix)
-
-    # create loadbalancer
-    service = service_iter.next()
-    lb_reader = LoadbalancerReader(service)
-    folder = '{0}_{1}'.format(env_prefix, lb_reader.tenant_id())
-    icontrol_driver._common_service_handler(service)
-    assert bigip.folder_exists(folder)
-
-    # create listener
-    service = service_iter.next()
-    listener = service['listeners'][0]
-    icontrol_driver._common_service_handler(service)
-    validator.assert_virtual_valid(listener, folder)
-
-    # create pool
-    service = service_iter.next()
-    pool = service['pools'][0]
-    icontrol_driver._common_service_handler(service)
-    validator.assert_pool_valid(pool, folder)
-
-    # create health monitor
-    service = service_iter.next()
-    monitor = service['healthmonitors'][0]
-    icontrol_driver._common_service_handler(service)
-    validator.assert_healthmonitor_valid(monitor, folder)
-
-    # create member, node
-    service = service_iter.next()
-    member = service['members'][0]
-    icontrol_driver._common_service_handler(service)
-    validator.assert_member_valid(pool, member, folder)
-
-    def fin():
-        # delete health monitor
-        service = service_iter.next()
-        icontrol_driver._common_service_handler(service)
-        validator.assert_healthmonitor_deleted(monitor, folder)
-
-        # delete pool (and member, node)
-        service = service_iter.next()
-        icontrol_driver._common_service_handler(service)
-        validator.assert_pool_deleted(pool, member, folder)
-
-        # delete listener
-        service = service_iter.next()
-        icontrol_driver._common_service_handler(service)
-        validator.assert_virtual_deleted(listener, folder)
-
-        # delete loadbalancer
-        service = service_iter.next()
-        icontrol_driver._common_service_handler(service, delete_partition=True)
-        assert not bigip.folder_exists(folder)
-
-    request.addfinalizer(fin)
-    return service_iter
-
-
-def test_create_single_member_up(
-        track_bigip_cfg, bigip, service_create_member_up_down, icd_config,
-        icontrol_driver):
-    """Tests the creation of a single member and that it is up"""
-    env_prefix = icd_config['environment_prefix']
-    service_iter = iter(service_create_member_up_down)
-
-    service = service_iter.next()
+def get_service_info(service, env_prefix):
     member = service['members'][0]
     pool = service['pools'][0]
     folder = '{0}_{1}'.format(env_prefix, pool['tenant_id'])
-
-    icontrol_driver._common_service_handler(service)
-
     pool_name = '{0}_{1}'.format(env_prefix, pool['id'])
     member_name = '{0}:{1}'.format(member['address'],
                                    member['protocol_port'])
     node_name = '{0}'.format(member['address'])
 
-    assert bigip.member_exists(
-        pool_name, member_name, partition=folder)
-    assert bigip.resource_exists(
-        ResourceType.node, node_name, partition=folder)
+    return pool_name, member_name, node_name, folder
 
+
+def get_member_created(bigip, pool_name, member_name, folder):
     p = bigip.get_resource(ResourceType.pool, pool_name, partition=folder)
-
     m = p.members_s.members
     m = m.load(name=urllib.quote(member_name), partition=folder)
-
-    assert m.address == "10.2.1.2%1"
-    assert m.session == "monitor-enabled"
-    assert m.ratio == 1
+    return m
 
 
-def test_create_single_member_down(track_bigip_cfg,
-                                   bigip,
-                                   service_create_member_down_up,
-                                   icd_config,
-                                   icontrol_driver):
-    """Tests a single member being down"""
+def check_member_up(member):
+    assert member.address == "10.2.1.2%1"
+    assert member.session == "monitor-enabled"
+    assert member.ratio == 1
+
+
+def check_member_down(member):
+    assert member.address == "10.2.1.2%1"
+    assert member.session == "user-disabled"
+    assert member.ratio == 1
+
+
+def test_create_single_member_down_up(bigip,
+                              track_bigip_cfg,
+                              icd_config,
+                              icontrol_driver):
+
     env_prefix = icd_config['environment_prefix']
+
+    # Tests the creation and bringing a member down and then up
+    service_create_member_down_up = get_service_file(
+        '../../testdata/service_requests/create_single_member_down_up.json')
     service_iter = iter(service_create_member_down_up)
 
+    # create single member down
     service = service_iter.next()
-    member = service['members'][0]
-    pool = service['pools'][0]
-    folder = '{0}_{1}'.format(env_prefix, pool['tenant_id'])
-
     icontrol_driver._common_service_handler(service)
 
-    pool = service['pools'][0]
-    pool_name = '{0}_{1}'.format(env_prefix, pool['id'])
-    member_name = '{0}:{1}'.format(member['address'],
-                                   member['protocol_port'])
-    node_name = '{0}'.format(member['address'])
-
+    pool_name, member_name, node_name, folder = get_service_info(service,
+                                                                 env_prefix)
     assert bigip.member_exists(
         pool_name, member_name, partition=folder)
     assert bigip.resource_exists(
         ResourceType.node, node_name, partition=folder)
 
-    p = bigip.get_resource(ResourceType.pool, pool_name, partition=folder)
+    m = get_member_created(bigip, pool_name, member_name, folder)
+    check_member_down(m)
 
-    m = p.members_s.members
-    m = m.load(name=urllib.quote(member_name), partition=folder)
-
-    assert m.address == "10.2.1.2%1"
-    assert m.session == "user-disabled"
-    assert m.ratio == 1
-
-
-def test_create_single_member_down_up(track_bigip_cfg,
-                                      bigip,
-                                      service_create_member_down_up,
-                                      icd_config,
-                                      icontrol_driver):
-    """Tests the creation and bringing a member up and then down"""
-    env_prefix = icd_config['environment_prefix']
-    service_iter = iter(service_create_member_down_up)
-
-    service = service_iter.next()
-    member = service['members'][0]
-    pool = service['pools'][0]
-    folder = '{0}_{1}'.format(env_prefix, pool['tenant_id'])
-
-    icontrol_driver._common_service_handler(service)
-
-    pool = service['pools'][0]
-    pool_name = '{0}_{1}'.format(env_prefix, pool['id'])
-    member_name = '{0}:{1}'.format(member['address'],
-                                   member['protocol_port'])
-    node_name = '{0}'.format(member['address'])
-
-    assert bigip.member_exists(
-        pool_name, member_name, partition=folder)
-    assert bigip.resource_exists(
-        ResourceType.node, node_name, partition=folder)
-
-    p = bigip.get_resource(ResourceType.pool, pool_name, partition=folder)
-    m = p.members_s.members
-    m = m.load(name=urllib.quote(member_name), partition=folder)
-
-    assert m.address == "10.2.1.2%1"
-    assert m.session == "user-disabled"
-
+    # bring member up
     service = service_iter.next()
     icontrol_driver._common_service_handler(service)
-
-    p = bigip.get_resource(ResourceType.pool, pool_name, partition=folder)
-    m = p.members_s.members
-    m = m.load(name=urllib.quote(member_name), partition=folder)
-
-    assert m.address == "10.2.1.2%1"
-    assert m.session == "monitor-enabled"
-
+    m = get_member_created(bigip, pool_name, member_name, folder)
+    check_member_up(m)
 
 def test_create_single_member_up_down(bigip,
-                                      service_create_member_up_down,
-                                      icd_config,
-                                      icontrol_driver, track_bigip_cfg):
-    """Tests single member can be brought up and then down"""
+                              track_bigip_cfg,
+                              icd_config,
+                              icontrol_driver):
+
     env_prefix = icd_config['environment_prefix']
+
+    # Tests the creation and bringing a member up and then down
+    service_create_member_up_down = get_service_file(
+        '../../testdata/service_requests/create_single_member_up_down.json')
     service_iter = iter(service_create_member_up_down)
 
+    # create single member up
     service = service_iter.next()
-    member = service['members'][0]
-    pool = service['pools'][0]
-    folder = '{0}_{1}'.format(env_prefix, pool['tenant_id'])
-
     icontrol_driver._common_service_handler(service)
 
-    pool = service['pools'][0]
-    pool_name = '{0}_{1}'.format(env_prefix, pool['id'])
-    member_name = '{0}:{1}'.format(member['address'],
-                                   member['protocol_port'])
-    node_name = '{0}'.format(member['address'])
-
+    pool_name, member_name, node_name, folder = get_service_info(service,
+                                                                 env_prefix)
     assert bigip.member_exists(
         pool_name, member_name, partition=folder)
     assert bigip.resource_exists(
         ResourceType.node, node_name, partition=folder)
 
-    p = bigip.get_resource(ResourceType.pool, pool_name, partition=folder)
-    m = p.members_s.members
-    m = m.load(name=urllib.quote(member_name), partition=folder)
+    m = get_member_created(bigip, pool_name, member_name, folder)
+    check_member_up(m)
 
-    assert m.address == "10.2.1.2%1"
-    assert m.session == "monitor-enabled"
-
+    # bring member down
     service = service_iter.next()
     icontrol_driver._common_service_handler(service)
-
-    p = bigip.get_resource(ResourceType.pool, pool_name, partition=folder)
-    m = p.members_s.members
-    m = m.load(name=urllib.quote(member_name), partition=folder)
-
-    assert m.address == "10.2.1.2%1"
-    assert m.session == "user-disabled"
+    m = get_member_created(bigip, pool_name, member_name, folder)
+    check_member_down(m)


### PR DESCRIPTION
Problem:
Neutronless single member tests need to be refactored.

Solution:
single member tests has a lot of repetitive tests that has now been consolidated.
test_single_member.py now has 2 tests test_create_single_member_down_up and
test_create_single_member_up_down.

@<reviewer_id>
#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?
