### PR TITLE
refactor neutronless test infrastructure

### DIFF
--- a/test/functional/neutronless/conftest.py
+++ b/test/functional/neutronless/conftest.py
@@ -12,28 +12,189 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+"""In addition to pytest fixtures this module also contains general classes.
 
-import json
-import os
-import pytest
-import re
-import traceback
-import sys
+    These classes are TestConfig, and Resource4TestTracker.
 
+    TestConfig:  This is a Python class designed to contain the configurable
+state and methods generally needed during testing.  The general approach is
+to provide a configuration specific to some test needs via the TestConfig
+objects methods (primarily, __init__, but also others e.g. "load_esd").
+
+   The expected caller of the TestConfig object is an Experiment fixture, where
+the experiment instantiates, and configures, a particular TestConfig instance, 
+before handing off to the test code.   Examples of "Experiments" can be found
+in esd/conftest.py.
+"""
+
+import collections
 from collections import deque
 from collections import namedtuple
 from copy import deepcopy
 from inspect import currentframe as cf
 from inspect import getframeinfo as gfi
 from inspect import getouterframes as gof
+import json
+import os
+from os.path import dirname as opd
+from os.path import join as opj
+import pytest
+import re
+import sys
+import traceback
 
-from .testlib.bigip_client import BigIpClient
-from bigip_interaction import BigIpInteraction
-from .testlib.fake_rpc import FakeRPCPlugin
 from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import \
     iControlDriver
 
+from .testlib.bigip_client import BigIpClient
+from .testlib.fake_rpc import FakeRPCPlugin
+from .testlib.resource_validator import ResourceValidator
+
 DEBUG = True  # sys.flags.debug
+
+DATADIR = opj(opd(opd(os.path.abspath(__file__))), "testdata")
+CONFIGDIR = opj(opd(DATADIR), "config")
+ESD_dir = opj(DATADIR, "esds")
+req_services_dir = opj(DATADIR, "service_requests")
+OSLOCONF = 'overcloud_basic_agent_config.json'
+
+
+class TestConfig(object):
+    """A configuration tool, Experiment fixtures use the public interface."""
+
+    def __init__(self,
+                 service_requests_file,
+                 oslo_config_file):
+        """Neutronless tests expect the state specified here.
+
+        self.oslo_config:  A faked interface to the oslo configuration system
+        self.TENANT_ID:    Usually a static fake specific to our test regime.
+        self.SERVICES:     Obtained by running replay scripts against neutron, 
+        we use these services to patch out neutron, by playing them through
+        the icontrol_driver._common_service_handler.
+        self.fake_rpc_OBJ: We can observe messages intended for neutron by
+        monitoring this.
+        self.ENV_PREFIX -FOLDER -OSLO_CONF:  Values set up for integration
+        tests (these tests run against a real bigip).
+        self.bigip:  The _agent's_ interface to a device (wraps the SDK).
+        self.validator:   A useful object that checks specific configurations
+        of the bigip according to agent-derived rules.
+        self.icontrol_driver:  An agent-internal method that submits service
+        objects (from neutron) to be interpreted and applied to the device. 
+        """
+        self.oslo_config = json.load(open(opj(CONFIGDIR, oslo_config_file)))
+        self.TENANT_ID, self.SERVICES =\
+            self.load_service(service_requests_file)
+        self.fake_rpc_OBJ = self.fake_plugin_rpc()
+        self.ENV_PREFIX, self.FOLDER, self.OSLO_CONF = self.icd_config()
+        self.bigip, self.validator = self.bigip()
+        self.icontrol_driver = self.icontrol_driver()
+
+    def load_service(self, service_file_name):
+        """Load testdata services that were produced by scripting neutron."""
+        neutron_services_filename = opj(req_services_dir, service_file_name)
+        SERVICE = json.load(open(neutron_services_filename),
+                            object_pairs_hook=collections.OrderedDict)
+        TENANT_ID = SERVICE["create_loadbalancer"]["loadbalancer"]["tenant_id"]
+        return TENANT_ID, SERVICE
+
+    def load_esd(self, esd_file):
+        """Obtain an esd for test, and attach it to an internal object."""
+        self.esd = json.load(open(opj(ESD_dir, esd_file)))
+        self.icontrol_driver.lbaas_builder.esd.esd_dict = self.esd
+
+    def define_esd_services(self, request):
+        """Extract the test name and process it as described above."""
+        literal_esd_name = request.function.__name__.partition('test_esd_')[2]
+        self.full_esd_name = 'f5_ESD_' + literal_esd_name
+        self.apply_esd = deepcopy(self.SERVICES["apply_ABSTRACT_ESD"])
+        self.remove_esd = deepcopy(self.SERVICES["remove_ABSTRACT_ESD"])
+        self.apply_esd['l7policies'][0]['name'] = self.full_esd_name
+        self.remove_esd['l7policies'][0]['name'] = self.full_esd_name
+
+    def fake_plugin_rpc(self):
+        """Return an object to patch out the RPC Plugin with."""
+        rpcObj = FakeRPCPlugin(self.SERVICES)
+
+        return rpcObj
+
+    def icd_config(self):
+        """Configure the icontrol_driver by mocking an historic oslo confg."""
+        config = deepcopy(self.oslo_config)
+        config['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
+        config['icontrol_username'] = pytest.symbols.bigip_username
+        config['icontrol_password'] = pytest.symbols.bigip_password
+        ENV_PREFIX = config['environment_prefix']
+        FOLDER = '{0}_{1}'.format(ENV_PREFIX, self.TENANT_ID)
+        return ENV_PREFIX, FOLDER, config
+
+    def bigip(self):
+        """Return a device-connected, agent-style, BigIpClient."""
+        bigip = BigIpClient(pytest.symbols.bigip_mgmt_ip_public,
+                            pytest.symbols.bigip_username,
+                            pytest.symbols.bigip_password)
+        VALIDATOR = ResourceValidator(bigip, self.ENV_PREFIX)
+        return bigip, VALIDATOR
+
+    def icontrol_driver(self):
+        """Return a patched icontrol_driver. Conf and RPC_plugin are fakes."""
+        class ConfFake(object):
+            """A configuration Fake that matches the oslo conf interface."""
+
+            def __init__(self, params):
+                self.__dict__ = params
+                for k, v in self.__dict__.items():
+                    if isinstance(v, unicode):
+                        self.__dict__[k] = v.encode('utf-8')
+
+            def __repr__(self):
+                return repr(self.__dict__)
+
+        icd = iControlDriver(ConfFake(self.OSLO_CONF),
+                             registerOpts=False)
+
+        icd.plugin_rpc = self.fake_plugin_rpc()
+        icd.connect()
+        return icd
+
+    def create_loadbalancer(self):
+        """Config the device, via the agent, with the fake neutron message."""
+        service = self.SERVICES['create_loadbalancer']
+        self.icontrol_driver._common_service_handler(service)
+        assert self.bigip.folder_exists(self.FOLDER)
+
+    def create_listener(self):
+        """Config the device, via the agent, with the fake neutron message."""
+        service = self.SERVICES['create_listener']
+        self.listener = service['listeners'][0]
+        self.icontrol_driver._common_service_handler(service)
+        self.validator.assert_virtual_valid(self.listener, self.FOLDER)
+
+    def create_pool(self):
+        """Config the device, via the agent, with the fake neutron message."""
+        service = self.SERVICES['create_pool']
+        self.pool = service['pools'][0]
+        self.icontrol_driver._common_service_handler(service)
+        self.validator.assert_pool_valid(self.pool, self.FOLDER)
+
+    def delete_pool(self):
+        """Config the device, via the agent, with the fake neutron message."""
+        service = self.SERVICES['delete_pool']
+        self.icontrol_driver._common_service_handler(service)
+        self.validator.assert_pool_deleted(self.pool, None, self.FOLDER)
+
+    def delete_listener(self):
+        """Config the device, via the agent, with the fake neutron message."""
+        service = self.SERVICES['delete_listener']
+        self.icontrol_driver._common_service_handler(service)
+        self.validator.assert_virtual_deleted(self.listener, self.FOLDER)
+
+    def delete_loadbalancer(self):
+        """Config the device, via the agent, with the fake neutron message."""
+        service = self.SERVICES['delete_loadbalancer']
+        self.icontrol_driver._common_service_handler(service,
+                                                     delete_partition=True)
+        assert not self.bigip.folder_exists(self.FOLDER)
 
 
 class Resource4TestTracker(object):
@@ -279,7 +440,6 @@ def icontrol_driver(icd_config, fake_plugin_rpc):
 
     icd.plugin_rpc = fake_plugin_rpc
     icd.connect()
-
     return icd
 
 

--- a/test/functional/neutronless/esd/conftest.py
+++ b/test/functional/neutronless/esd/conftest.py
@@ -38,187 +38,21 @@ the test FAILs), and the "remove_service" is then effected, and validated.
    It's not impossible that a FAIL at this point in the test could cause an
 ERROR in teardown.
 """
-import collections
-from copy import deepcopy
-import json
 import logging
-import os
 
 import pytest
 import requests
 
-from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import \
-    iControlDriver
 
-from ..testlib.bigip_client import BigIpClient
-from ..testlib.fake_rpc import FakeRPCPlugin
-from ..testlib.resource_validator import ResourceValidator
+from ..conftest import OSLOCONF
+from ..conftest import TestConfig
 
 requests.packages.urllib3.disable_warnings()
 LOG = logging.getLogger(__name__)
 
 
-global TENANT_ID
-global FOLDER
-global ENV_PREFIX
-global VALIDATOR
-
-
-@pytest.fixture(scope="module")
-def services():
-    """Load testdata services that were produced by scripting neutron.
-
-    WARNING: THIS FUNCTION SETS A MODULE_LEVEL GLOBAL!
-    """
-    neutron_services_filename = (
-        os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                     '../../testdata/service_requests/l7_esd.json')
-    )
-    s = json.load(open(neutron_services_filename),
-                  object_pairs_hook=collections.OrderedDict)
-    global TENANT_ID
-    TENANT_ID = s["create_loadbalancer"]["loadbalancer"]["tenant_id"]
-    return s
-
-
-@pytest.fixture(scope="module")
-def icd_config(services):
-    """Configure the icontrol_driver by mocking an historical oslo confg.
-
-    WARNING: THIS FUNCTION SETS A MODULE_LEVEL GLOBAL!
-    """
-    oslo_config_filename = (
-        os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                     '../../config/overcloud_basic_agent_config.json')
-    )
-    OSLO_CONFIGS = json.load(open(oslo_config_filename))
-
-    config = deepcopy(OSLO_CONFIGS)
-    config['icontrol_hostname'] = pytest.symbols.bigip_mgmt_ip_public
-    config['icontrol_username'] = pytest.symbols.bigip_username
-    config['icontrol_password'] = pytest.symbols.bigip_password
-    global ENV_PREFIX
-    ENV_PREFIX = config['environment_prefix']
-    global FOLDER
-    FOLDER = '{0}_{1}'.format(ENV_PREFIX, TENANT_ID)
-    return config
-
-
-@pytest.fixture(scope="module")
-def bigip(icd_config):
-    """Return a device-connected, agent-style, BigIpClient."""
-    bigip = BigIpClient(pytest.symbols.bigip_mgmt_ip_public,
-                        pytest.symbols.bigip_username,
-                        pytest.symbols.bigip_password)
-    global VALIDATOR
-    VALIDATOR = ResourceValidator(bigip, ENV_PREFIX)
-    return bigip
-
-
 @pytest.fixture
-def fake_plugin_rpc(services):
-    """Return an object to patch out the RPC Plugin with."""
-    rpcObj = FakeRPCPlugin(services)
-
-    return rpcObj
-
-
-@pytest.fixture
-def icontrol_driver(icd_config, fake_plugin_rpc):
-    """Return a patched icontrol_driver. Config and RPC_plugin are fakes."""
-    class ConfFake(object):
-        """A configuration Fake that matches the oslo conf interface."""
-
-        def __init__(self, params):
-            self.__dict__ = params
-            for k, v in self.__dict__.items():
-                if isinstance(v, unicode):
-                    self.__dict__[k] = v.encode('utf-8')
-
-        def __repr__(self):
-            return repr(self.__dict__)
-
-    icd = iControlDriver(ConfFake(icd_config),
-                         registerOpts=False)
-
-    icd.plugin_rpc = fake_plugin_rpc
-    icd.connect()
-
-    return icd
-
-
-def load_esd(target_esd):
-    """Return an esd dict containing state specced in demo.json."""
-    osd = os.path.dirname
-    ESDDIRNAME = os.path.join(osd(osd(osd(os.path.abspath(__file__)))),
-                              "testdata",
-                              "esds")
-    esd_file = os.path.join(ESDDIRNAME, target_esd)
-    return (json.load(open(esd_file)))
-
-
-TESTINFRA = collections.namedtuple(
-    "TESTINFRA", ('apply_service', 'remove_service', 'icontrol_driver', 'esd',
-                  'listener', 'esd_name')
-)
-
-
-def _create_loadbalancer(services, icontrol_driver, bigip):
-    service = services['create_loadbalancer']
-    icontrol_driver._common_service_handler(service)
-    assert bigip.folder_exists(FOLDER)
-
-
-def _create_listener(services, icontrol_driver):
-    service = services['create_listener']
-    listener = service['listeners'][0]
-    icontrol_driver._common_service_handler(service)
-    VALIDATOR.assert_virtual_valid(listener, FOLDER)
-    return listener
-
-
-def _create_pool(services, icontrol_driver):
-    service = services['create_pool']
-    pool = service['pools'][0]
-    icontrol_driver._common_service_handler(service)
-    VALIDATOR.assert_pool_valid(pool, FOLDER)
-    return pool
-
-
-def _delete_pool(services, icontrol_driver, pool):
-    service = services['delete_pool']
-    icontrol_driver._common_service_handler(service)
-    VALIDATOR.assert_pool_deleted(pool, None, FOLDER)
-
-
-def _delete_listener(services, icontrol_driver, listener):
-    service = services['delete_listener']
-    icontrol_driver._common_service_handler(service)
-    VALIDATOR.assert_virtual_deleted(listener, FOLDER)
-
-
-def _delete_loadbalancer(services, icontrol_driver, bigip):
-    service = services['delete_loadbalancer']
-    icontrol_driver._common_service_handler(service, delete_partition=True)
-    assert not bigip.folder_exists(FOLDER)
-
-
-def _set_esd(services, request):
-    """Extract the test name and process it as described above."""
-    literal_esd_name = request.function.__name__.partition('test_esd_')[2]
-    full_esd_name = 'f5_ESD_' + literal_esd_name
-    new_apply_esd = deepcopy(services["apply_ABSTRACT_ESD"])
-    new_remove_esd = deepcopy(services["remove_ABSTRACT_ESD"])
-    new_apply_esd['l7policies'][0]['name'] = full_esd_name
-    new_remove_esd['l7policies'][0]['name'] = full_esd_name
-    return new_apply_esd, new_remove_esd, full_esd_name
-
-
-Context = collections.namedtuple("Context", ("listener", "pool"))
-
-
-@pytest.fixture
-def Experiment(request, bigip, services, icd_config, icontrol_driver):
+def Experiment(request, bigip):
     """Build/Remove an invariant test environment.
 
     NOTE:  This fixture is modfiying the state of the BigIP device.  That is
@@ -228,66 +62,59 @@ def Experiment(request, bigip, services, icd_config, icontrol_driver):
     device prior to test initiation, and removes them after the ESD test is
     performed.   It also invokes the introspection necessary to customize test
     behavior as a function of the function name. The logic for this step is in
-    the _set_esd function.
+    the define_esd_services method.
     """
+    testconfig = TestConfig('l7_esd.json', OSLOCONF)
     # create loadbalancer
-    _create_loadbalancer(services, icontrol_driver, bigip)
+    testconfig.create_loadbalancer()
     # create listener
-    listener = _create_listener(services, icontrol_driver)
+    testconfig.create_listener()
     # create pool
-    pool = _create_pool(services, icontrol_driver)
+    testconfig.create_pool()
 
     def teardown():
         """Teardown and verify removal of the testbed."""
         # delete pool (and member, node)
-        _delete_pool(services, icontrol_driver, pool)
+        testconfig.delete_pool()
         # delete listener
-        _delete_listener(services, icontrol_driver, listener)
+        testconfig.delete_listener()
         # delete loadbalancer
-        _delete_loadbalancer(services, icontrol_driver, bigip)
+        testconfig.delete_loadbalancer()
 
     request.addfinalizer(teardown)
-    return Context(listener, pool)
+    return testconfig
 
 
 @pytest.fixture
-def ESD_Experiment(Experiment, request, services, icontrol_driver):
+def ESD_Experiment(Experiment, request):
     """Run tests in a single tag-per-ESD regime, the base (control) case."""
-    demo_esd = load_esd("demo.json")
-    icontrol_driver.lbaas_builder.esd.esd_dict = demo_esd
-    apply_service, remove_service, esd_name = _set_esd(services, request)
-    ti = TESTINFRA(apply_service,
-                   remove_service,
-                   icontrol_driver,
-                   demo_esd,
-                   Experiment.listener,
-                   esd_name)
-    return ti
+    testconfig = Experiment
+    testconfig.load_esd("demo.json")
+    testconfig.define_esd_services(request)
+    return testconfig
 
 
 @pytest.fixture
-def ESD_Pairs_Experiment(Experiment, request, services, icontrol_driver):
+def ESD_Pairs_Experiment(Experiment, request):
     """Run tests in a regime run ESDs that contain pairs of tags."""
-    demo_esd = load_esd("esd_pairs.json")
-    icontrol_driver.lbaas_builder.esd.esd_dict = demo_esd
-    apply_service, remove_service, esd_name = _set_esd(services, request)
-    ti = TESTINFRA(apply_service,
-                   remove_service,
-                   icontrol_driver,
-                   demo_esd,
-                   Experiment.listener,
-                   esd_name)
-    return ti
+    testconfig = Experiment
+    testconfig.load_esd("esd_pairs.json")
+    testconfig.define_esd_services(request)
+    return testconfig
 
 
-def apply_validate_remove_validate(infra):
+def apply_validate_remove_validate(testconfig):
     """Apply an ESD, validate application, remove ESD, validate removal."""
-    i = infra
+    t = testconfig
     # apply ESD
-    i.icontrol_driver._common_service_handler(i.apply_service)
-    VALIDATOR.assert_esd_applied(i.esd[i.esd_name], i.listener, FOLDER)
+    t.icontrol_driver._common_service_handler(t.apply_esd)
+    t.validator.assert_esd_applied(t.esd[t.full_esd_name],
+                                   t.listener,
+                                   t.FOLDER)
 
     # remove ESD
-    i.icontrol_driver._common_service_handler(i.remove_service)
-    VALIDATOR.assert_virtual_valid(i.listener, FOLDER)
-    VALIDATOR.assert_esd_removed(i.esd[i.esd_name], i.listener, FOLDER)
+    t.icontrol_driver._common_service_handler(t.remove_esd)
+    t.validator.assert_virtual_valid(t.listener, t.FOLDER)
+    t.validator.assert_esd_removed(t.esd[t.full_esd_name],
+                                   t.listener,
+                                   t.FOLDER)


### PR DESCRIPTION
@janakimeyyappan 
Issues:
Fixes:  This is a test issue.

Problem: In the previous iteration of the neutronless test architecture all
configuration was accomplished with a tall stack of fixtures.  This worked for
a given set of tests, but proved to be very difficult to modify.

Analysis:  In order to make it easier to write different kinds of tests
the bulk of configuration has been migrated into a standard Python class.  This
class is instantiated within a fixture, guaranteeing that entry into the test
system still conforms to the behaviors enforced by pytest.

The result is a much more flexible system that maintains the feature set of
pytest.

Tests:  I ran the tests inside neutronless/esd
