### PR TITLE
Issue.1111.master

### DIFF
--- a/f5-openstack-agent-dist/Docker/ubuntu/16.04/Dockerfile
+++ b/f5-openstack-agent-dist/Docker/ubuntu/16.04/Dockerfile
@@ -1,0 +1,12 @@
+# Dockerfile
+FROM ubuntu:trusty
+
+RUN apt-get update && apt-get install -y \
+	python-stdeb \
+	fakeroot \
+	python-all \
+	dh-python \
+	git
+
+COPY ./build-debs.sh /
+

--- a/f5-openstack-agent-dist/Docker/ubuntu/16.04/build-debs.sh
+++ b/f5-openstack-agent-dist/Docker/ubuntu/16.04/build-debs.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -ex
+
+SRC_DIR=$1
+
+PKG_NAME="f5-openstack-agent"
+OS_VERSION="1604"
+DIST_DIR="f5-openstack-agent-dist/deb_dist"
+
+# Change directory to the source to get package information.
+pushd ${SRC_DIR}
+
+# The version is embedded in the package.
+PKG_VERSION=$(python -c "import f5_openstack_agent; print(f5_openstack_agent.__version__)")
+PKG_RELEASE=$(python ./f5-openstack-agent-dist/scripts/get-version-release.py --release)
+
+# Exit source directory
+popd
+
+# Create a temporary work directory and copy the source to it.
+BUILDROOT=$(mktemp -d /tmp/${PKG_NAME}.XXXXX)
+cp -R ${SRC_DIR}/* ${BUILDROOT}
+pushd ${BUILDROOT}
+
+echo "Building ${PKG_NAME} debian packages..."
+
+# Copy the stdeb.cfg file to the current directory and add the pkg release to it.
+cp -R "${SRC_DIR}/${DIST_DIR}/stdeb.cfg" .
+echo "Debian-Version: ${PKG_RELEASE}" >> stdeb.cfg
+
+# Build debian package.
+python setup.py --command-packages=stdeb.command sdist_dsc
+pushd "deb_dist/${PKG_NAME}-${PKG_VERSION}"
+export DEB_BUILD_OPTIONS=nocheck
+dpkg-buildpackage -rfakeroot -uc -us
+popd
+
+pkg="python-${PKG_NAME}_${PKG_VERSION}-${PKG_RELEASE}_all.deb"
+cp "deb_dist/${pkg}" "${SRC_DIR}/${DIST_DIR}/${pkg%%_all.deb}_${OS_VERSION}_all.deb"

--- a/f5-openstack-agent-dist/deb_dist/stdeb.cfg
+++ b/f5-openstack-agent-dist/deb_dist/stdeb.cfg
@@ -1,0 +1,1 @@
+[DEFAULT]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[bdist_rpm]
+requires =  f5-sdk == 2.3.3
+


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
Fixes #1111 
...

#### What's this change do?
Adds the template stdeb.cfg file back and adds the build Dockerfile and script for Ubuntu LTS 16.04

#### Where should the reviewer start?
On a machine with git and docker properly install, from the repository directory run:

```
./f5-openstack-agent-dist/scripts/package_agent.sh "ubuntu" "14.04"
./f5-openstack-agent-dist/scripts/package_agent.sh "ubuntu" "16.04"
```

#### Any background context?
