### PR TITLE
Fix service validation error after upgrading from LIberty to Newton release

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -95,12 +95,14 @@ class ServiceModelAdapter(object):
 
         full_description = resource.get('name', "")
         description = resource.get('description', "")
-        if len(full_description):
+        if full_description:
             full_description += ":"
-            if len(description):
+            if description:
                 full_description += (" %s" % (description))
+        elif description:
+            full_description = description
         else:
-            full_description += description
+            full_description = ""
 
         return full_description
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_service_adapter.py
@@ -806,3 +806,51 @@ class TestServiceAdapter(object):
     def test_get_tls(self, basic_l7service):
         pass
         # adapter = ServiceModelAdapter(mock.MagicMock())
+
+    def test_get_resource_description(self):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        resource = dict(name='test_name',
+                        description='test_description')
+
+        # invalid input type
+        with pytest.raises(ValueError):
+            description = adapter.get_resource_description('')
+
+        # both name and description
+        description = adapter.get_resource_description(resource)
+        assert description == 'test_name: test_description'
+
+        # name but no description
+        resource['description'] = ''
+        description = adapter.get_resource_description(resource)
+        assert description == 'test_name:'
+
+        # handle None for value
+        resource['description'] = None
+        description = adapter.get_resource_description(resource)
+        assert description == 'test_name:'
+
+        # neither name nor description
+        resource['name'] = ''
+        description = adapter.get_resource_description(resource)
+        assert description == ''
+
+        # handle None for value
+        resource['name'] = None
+        description = adapter.get_resource_description(resource)
+        assert description == ''
+
+        # description but no name
+        resource['description'] = 'test_description'
+        description = adapter.get_resource_description(resource)
+        assert description == 'test_description'
+
+        # no keys defined
+        resource.pop('name')
+        description = adapter.get_resource_description(resource)
+        assert description == 'test_description'
+
+        resource['name'] = 'test_name'
+        resource.pop('description')
+        description = adapter.get_resource_description(resource)
+        assert description == 'test_name:'


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
#1117 Service validation error after upgrading from LIberty to Newton release 

#### What's this change do?
Instead of checking for valid name and description strings using len(), substituted using more general truth value testing (.e.g, if value instead of if len(value)). In this way, values with None type and values with empty string are both handled without exception.

#### Where should the reviewer start?
service_adapter.py

#### Any background context?
Normally we don't expect None types for resource values. But this can happen when a new database column is initialized to NULL, as is the case when upgrading OpenStack releases (health monitor names not defined in Liberty and added in Mitaka release).
