### PR TITLE
added missing setup.cfg to build RPMs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[bdist_rpm]
+requires =  f5-sdk == 2.3.3
+


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
Fixes #1107 
...

#### What's this change do?
adds setuptools file for RPMs

#### Where should the reviewer start?
run the RPM build script for 'redhat' '7'

#### Any background context?
