### PR TITLE
Fixing bigip_interaction.py to appropriately clean

### DIFF
--- a/test/functional/neutronless/bigip_interaction.py
+++ b/test/functional/neutronless/bigip_interaction.py
@@ -139,9 +139,7 @@ EOF'''
             * Generate a diff file against the polluted config
         """
         try:
-            with open(cls.config_file.format(my_epoch)) as fh:
-                content = fh.read()
-            diff_file = cls.__collect_diff(content, test_method)
+            diff_file = cls.__collect_diff(test_method)
             os.remove(diff_file)
         except AssertionError as err:
             cls.__restore_from_backup()
@@ -165,7 +163,7 @@ EOF'''
         return diff_file
 
     @classmethod
-    def __collect_diff(cls, clean, test_method):
+    def __collect_diff(cls, test_method):
         """An internal method"""
         dirty_file = cls.dirty_file.format(test_method, my_epoch)
         dirty_content = cls._get_current_bigip_cfg()

--- a/test/functional/neutronless/bigip_interaction.py
+++ b/test/functional/neutronless/bigip_interaction.py
@@ -123,6 +123,12 @@ EOF'''
             fh.write(result)
 
     @classmethod
+    def __restore_from_backup(cls):
+        cmd = cls.__ucs_cmd_fmt.format(cls.ssh_cmd, 'load')
+        result = cls.__exec_shell(cmd, True)
+        cls.__check_results(result)
+
+    @classmethod
     def _resulting_bigip_cfg(cls, test_method):
         """Checks the resulting BIG-IP config as it stands against snap shot
 
@@ -159,17 +165,19 @@ EOF'''
         return diff_file
 
     @classmethod
-    def __collect_diff(cls, result, test_method):
+    def __collect_diff(cls, clean, test_method):
         """An internal method"""
         dirty_file = cls.dirty_file.format(test_method, my_epoch)
+        dirty_content = cls._get_current_bigip_cfg()
         with open(dirty_file, 'w') as fh:
-            fh.write(result)
+            fh.write(dirty_content)
         diff_file = cls.diff_file.format(test_method, my_epoch)
         cmd = "diff -u {} {} > {}".format(
             cls.config_file.format(my_epoch), dirty_file, diff_file)
         result = cls.__exec_shell(cmd, True)
-        cls.__check_results(result)
-        if os.path.getsize(diff_file) > 0:
+        try:
+            cls.__check_results(result)
+        except RuntimeError:
             raise AssertionError(diff_file)
         return diff_file
 

--- a/test/functional/neutronless/conftest.py
+++ b/test/functional/neutronless/conftest.py
@@ -22,7 +22,7 @@ to provide a configuration specific to some test needs via the TestConfig
 objects methods (primarily, __init__, but also others e.g. "load_esd").
 
    The expected caller of the TestConfig object is an Experiment fixture, where
-the experiment instantiates, and configures, a particular TestConfig instance, 
+the experiment instantiates, and configures, a particular TestConfig instance,
 before handing off to the test code.   Examples of "Experiments" can be found
 in esd/conftest.py.
 """
@@ -46,6 +46,7 @@ import traceback
 from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import \
     iControlDriver
 
+from .bigip_interaction import BigIpInteraction
 from .testlib.bigip_client import BigIpClient
 from .testlib.fake_rpc import FakeRPCPlugin
 from .testlib.resource_validator import ResourceValidator
@@ -69,7 +70,7 @@ class TestConfig(object):
 
         self.oslo_config:  A faked interface to the oslo configuration system
         self.TENANT_ID:    Usually a static fake specific to our test regime.
-        self.SERVICES:     Obtained by running replay scripts against neutron, 
+        self.SERVICES:     Obtained by running replay scripts against neutron,
         we use these services to patch out neutron, by playing them through
         the icontrol_driver._common_service_handler.
         self.fake_rpc_OBJ: We can observe messages intended for neutron by
@@ -80,7 +81,7 @@ class TestConfig(object):
         self.validator:   A useful object that checks specific configurations
         of the bigip according to agent-derived rules.
         self.icontrol_driver:  An agent-internal method that submits service
-        objects (from neutron) to be interpreted and applied to the device. 
+        objects (from neutron) to be interpreted and applied to the device.
         """
         self.oslo_config = json.load(open(opj(CONFIGDIR, oslo_config_file)))
         self.TENANT_ID, self.SERVICES =\
@@ -402,9 +403,8 @@ def bigip(request):
 
 @pytest.fixture
 def track_bigip_cfg(request):
-    # request.addfinalizer(BigIpInteraction.check_resulting_cfg)
-    # BigIpInteraction.backup_bigip_cfg()
-    pass
+    request.addfinalizer(BigIpInteraction.check_resulting_cfg)
+    BigIpInteraction.backup_bigip_cfg()
 
 
 def debug_msg(status):


### PR DESCRIPTION
Problem:
* Fixes test bug where bigip_interaction.py did not clean up after tests
  * This is largely due to inappropriately handled variables and content

Solution:
* Grabs the content from the BIG-IP once post-test
  * This is then stored appropriately under the dirty-config file
  * This file is then appropriately diff'ed with the "clean" one
  * The resulting diff cmd call results in a exit status of (1)
  * Handling this by then handling the resulting RuntimeError
    * Transforming this into the appropriate AssertionError

Tests:
Have perform the following tests:
* file ./test/functional/neutronless/loadbalancer/test_purge_folder.py
  * Comment line `sh.purge_folder_contents(bigip.bigip, folder)`
  * Comment line `sh.purge_folder(bigip.bigip, folder)`
* Run py.test against this file
  * Expected to fail at this point
* Check BIG-IP config to assure that state is clean
* Revert changes to the test_purge_folder.py and re-test
  * Expect a passing result

@richbrowne @jlongstaf @janakimeyyappan 
#### What issues does this address?
BIG-IP cleanup issues via the tracker in the agent's functional tests.

#### What's this change do?
* conftest.py missing the importation and use of the bigip_interaction.py for its fixture
* Handle the dirty contents properly from the BIG-IP (fixes a bug here)
  * Was always coming back as 'clean' unintentionally
* Handles the diff command call appropriately
  * Catches the RuntimeError from calling _check_results() method
  * Handles then returning these results properly and cleaning up the BIG-IP by restoring from the backup ucs file

#### Where should the reviewer start?
conftest.py, which was commented out over to bigip_interaction.py changes

#### Any background context?
@janakimeyyappan ran into a scenario in her purge testing that the BIG-IP was not getting auto-cleaned up.  These changes seem like they were fixes I already implemented earlier...  though I can't now find a record of it in one of my old branches.