### PR TITLE
Fix test_purge_folder_contents and add test for it

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/system_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/system_helper.py
@@ -149,7 +149,9 @@ class SystemHelper(object):
                 ResourceType.snat,
                 ResourceType.snatpool,
                 ResourceType.snat_translation,
-                ResourceType.rule
+                ResourceType.universal_persistence,
+                ResourceType.rule,
+                ResourceType.l7policy
             ]
             for ltm_type in ltm_types:
                 resource = BigIPResourceHelper(ltm_type)

--- a/test/functional/neutronless/loadbalancer/test_purge_folder.py
+++ b/test/functional/neutronless/loadbalancer/test_purge_folder.py
@@ -1,0 +1,122 @@
+# coding=utf-8
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import \
+    iControlDriver
+from f5_openstack_agent.lbaasv2.drivers.bigip.system_helper import \
+    SystemHelper
+
+import json
+import logging
+import os
+import pytest
+import requests
+
+from ..testlib.bigip_client import BigIpClient
+from ..testlib.fake_rpc import FakeRPCPlugin
+from ..testlib.service_reader import LoadbalancerReader
+from ..testlib.resource_validator import ResourceValidator
+
+requests.packages.urllib3.disable_warnings()
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def services():
+    neutron_services_filename = (
+        os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                     '../../testdata/service_requests/test_purge_folder.json')
+    )
+    return (json.load(open(neutron_services_filename)))
+
+
+@pytest.fixture(scope="module")
+def bigip():
+
+    return BigIpClient(pytest.symbols.bigip_mgmt_ip_public,
+                       pytest.symbols.bigip_username,
+                       pytest.symbols.bigip_password)
+
+
+@pytest.fixture
+def fake_plugin_rpc(services):
+
+    rpcObj = FakeRPCPlugin(services)
+
+    return rpcObj
+
+
+@pytest.fixture
+def icontrol_driver(icd_config, fake_plugin_rpc):
+    class ConfFake(object):
+        def __init__(self, params):
+            self.__dict__ = params
+            for k, v in self.__dict__.items():
+                if isinstance(v, unicode):
+                    self.__dict__[k] = v.encode('utf-8')
+
+        def __repr__(self):
+            return repr(self.__dict__)
+
+    icd = iControlDriver(ConfFake(icd_config),
+                         registerOpts=False)
+
+    icd.plugin_rpc = fake_plugin_rpc
+    icd.connect()
+
+    return icd
+
+
+def test_purge_folder(track_bigip_cfg, bigip, services, icd_config,
+                     icontrol_driver):
+    env_prefix = icd_config['environment_prefix']
+    service_iter = iter(services)
+    validator = ResourceValidator(bigip, env_prefix)
+
+    # create loadbalancer
+    service = service_iter.next()
+    lb_reader = LoadbalancerReader(service)
+    folder = '{0}_{1}'.format(env_prefix, lb_reader.tenant_id())
+    icontrol_driver._common_service_handler(service)
+    assert bigip.folder_exists(folder)
+
+    # create listener
+    service = service_iter.next()
+    listener = service['listeners'][0]
+    icontrol_driver._common_service_handler(service)
+    validator.assert_virtual_valid(listener, folder)
+
+    # create pool
+    service = service_iter.next()
+    pool = service['pools'][0]
+    icontrol_driver._common_service_handler(service)
+    validator.assert_pool_valid(pool, folder)
+
+    # create l7policy with l7rule attached to the above created
+    # listener
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+    validator.assert_policy_valid(listener, folder)
+
+    sh = SystemHelper()
+    sh.purge_folder_contents(bigip.bigip, folder)
+
+    # delete folder and check that it does not exist
+    sh.purge_folder(bigip.bigip, folder)
+    assert not bigip.folder_exists(folder)
+

--- a/test/functional/neutronless/testlib/fake_rpc.py
+++ b/test/functional/neutronless/testlib/fake_rpc.py
@@ -200,6 +200,12 @@ class FakeRPCPlugin(object):
         pass
 
     @track_call
+    def update_l7rule_status(self, l7rule_id, l7policy_id,
+                                   provisioning_status="ERROR",
+                                   operating_status="OFFLINE"):
+        pass
+
+    @track_call
     def health_monitor_destroyed(self, id):
         pass
 

--- a/test/functional/neutronless/testlib/resource_validator.py
+++ b/test/functional/neutronless/testlib/resource_validator.py
@@ -22,6 +22,7 @@ class ResourceValidator(object):
     def __init__(self, bigip, prefix):
         self.bigip = bigip
         self.prefix = prefix
+        self.policy_prefix = "wrapper_policy"
 
     def assert_healthmonitor_deleted(self, monitor, folder):
         monitor_name = '{0}_{1}'.format(self.prefix, monitor['id'])
@@ -66,6 +67,11 @@ class ResourceValidator(object):
         pool_name = '{0}_{1}'.format(self.prefix, pool['id'])
         assert self.bigip.resource_exists(
             ResourceType.pool, pool_name, partition=folder)
+
+    def assert_policy_valid(self, listener, folder):
+        policy_name = '{0}_{1}'.format(self.policy_prefix, listener['id'])
+        assert self.bigip.resource_exists(
+            ResourceType.l7policy, policy_name, partition=folder)
 
     def assert_virtual_deleted(self, listener, folder):
         listener_name = '{0}_{1}'.format(self.prefix, listener['id'])

--- a/test/functional/testdata/service_requests/test_purge_folder.json
+++ b/test/functional/testdata/service_requests/test_purge_folder.json
@@ -1,0 +1,824 @@
+[{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "64291f61-3dc0-4027-9875-b6b569eb8b45", 
+    "listeners": [], 
+    "name": "lb1", 
+    "network_id": "ee5d0a7a-6784-4c30-8450-001b272eecb3", 
+    "operating_status": "OFFLINE", 
+    "pools": [], 
+    "provider": null, 
+    "provisioning_status": "PENDING_CREATE", 
+    "tenant_id": "d82b533eb0784354856b6613cd557236", 
+    "vip_address": "172.16.7.33", 
+    "vip_port": {
+      "admin_state_up": false, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "unbound", 
+      "binding:vnic_type": "normal", 
+      "created_at": "2017-11-30T21:32:05", 
+      "description": null, 
+      "device_id": "64291f61-3dc0-4027-9875-b6b569eb8b45", 
+      "device_owner": "neutron:LOADBALANCERV2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "172.16.7.33", 
+          "subnet_id": "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a"
+        }
+      ], 
+      "id": "bf0f8e60-1fcb-4a78-95db-f9fcccadbfde", 
+      "mac_address": "fa:16:3e:b1:84:8b", 
+      "name": "loadbalancer-64291f61-3dc0-4027-9875-b6b569eb8b45", 
+      "network_id": "ee5d0a7a-6784-4c30-8450-001b272eecb3", 
+      "port_security_enabled": true, 
+      "security_groups": [
+        "a20f7e4d-a8f8-497b-80bb-872d77e1eaed"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "d82b533eb0784354856b6613cd557236", 
+      "updated_at": "2017-11-30T21:32:05"
+    }, 
+    "vip_port_id": "bf0f8e60-1fcb-4a78-95db-f9fcccadbfde", 
+    "vip_subnet_id": "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a", 
+    "vxlan_vteps": [
+      "172.16.4.3", 
+      "172.16.4.4", 
+      "172.16.4.2"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "ee5d0a7a-6784-4c30-8450-001b272eecb3": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-11-29T19:30:13", 
+      "description": "", 
+      "id": "ee5d0a7a-6784-4c30-8450-001b272eecb3", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "admin_net", 
+      "port_security_enabled": true, 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 41, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a"
+      ], 
+      "tags": [], 
+      "tenant_id": "d82b533eb0784354856b6613cd557236", 
+      "updated_at": "2017-11-29T19:30:13", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a": {
+      "allocation_pools": [
+        {
+          "end": "172.16.7.254", 
+          "start": "172.16.7.2"
+        }
+      ], 
+      "cidr": "172.16.7.0/24", 
+      "created_at": "2017-11-29T19:30:16", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.7"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "172.16.7.1", 
+      "host_routes": [], 
+      "id": "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "admin_subnet", 
+      "network_id": "ee5d0a7a-6784-4c30-8450-001b272eecb3", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "d82b533eb0784354856b6613cd557236", 
+      "updated_at": "2017-11-29T19:30:16"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": null, 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "55bc4120-daf4-42aa-b4f3-c2fc2b30e367", 
+      "l7_policies": [], 
+      "loadbalancer_id": "64291f61-3dc0-4027-9875-b6b569eb8b45", 
+      "name": "vs1", 
+      "operating_status": "OFFLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "PENDING_CREATE", 
+      "sni_containers": [], 
+      "tenant_id": "d82b533eb0784354856b6613cd557236"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "64291f61-3dc0-4027-9875-b6b569eb8b45", 
+    "listeners": [
+      {
+        "id": "55bc4120-daf4-42aa-b4f3-c2fc2b30e367"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "ee5d0a7a-6784-4c30-8450-001b272eecb3", 
+    "operating_status": "ONLINE", 
+    "pools": [], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "d82b533eb0784354856b6613cd557236", 
+    "vip_address": "172.16.7.33", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "mitaka-master-0:726d5106-80e1-537d-a8ab-9fb80e00feda", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "baremetal", 
+      "created_at": "2017-11-30T21:32:05", 
+      "description": null, 
+      "device_id": "64291f61-3dc0-4027-9875-b6b569eb8b45", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "172.16.7.33", 
+          "subnet_id": "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a"
+        }
+      ], 
+      "id": "bf0f8e60-1fcb-4a78-95db-f9fcccadbfde", 
+      "mac_address": "fa:16:3e:b1:84:8b", 
+      "name": "loadbalancer-64291f61-3dc0-4027-9875-b6b569eb8b45", 
+      "network_id": "ee5d0a7a-6784-4c30-8450-001b272eecb3", 
+      "port_security_enabled": true, 
+      "security_groups": [
+        "a20f7e4d-a8f8-497b-80bb-872d77e1eaed"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "d82b533eb0784354856b6613cd557236", 
+      "updated_at": "2017-11-30T21:32:07"
+    }, 
+    "vip_port_id": "bf0f8e60-1fcb-4a78-95db-f9fcccadbfde", 
+    "vip_subnet_id": "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a", 
+    "vxlan_vteps": [
+      "172.16.4.3", 
+      "172.16.4.4", 
+      "172.16.4.2"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "ee5d0a7a-6784-4c30-8450-001b272eecb3": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-11-29T19:30:13", 
+      "description": "", 
+      "id": "ee5d0a7a-6784-4c30-8450-001b272eecb3", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "admin_net", 
+      "port_security_enabled": true, 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 41, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a"
+      ], 
+      "tags": [], 
+      "tenant_id": "d82b533eb0784354856b6613cd557236", 
+      "updated_at": "2017-11-29T19:30:13", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a": {
+      "allocation_pools": [
+        {
+          "end": "172.16.7.254", 
+          "start": "172.16.7.2"
+        }
+      ], 
+      "cidr": "172.16.7.0/24", 
+      "created_at": "2017-11-29T19:30:16", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.7"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "172.16.7.1", 
+      "host_routes": [], 
+      "id": "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "admin_subnet", 
+      "network_id": "ee5d0a7a-6784-4c30-8450-001b272eecb3", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "d82b533eb0784354856b6613cd557236", 
+      "updated_at": "2017-11-29T19:30:16"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "4bc522dc-065f-4877-a856-4a1881019a0b", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "55bc4120-daf4-42aa-b4f3-c2fc2b30e367", 
+      "l7_policies": [], 
+      "loadbalancer_id": "64291f61-3dc0-4027-9875-b6b569eb8b45", 
+      "name": "vs1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "d82b533eb0784354856b6613cd557236"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "64291f61-3dc0-4027-9875-b6b569eb8b45", 
+    "listeners": [
+      {
+        "id": "55bc4120-daf4-42aa-b4f3-c2fc2b30e367"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "ee5d0a7a-6784-4c30-8450-001b272eecb3", 
+    "operating_status": "ONLINE", 
+    "pools": [
+      {
+        "id": "4bc522dc-065f-4877-a856-4a1881019a0b"
+      }
+    ], 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "d82b533eb0784354856b6613cd557236", 
+    "vip_address": "172.16.7.33", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "mitaka-master-0:726d5106-80e1-537d-a8ab-9fb80e00feda", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "baremetal", 
+      "created_at": "2017-11-30T21:32:05", 
+      "description": null, 
+      "device_id": "64291f61-3dc0-4027-9875-b6b569eb8b45", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "172.16.7.33", 
+          "subnet_id": "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a"
+        }
+      ], 
+      "id": "bf0f8e60-1fcb-4a78-95db-f9fcccadbfde", 
+      "mac_address": "fa:16:3e:b1:84:8b", 
+      "name": "loadbalancer-64291f61-3dc0-4027-9875-b6b569eb8b45", 
+      "network_id": "ee5d0a7a-6784-4c30-8450-001b272eecb3", 
+      "port_security_enabled": true, 
+      "security_groups": [
+        "a20f7e4d-a8f8-497b-80bb-872d77e1eaed"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "d82b533eb0784354856b6613cd557236", 
+      "updated_at": "2017-11-30T21:32:07"
+    }, 
+    "vip_port_id": "bf0f8e60-1fcb-4a78-95db-f9fcccadbfde", 
+    "vip_subnet_id": "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a", 
+    "vxlan_vteps": [
+      "172.16.4.3", 
+      "172.16.4.4", 
+      "172.16.4.2"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "ee5d0a7a-6784-4c30-8450-001b272eecb3": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-11-29T19:30:13", 
+      "description": "", 
+      "id": "ee5d0a7a-6784-4c30-8450-001b272eecb3", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "admin_net", 
+      "port_security_enabled": true, 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 41, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a"
+      ], 
+      "tags": [], 
+      "tenant_id": "d82b533eb0784354856b6613cd557236", 
+      "updated_at": "2017-11-29T19:30:13", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "4bc522dc-065f-4877-a856-4a1881019a0b", 
+      "l7_policies": [], 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "loadbalancer_id": "64291f61-3dc0-4027-9875-b6b569eb8b45", 
+      "members": [], 
+      "name": "pool2", 
+      "operating_status": "OFFLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "PENDING_CREATE", 
+      "session_persistence": {
+        "cookie_name": "TEST_COOKIE", 
+        "type": "APP_COOKIE"
+      }, 
+      "sessionpersistence": null, 
+      "tenant_id": "d82b533eb0784354856b6613cd557236"
+    }
+  ], 
+  "subnets": {
+    "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a": {
+      "allocation_pools": [
+        {
+          "end": "172.16.7.254", 
+          "start": "172.16.7.2"
+        }
+      ], 
+      "cidr": "172.16.7.0/24", 
+      "created_at": "2017-11-29T19:30:16", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.7"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "172.16.7.1", 
+      "host_routes": [], 
+      "id": "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "admin_subnet", 
+      "network_id": "ee5d0a7a-6784-4c30-8450-001b272eecb3", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "d82b533eb0784354856b6613cd557236", 
+      "updated_at": "2017-11-29T19:30:16"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [
+    {
+      "action": "REJECT", 
+      "admin_state_up": true, 
+      "description": "", 
+      "id": "7dc5e26a-5322-4d11-9e62-eaa9c49aae9f", 
+      "listener_id": "55bc4120-daf4-42aa-b4f3-c2fc2b30e367", 
+      "name": "", 
+      "position": 1, 
+      "provisioning_status": "PENDING_CREATE", 
+      "redirect_pool_id": null, 
+      "redirect_url": null, 
+      "rules": [], 
+      "tenant_id": "d82b533eb0784354856b6613cd557236"
+    }
+  ], 
+  "l7policy_rules": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "4bc522dc-065f-4877-a856-4a1881019a0b", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "55bc4120-daf4-42aa-b4f3-c2fc2b30e367", 
+      "l7_policies": [
+        {
+          "id": "7dc5e26a-5322-4d11-9e62-eaa9c49aae9f"
+        }
+      ], 
+      "loadbalancer_id": "64291f61-3dc0-4027-9875-b6b569eb8b45", 
+      "name": "vs1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "d82b533eb0784354856b6613cd557236"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "64291f61-3dc0-4027-9875-b6b569eb8b45", 
+    "listeners": [
+      {
+        "id": "55bc4120-daf4-42aa-b4f3-c2fc2b30e367"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "ee5d0a7a-6784-4c30-8450-001b272eecb3", 
+    "operating_status": "ONLINE", 
+    "pools": [
+      {
+        "id": "4bc522dc-065f-4877-a856-4a1881019a0b"
+      }
+    ], 
+    "provider": "f5networks", 
+    "provisioning_status": "ACTIVE", 
+    "tenant_id": "d82b533eb0784354856b6613cd557236", 
+    "vip_address": "172.16.7.33", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "mitaka-master-0:726d5106-80e1-537d-a8ab-9fb80e00feda", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "baremetal", 
+      "created_at": "2017-11-30T21:32:05", 
+      "description": null, 
+      "device_id": "64291f61-3dc0-4027-9875-b6b569eb8b45", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "172.16.7.33", 
+          "subnet_id": "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a"
+        }
+      ], 
+      "id": "bf0f8e60-1fcb-4a78-95db-f9fcccadbfde", 
+      "mac_address": "fa:16:3e:b1:84:8b", 
+      "name": "loadbalancer-64291f61-3dc0-4027-9875-b6b569eb8b45", 
+      "network_id": "ee5d0a7a-6784-4c30-8450-001b272eecb3", 
+      "port_security_enabled": true, 
+      "security_groups": [
+        "a20f7e4d-a8f8-497b-80bb-872d77e1eaed"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "d82b533eb0784354856b6613cd557236", 
+      "updated_at": "2017-11-30T21:32:07"
+    }, 
+    "vip_port_id": "bf0f8e60-1fcb-4a78-95db-f9fcccadbfde", 
+    "vip_subnet_id": "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a", 
+    "vxlan_vteps": [
+      "172.16.4.3", 
+      "172.16.4.4", 
+      "172.16.4.2"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "ee5d0a7a-6784-4c30-8450-001b272eecb3": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-11-29T19:30:13", 
+      "description": "", 
+      "id": "ee5d0a7a-6784-4c30-8450-001b272eecb3", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "admin_net", 
+      "port_security_enabled": true, 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 41, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a"
+      ], 
+      "tags": [], 
+      "tenant_id": "d82b533eb0784354856b6613cd557236", 
+      "updated_at": "2017-11-29T19:30:13", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "4bc522dc-065f-4877-a856-4a1881019a0b", 
+      "l7_policies": [], 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "loadbalancer_id": "64291f61-3dc0-4027-9875-b6b569eb8b45", 
+      "members": [], 
+      "name": "pool2", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "ACTIVE", 
+      "session_persistence": {
+        "cookie_name": "TEST_COOKIE", 
+        "type": "APP_COOKIE"
+      }, 
+      "sessionpersistence": null, 
+      "tenant_id": "d82b533eb0784354856b6613cd557236"
+    }
+  ], 
+  "subnets": {
+    "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a": {
+      "allocation_pools": [
+        {
+          "end": "172.16.7.254", 
+          "start": "172.16.7.2"
+        }
+      ], 
+      "cidr": "172.16.7.0/24", 
+      "created_at": "2017-11-29T19:30:16", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.7"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "172.16.7.1", 
+      "host_routes": [], 
+      "id": "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "admin_subnet", 
+      "network_id": "ee5d0a7a-6784-4c30-8450-001b272eecb3", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "d82b533eb0784354856b6613cd557236", 
+      "updated_at": "2017-11-29T19:30:16"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "l7policies": [
+    {
+      "action": "REJECT", 
+      "admin_state_up": true, 
+      "description": "", 
+      "id": "7dc5e26a-5322-4d11-9e62-eaa9c49aae9f", 
+      "listener_id": "55bc4120-daf4-42aa-b4f3-c2fc2b30e367", 
+      "name": "", 
+      "position": 1, 
+      "provisioning_status": "ACTIVE", 
+      "redirect_pool_id": null, 
+      "redirect_url": null, 
+      "rules": [
+        {
+          "id": "a332b3e0-fbae-4950-8975-b7110658c3c2"
+        }
+      ], 
+      "tenant_id": "d82b533eb0784354856b6613cd557236"
+    }
+  ], 
+  "l7policy_rules": [
+    {
+      "admin_state_up": true, 
+      "compare_type": "EQUAL_TO", 
+      "id": "a332b3e0-fbae-4950-8975-b7110658c3c2", 
+      "invert": false, 
+      "key": null, 
+      "policies": [
+        {
+          "id": "7dc5e26a-5322-4d11-9e62-eaa9c49aae9f"
+        }
+      ], 
+      "policy_id": "7dc5e26a-5322-4d11-9e62-eaa9c49aae9f", 
+      "provisioning_status": "PENDING_CREATE", 
+      "tenant_id": "d82b533eb0784354856b6613cd557236", 
+      "type": "HOST_NAME", 
+      "value": "foo"
+    }
+  ], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "4bc522dc-065f-4877-a856-4a1881019a0b", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "55bc4120-daf4-42aa-b4f3-c2fc2b30e367", 
+      "l7_policies": [
+        {
+          "id": "7dc5e26a-5322-4d11-9e62-eaa9c49aae9f"
+        }
+      ], 
+      "loadbalancer_id": "64291f61-3dc0-4027-9875-b6b569eb8b45", 
+      "name": "vs1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "d82b533eb0784354856b6613cd557236"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "64291f61-3dc0-4027-9875-b6b569eb8b45", 
+    "listeners": [
+      {
+        "id": "55bc4120-daf4-42aa-b4f3-c2fc2b30e367"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "ee5d0a7a-6784-4c30-8450-001b272eecb3", 
+    "operating_status": "ONLINE", 
+    "pools": [
+      {
+        "id": "4bc522dc-065f-4877-a856-4a1881019a0b"
+      }
+    ], 
+    "provider": "f5networks", 
+    "provisioning_status": "ACTIVE", 
+    "tenant_id": "d82b533eb0784354856b6613cd557236", 
+    "vip_address": "172.16.7.33", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "mitaka-master-0:726d5106-80e1-537d-a8ab-9fb80e00feda", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "baremetal", 
+      "created_at": "2017-11-30T21:32:05", 
+      "description": null, 
+      "device_id": "64291f61-3dc0-4027-9875-b6b569eb8b45", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "172.16.7.33", 
+          "subnet_id": "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a"
+        }
+      ], 
+      "id": "bf0f8e60-1fcb-4a78-95db-f9fcccadbfde", 
+      "mac_address": "fa:16:3e:b1:84:8b", 
+      "name": "loadbalancer-64291f61-3dc0-4027-9875-b6b569eb8b45", 
+      "network_id": "ee5d0a7a-6784-4c30-8450-001b272eecb3", 
+      "port_security_enabled": true, 
+      "security_groups": [
+        "a20f7e4d-a8f8-497b-80bb-872d77e1eaed"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "d82b533eb0784354856b6613cd557236", 
+      "updated_at": "2017-11-30T21:32:07"
+    }, 
+    "vip_port_id": "bf0f8e60-1fcb-4a78-95db-f9fcccadbfde", 
+    "vip_subnet_id": "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a", 
+    "vxlan_vteps": [
+      "172.16.4.3", 
+      "172.16.4.4", 
+      "172.16.4.2"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "ee5d0a7a-6784-4c30-8450-001b272eecb3": {
+      "admin_state_up": true, 
+      "availability_zone_hints": [], 
+      "availability_zones": [
+        "nova"
+      ], 
+      "created_at": "2017-11-29T19:30:13", 
+      "description": "", 
+      "id": "ee5d0a7a-6784-4c30-8450-001b272eecb3", 
+      "ipv4_address_scope": null, 
+      "ipv6_address_scope": null, 
+      "mtu": 1450, 
+      "name": "admin_net", 
+      "port_security_enabled": true, 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 41, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a"
+      ], 
+      "tags": [], 
+      "tenant_id": "d82b533eb0784354856b6613cd557236", 
+      "updated_at": "2017-11-29T19:30:13", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "4bc522dc-065f-4877-a856-4a1881019a0b", 
+      "l7_policies": [], 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "loadbalancer_id": "64291f61-3dc0-4027-9875-b6b569eb8b45", 
+      "members": [], 
+      "name": "pool2", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "ACTIVE", 
+      "session_persistence": {
+        "cookie_name": "TEST_COOKIE", 
+        "type": "APP_COOKIE"
+      }, 
+      "sessionpersistence": null, 
+      "tenant_id": "d82b533eb0784354856b6613cd557236"
+    }
+  ], 
+  "subnets": {
+    "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a": {
+      "allocation_pools": [
+        {
+          "end": "172.16.7.254", 
+          "start": "172.16.7.2"
+        }
+      ], 
+      "cidr": "172.16.7.0/24", 
+      "created_at": "2017-11-29T19:30:16", 
+      "description": "", 
+      "dns_nameservers": [
+        "10.190.20.7"
+      ], 
+      "enable_dhcp": true, 
+      "gateway_ip": "172.16.7.1", 
+      "host_routes": [], 
+      "id": "98bdfcf1-aa3d-499f-8258-5fa2ae94e50a", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "admin_subnet", 
+      "network_id": "ee5d0a7a-6784-4c30-8450-001b272eecb3", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "d82b533eb0784354856b6613cd557236", 
+      "updated_at": "2017-11-29T19:30:16"
+    }
+  }
+}]


### PR DESCRIPTION
Problem:
purge folder contents does not delete persistence objects and l7policy objects

Solution:
Added resource type universal.persistence and l7policy objects to the list of items to be deleted.
Added a new test test_purge_folder that creates a bunch of objects on the bigip using service_requests
objects and calls the function purge_folder_contents. Then it verifies that all contents are deleted
by calling purge_folder which will throw error if some objects still exsists in the folder.

Fixes #1024

