### PR TITLE
Add demo_policy fixture for ESD tests

### DIFF
--- a/test/functional/neutronless/esd/test_esd.py
+++ b/test/functional/neutronless/esd/test_esd.py
@@ -57,8 +57,7 @@ def test_esd_lbaas_irule(track_bigip_cfg, ESD_Experiment):
     apply_validate_remove_validate(ESD_Experiment)
 
 
-@pytest.mark.skip(reason="No demo policy created by the test")
-def test_esd_lbaas_policy(track_bigip_cfg, ESD_Experiment):
+def test_esd_lbaas_policy(track_bigip_cfg, demo_policy, ESD_Experiment):
     """Test a single tag."""
     apply_validate_remove_validate(ESD_Experiment)
 
@@ -73,8 +72,7 @@ def test_esd_lbaas_fallback_persist(track_bigip_cfg, ESD_Experiment):
     apply_validate_remove_validate(ESD_Experiment)
 
 
-@pytest.mark.skip(reason="No demo policy created by the test")
-def test_esd_full_8_tag_set(track_bigip_cfg, ESD_Experiment):
+def test_esd_full_8_tag_set(track_bigip_cfg, demo_policy, ESD_Experiment):
     """Test of a full tag set.  Tags specifics are historical."""
     apply_validate_remove_validate(ESD_Experiment)
 

--- a/test/functional/neutronless/esd/test_esd_pairs.py
+++ b/test/functional/neutronless/esd/test_esd_pairs.py
@@ -13,7 +13,6 @@
 #   limitations under the License.
 """Tests of all (unordered) pairs of ESD tags."""
 from .conftest import apply_validate_remove_validate
-import pytest
 
 
 def test_esd_lbaas_stcp_lbaas_persist(track_bigip_cfg, ESD_Pairs_Experiment):
@@ -63,29 +62,29 @@ def test_esd_lbaas_ctcp_lbaas_fallback_persist(track_bigip_cfg,
     apply_validate_remove_validate(ESD_Pairs_Experiment)
 
 
-@pytest.mark.skip(reason="No demo policy created by the test")
 def test_esd_lbaas_irule_lbaas_policy(track_bigip_cfg,
+                                      demo_policy,
                                       ESD_Pairs_Experiment):
     """Validate application of a pair of tags."""
     apply_validate_remove_validate(ESD_Pairs_Experiment)
 
 
-@pytest.mark.skip(reason="No demo policy created by the test")
 def test_esd_lbaas_cssl_profile_lbaas_policy(track_bigip_cfg,
+                                             demo_policy,
                                              ESD_Pairs_Experiment):
     """Validate application of a pair of tags."""
     apply_validate_remove_validate(ESD_Pairs_Experiment)
 
 
-@pytest.mark.skip(reason="No demo policy created by the test")
 def test_esd_lbaas_policy_lbaas_sssl_profile(track_bigip_cfg,
+                                             demo_policy,
                                              ESD_Pairs_Experiment):
     """Validate application of a pair of tags."""
     apply_validate_remove_validate(ESD_Pairs_Experiment)
 
 
-@pytest.mark.skip(reason="No demo policy created by the test")
 def test_esd_lbaas_stcp_lbaas_policy(track_bigip_cfg,
+                                     demo_policy,
                                      ESD_Pairs_Experiment):
     """Validate application of a pair of tags."""
     apply_validate_remove_validate(ESD_Pairs_Experiment)
@@ -115,8 +114,8 @@ def test_esd_lbaas_irule_lbaas_sssl_profile(track_bigip_cfg,
     apply_validate_remove_validate(ESD_Pairs_Experiment)
 
 
-@pytest.mark.skip(reason="No demo policy created by the test")
 def test_esd_lbaas_policy_lbaas_persist(track_bigip_cfg,
+                                        demo_policy,
                                         ESD_Pairs_Experiment):
     """Validate application of a pair of tags."""
     apply_validate_remove_validate(ESD_Pairs_Experiment)
@@ -146,15 +145,15 @@ def test_esd_lbaas_fallback_persist_lbaas_sssl_profile(track_bigip_cfg,
     apply_validate_remove_validate(ESD_Pairs_Experiment)
 
 
-@pytest.mark.skip(reason="No demo policy created by the test")
 def test_esd_lbaas_fallback_persist_lbaas_policy(track_bigip_cfg,
+                                                 demo_policy,
                                                  ESD_Pairs_Experiment):
     """Validate application of a pair of tags."""
     apply_validate_remove_validate(ESD_Pairs_Experiment)
 
 
-@pytest.mark.skip(reason="No demo policy created by the test")
 def test_esd_lbaas_ctcp_lbaas_policy(track_bigip_cfg,
+                                     demo_policy,
                                      ESD_Pairs_Experiment):
     """Validate application of a pair of tags."""
     apply_validate_remove_validate(ESD_Pairs_Experiment)

--- a/test/functional/neutronless/testlib/resource_validator.py
+++ b/test/functional/neutronless/testlib/resource_validator.py
@@ -156,9 +156,10 @@ class ResourceValidator(object):
                 assert rule_name in vs.rules
 
         if 'lbaas_policy' in esd:
-            for rule in esd['lbaas_policy']:
-                rule_name = '/Common/' + rule
-                assert rule_name in vs.rules
+            policy_names_list = ["/"+p.partition+"/"+p.name for p in policies]
+            for policy in esd['lbaas_policy']:
+                policy_name = '/Common/' + policy
+                assert policy_name in policy_names_list
 
     def assert_esd_removed(self, esd, listener, folder):
         listener_name = '{0}_{1}'.format(self.prefix, listener['id'])


### PR DESCRIPTION
Problem:
Some ESD tests attempt to configure a virtual with a non-existent policy 'demo-policy'.
For these tests to pass, there must be a demo-policy deployed on the system.

Solution:
Added fixture demo_policy that creates a policy, with a rule and publishes it.
This fixture is passed to those ESD tests that require demo_policy.
