### PR TITLE
validate that ESD application doesn't change vlans

### DIFF
--- a/test/functional/neutronless/esd/conftest.py
+++ b/test/functional/neutronless/esd/conftest.py
@@ -126,6 +126,16 @@ def ESD_Experiment(Experiment, request):
 
 
 @pytest.fixture
+def ESD_GRF_False_Experiment(Experiment, request):
+    """Run tests in a single tag-per-ESD regime, the base (control) case."""
+    testconfig = Experiment
+    testconfig.OSLO_CONF["f5_global_routed_mode"] = False
+    testconfig.load_esd("demo.json")
+    testconfig.define_esd_services(request)
+    return testconfig
+
+
+@pytest.fixture
 def ESD_Pairs_Experiment(Experiment, request):
     """Run tests in a regime run ESDs that contain pairs of tags."""
     testconfig = Experiment

--- a/test/functional/neutronless/esd/test_esd.py
+++ b/test/functional/neutronless/esd/test_esd.py
@@ -77,18 +77,20 @@ def test_esd_full_8_tag_set(track_bigip_cfg, demo_policy, ESD_Experiment):
     apply_validate_remove_validate(ESD_Experiment)
 
 
-@pytest.mark.skip(reason="Test assumptions not valid for GlobalRoutedMode")
-def test_esd_issue_1047_basic(ESD_Experiment, bigip):
+def test_esd_issue_1047_basic(ESD_GRF_False_Experiment, bigip):
     """Test behavior of l7policy removal as documented in github issue.
 
     https://github.com/F5Networks/f5-openstack-agent/issues/1047
     """
     test_virtual = bigip.bigip.tm.ltm.virtuals.get_collection()[0]
+    test_virtual.modify(vlansEnabled=True)
     assert test_virtual.vlansEnabled is True
-    assert test_virtual.vlans != []
-    apply_validate_remove_validate(ESD_Experiment)
+    tvvlans = test_virtual.__dict__.pop('vlans', "MISSING")
+    assert tvvlans == "MISSING"
+    apply_validate_remove_validate(ESD_GRF_False_Experiment)
     assert test_virtual.vlansEnabled is True
-    assert test_virtual.vlans != []
+    tvvlans = test_virtual.__dict__.pop('vlans', "MISSING")
+    assert tvvlans == "MISSING"
 
 
 @pytest.mark.skip(reason="ESD contains invalid iRule names")

--- a/test/functional/testdata/esds/demo.json
+++ b/test/functional/testdata/esds/demo.json
@@ -26,7 +26,7 @@
   "f5_ESD_lbaas_persist":          { "lbaas_persist": "hash" },
   "f5_ESD_lbaas_fallback_persist": { "lbaas_fallback_persist": "source_addr" },
 
-  "f5_ESD_issue_1047_basic":             { "lbaas_ctcp": "tcp-mobile-optimized" },
+  "f5_ESD_issue_1047_basic":       { "lbaas_ctcp": "tcp-mobile-optimized" },
   "f5_ESD_dmzmobile": {
     "lbaas_ctcp": "tcp-mobile-optimized",
     "lbaas_stcp": "tcp-lan-optimized",


### PR DESCRIPTION
Issues:
Fixes #1047 (tests)

Problem: This commit validates the fix for issue #1047

Analysis:  The relevant test now has GRF set to false, and
configures the virtual to have an expected start state.  The
rest of the test is the standard apply_validate_remove_validate
operation.

Tests: test_esd.py::test_esd_issue_1047_basic
