### PR TITLE
Fix deleting pool with members leaves member network config on bigip

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1818,8 +1818,9 @@ class iControlDriver(LBaaSBaseDriver):
                         operating_status
                     )
                 elif provisioning_status == plugin_const.PENDING_DELETE:
-                    self.plugin_rpc.member_destroyed(
-                        member['id'])
+                    if not member.get('parent_pool_deleted', False):
+                        self.plugin_rpc.member_destroyed(
+                            member['id'])
                 elif provisioning_status == plugin_const.ERROR:
                     self.plugin_rpc.update_member_status(
                         member['id'],

--- a/test/functional/neutronless/pool/test_delete_pool.py
+++ b/test/functional/neutronless/pool/test_delete_pool.py
@@ -1,0 +1,132 @@
+# coding=utf-8
+# Copyright 2016 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import \
+    iControlDriver
+import json
+import logging
+import os
+import pytest
+import requests
+
+from ..testlib.bigip_client import BigIpClient
+from ..testlib.fake_rpc import FakeRPCPlugin
+from ..testlib.service_reader import LoadbalancerReader
+from ..testlib.resource_validator import ResourceValidator
+
+requests.packages.urllib3.disable_warnings()
+
+LOG = logging.getLogger(__name__)
+
+
+@pytest.fixture(scope="module")
+def services():
+    neutron_services_filename = (
+        os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                     '../../testdata/service_requests/delete_pool.json')
+    )
+    return (json.load(open(neutron_services_filename)))
+
+
+@pytest.fixture(scope="module")
+def bigip():
+
+    return BigIpClient(pytest.symbols.bigip_mgmt_ip_public,
+                       pytest.symbols.bigip_username,
+                       pytest.symbols.bigip_password)
+
+
+@pytest.fixture
+def fake_plugin_rpc(services):
+
+    rpcObj = FakeRPCPlugin(services)
+
+    return rpcObj
+
+
+@pytest.fixture
+def icontrol_driver(icd_config, fake_plugin_rpc):
+    class ConfFake(object):
+        def __init__(self, params):
+            self.__dict__ = params
+            for k, v in self.__dict__.items():
+                if isinstance(v, unicode):
+                    self.__dict__[k] = v.encode('utf-8')
+
+        def __repr__(self):
+            return repr(self.__dict__)
+
+    icd = iControlDriver(ConfFake(icd_config),
+                         registerOpts=False)
+
+    icd.plugin_rpc = fake_plugin_rpc
+    icd.connect()
+
+    return icd
+
+
+def test_single_pool(track_bigip_cfg, bigip, services, icd_config,
+                     icontrol_driver):
+    env_prefix = icd_config['environment_prefix']
+    service_iter = iter(services)
+    validator = ResourceValidator(bigip, env_prefix)
+
+    # create loadbalancer on lb_subnet (membes will be on different subnet)
+    service = service_iter.next()
+    lb_reader = LoadbalancerReader(service)
+    folder = '{0}_{1}'.format(env_prefix, lb_reader.tenant_id())
+    icontrol_driver._common_service_handler(service)
+    assert bigip.folder_exists(folder)
+
+    # create listener
+    service = service_iter.next()
+    listener = service['listeners'][0]
+    icontrol_driver._common_service_handler(service)
+    validator.assert_virtual_valid(listener, folder)
+
+    # create pool
+    service = service_iter.next()
+    pool = service['pools'][0]
+    icontrol_driver._common_service_handler(service)
+    validator.assert_pool_valid(pool, folder)
+
+    # create member on member_subnet (different subnet than LB)
+    service = service_iter.next()
+    member = service['members'][0]
+    icontrol_driver._common_service_handler(service)
+    validator.assert_member_valid(pool, member, folder)
+
+    # create second member on member_subnet
+    service = service_iter.next()
+    member = service['members'][1]
+    icontrol_driver._common_service_handler(service)
+    validator.assert_member_valid(pool, member, folder)
+
+    # delete pool without first deleting members
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+    validator.assert_pool_deleted(pool, member, folder)
+
+    # delete listener
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service)
+    validator.assert_virtual_deleted(listener, folder)
+
+    # delete loadbalancer
+    service = service_iter.next()
+    icontrol_driver._common_service_handler(service, delete_partition=True)
+
+    # if folder still exists, agent failed to fully clean up network objects
+    assert not bigip.folder_exists(folder)

--- a/test/functional/testdata/service_requests/delete_pool.json
+++ b/test/functional/testdata/service_requests/delete_pool.json
@@ -1,0 +1,1439 @@
+[{
+  "healthmonitors": [], 
+  "listeners": [], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+    "listeners": [], 
+    "name": "lb1", 
+    "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+    "operating_status": "OFFLINE", 
+    "provider": null, 
+    "provisioning_status": "PENDING_CREATE", 
+    "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+    "vip_address": "192.168.100.26", 
+    "vip_port": {
+      "admin_state_up": false, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "unbound", 
+      "binding:vnic_type": "normal", 
+      "device_id": "8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+      "device_owner": "neutron:LOADBALANCERV2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-192-168-100-26.openstacklocal.", 
+          "hostname": "host-192-168-100-26", 
+          "ip_address": "192.168.100.26"
+        }
+      ], 
+      "dns_name": null, 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "192.168.100.26", 
+          "subnet_id": "74386b85-12ef-4686-accb-decdf6f5c8a5"
+        }
+      ], 
+      "id": "aad3e4cd-74d9-455e-8308-8930f1ea73ba", 
+      "mac_address": "fa:16:3e:21:00:38", 
+      "name": "loadbalancer-8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+      "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "security_groups": [
+        "c9322869-fd20-44ae-a306-ad6b97153170"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }, 
+    "vip_port_id": "aad3e4cd-74d9-455e-8308-8930f1ea73ba", 
+    "vip_subnet_id": "74386b85-12ef-4686-accb-decdf6f5c8a5", 
+    "vxlan_vteps": [
+      "201.0.155.10", 
+      "201.0.159.1", 
+      "201.0.157.1", 
+      "201.0.160.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "707f8626-ad1b-4cb0-818a-de0a74637c90": {
+      "admin_state_up": true, 
+      "id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "mtu": 0, 
+      "name": "lb-net", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 86, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "74386b85-12ef-4686-accb-decdf6f5c8a5"
+      ], 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "74386b85-12ef-4686-accb-decdf6f5c8a5": {
+      "allocation_pools": [
+        {
+          "end": "192.168.100.254", 
+          "start": "192.168.100.2"
+        }
+      ], 
+      "cidr": "192.168.100.0/24", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.100.1", 
+      "host_routes": [], 
+      "id": "74386b85-12ef-4686-accb-decdf6f5c8a5", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "lb-subnet", 
+      "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": null, 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "3dd7d533-8de3-4038-b8e5-74a6c2d46da3", 
+      "loadbalancer_id": "8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+      "name": "listener1", 
+      "operating_status": "OFFLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "PENDING_CREATE", 
+      "sni_containers": [], 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+    "listeners": [
+      {
+        "id": "3dd7d533-8de3-4038-b8e5-74a6c2d46da3"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+    "operating_status": "ONLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+    "vip_address": "192.168.100.26", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-159.int.lineratesystems.com:a54f31cf-6cb2-56fa-82ea-45c7d5085ad2", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "cf706bbc-4d10-5454-ad06-0ca7bb4274bb", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-192-168-100-26.openstacklocal.", 
+          "hostname": "host-192-168-100-26", 
+          "ip_address": "192.168.100.26"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "192.168.100.26", 
+          "subnet_id": "74386b85-12ef-4686-accb-decdf6f5c8a5"
+        }
+      ], 
+      "id": "aad3e4cd-74d9-455e-8308-8930f1ea73ba", 
+      "mac_address": "fa:16:3e:21:00:38", 
+      "name": "loadbalancer-8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+      "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "security_groups": [
+        "c9322869-fd20-44ae-a306-ad6b97153170"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }, 
+    "vip_port_id": "aad3e4cd-74d9-455e-8308-8930f1ea73ba", 
+    "vip_subnet_id": "74386b85-12ef-4686-accb-decdf6f5c8a5", 
+    "vxlan_vteps": [
+      "201.0.155.10", 
+      "201.0.159.1", 
+      "201.0.157.1", 
+      "201.0.160.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "707f8626-ad1b-4cb0-818a-de0a74637c90": {
+      "admin_state_up": true, 
+      "id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "mtu": 0, 
+      "name": "lb-net", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 86, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "74386b85-12ef-4686-accb-decdf6f5c8a5"
+      ], 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "74386b85-12ef-4686-accb-decdf6f5c8a5": {
+      "allocation_pools": [
+        {
+          "end": "192.168.100.254", 
+          "start": "192.168.100.2"
+        }
+      ], 
+      "cidr": "192.168.100.0/24", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.100.1", 
+      "host_routes": [], 
+      "id": "74386b85-12ef-4686-accb-decdf6f5c8a5", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "lb-subnet", 
+      "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "8af105b8-95f3-40ef-aa5f-c61535e86b6c", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "3dd7d533-8de3-4038-b8e5-74a6c2d46da3", 
+      "loadbalancer_id": "8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+      "name": "listener1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+    "listeners": [
+      {
+        "id": "3dd7d533-8de3-4038-b8e5-74a6c2d46da3"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+    "operating_status": "ONLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+    "vip_address": "192.168.100.26", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-159.int.lineratesystems.com:a54f31cf-6cb2-56fa-82ea-45c7d5085ad2", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "cf706bbc-4d10-5454-ad06-0ca7bb4274bb", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-192-168-100-26.openstacklocal.", 
+          "hostname": "host-192-168-100-26", 
+          "ip_address": "192.168.100.26"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "192.168.100.26", 
+          "subnet_id": "74386b85-12ef-4686-accb-decdf6f5c8a5"
+        }
+      ], 
+      "id": "aad3e4cd-74d9-455e-8308-8930f1ea73ba", 
+      "mac_address": "fa:16:3e:21:00:38", 
+      "name": "loadbalancer-8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+      "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "security_groups": [
+        "c9322869-fd20-44ae-a306-ad6b97153170"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }, 
+    "vip_port_id": "aad3e4cd-74d9-455e-8308-8930f1ea73ba", 
+    "vip_subnet_id": "74386b85-12ef-4686-accb-decdf6f5c8a5", 
+    "vxlan_vteps": [
+      "201.0.155.10", 
+      "201.0.159.1", 
+      "201.0.157.1", 
+      "201.0.160.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "707f8626-ad1b-4cb0-818a-de0a74637c90": {
+      "admin_state_up": true, 
+      "id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "mtu": 0, 
+      "name": "lb-net", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 86, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "74386b85-12ef-4686-accb-decdf6f5c8a5"
+      ], 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "8af105b8-95f3-40ef-aa5f-c61535e86b6c", 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listeners": [
+        {
+          "id": "3dd7d533-8de3-4038-b8e5-74a6c2d46da3"
+        }
+      ], 
+      "members": [], 
+      "name": "pool1", 
+      "operating_status": "OFFLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "PENDING_CREATE", 
+      "session_persistence": null, 
+      "sessionpersistence": null, 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }
+  ], 
+  "subnets": {
+    "74386b85-12ef-4686-accb-decdf6f5c8a5": {
+      "allocation_pools": [
+        {
+          "end": "192.168.100.254", 
+          "start": "192.168.100.2"
+        }
+      ], 
+      "cidr": "192.168.100.0/24", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.100.1", 
+      "host_routes": [], 
+      "id": "74386b85-12ef-4686-accb-decdf6f5c8a5", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "lb-subnet", 
+      "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "8af105b8-95f3-40ef-aa5f-c61535e86b6c", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "3dd7d533-8de3-4038-b8e5-74a6c2d46da3", 
+      "loadbalancer_id": "8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+      "name": "listener1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+    "listeners": [
+      {
+        "id": "3dd7d533-8de3-4038-b8e5-74a6c2d46da3"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+    "operating_status": "ONLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+    "vip_address": "192.168.100.26", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-159.int.lineratesystems.com:a54f31cf-6cb2-56fa-82ea-45c7d5085ad2", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "cf706bbc-4d10-5454-ad06-0ca7bb4274bb", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-192-168-100-26.openstacklocal.", 
+          "hostname": "host-192-168-100-26", 
+          "ip_address": "192.168.100.26"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "192.168.100.26", 
+          "subnet_id": "74386b85-12ef-4686-accb-decdf6f5c8a5"
+        }
+      ], 
+      "id": "aad3e4cd-74d9-455e-8308-8930f1ea73ba", 
+      "mac_address": "fa:16:3e:21:00:38", 
+      "name": "loadbalancer-8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+      "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "security_groups": [
+        "c9322869-fd20-44ae-a306-ad6b97153170"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }, 
+    "vip_port_id": "aad3e4cd-74d9-455e-8308-8930f1ea73ba", 
+    "vip_subnet_id": "74386b85-12ef-4686-accb-decdf6f5c8a5", 
+    "vxlan_vteps": [
+      "201.0.155.10", 
+      "201.0.159.1", 
+      "201.0.157.1", 
+      "201.0.160.1"
+    ]
+  }, 
+  "members": [
+    {
+      "address": "192.168.200.30", 
+      "admin_state_up": true, 
+      "gre_vteps": [], 
+      "id": "5c29c74a-8574-4525-8686-8b3d22f6f25c", 
+      "network_id": "cfffa829-5bef-49f8-870a-45c636202ff0", 
+      "operating_status": "OFFLINE", 
+      "pool_id": "8af105b8-95f3-40ef-aa5f-c61535e86b6c", 
+      "port": {
+        "admin_state_up": true, 
+        "allowed_address_pairs": [], 
+        "binding:host_id": "host-159.int.lineratesystems.com:a54f31cf-6cb2-56fa-82ea-45c7d5085ad2", 
+        "binding:profile": {}, 
+        "binding:vif_details": {}, 
+        "binding:vif_type": "binding_failed", 
+        "binding:vnic_type": "normal", 
+        "device_id": "cf706bbc-4d10-5454-ad06-0ca7bb4274bb", 
+        "device_owner": "network:f5lbaasv2", 
+        "dns_assignment": [
+          {
+            "fqdn": "host-192-168-200-30.openstacklocal.", 
+            "hostname": "host-192-168-200-30", 
+            "ip_address": "192.168.200.30"
+          }
+        ], 
+        "dns_name": "", 
+        "extra_dhcp_opts": [], 
+        "fixed_ips": [
+          {
+            "ip_address": "192.168.200.30", 
+            "subnet_id": "192db52c-fbb3-45cb-bb37-47c887d0f3ad"
+          }
+        ], 
+        "id": "6ab21a5b-b392-4dca-a869-91974a8bf285", 
+        "mac_address": "fa:16:3e:85:cb:86", 
+        "name": "local-bigip1-192db52c-fbb3-45cb-bb37-47c887d0f3ad", 
+        "network_id": "cfffa829-5bef-49f8-870a-45c636202ff0", 
+        "security_groups": [], 
+        "status": "ACTIVE", 
+        "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+      }, 
+      "protocol_port": 80, 
+      "provisioning_status": "PENDING_CREATE", 
+      "subnet_id": "192db52c-fbb3-45cb-bb37-47c887d0f3ad", 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+      "vxlan_vteps": [
+        "201.0.155.10"
+      ], 
+      "weight": 1
+    }
+  ], 
+  "networks": {
+    "707f8626-ad1b-4cb0-818a-de0a74637c90": {
+      "admin_state_up": true, 
+      "id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "mtu": 0, 
+      "name": "lb-net", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 86, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "74386b85-12ef-4686-accb-decdf6f5c8a5"
+      ], 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+      "vlan_transparent": null
+    }, 
+    "cfffa829-5bef-49f8-870a-45c636202ff0": {
+      "admin_state_up": true, 
+      "id": "cfffa829-5bef-49f8-870a-45c636202ff0", 
+      "mtu": 0, 
+      "name": "member-net", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 92, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "192db52c-fbb3-45cb-bb37-47c887d0f3ad"
+      ], 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "8af105b8-95f3-40ef-aa5f-c61535e86b6c", 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listeners": [
+        {
+          "id": "3dd7d533-8de3-4038-b8e5-74a6c2d46da3"
+        }
+      ], 
+      "members": [
+        {
+          "id": "5c29c74a-8574-4525-8686-8b3d22f6f25c"
+        }
+      ], 
+      "name": "pool1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "ACTIVE", 
+      "session_persistence": null, 
+      "sessionpersistence": null, 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }
+  ], 
+  "subnets": {
+    "192db52c-fbb3-45cb-bb37-47c887d0f3ad": {
+      "allocation_pools": [
+        {
+          "end": "192.168.200.254", 
+          "start": "192.168.200.2"
+        }
+      ], 
+      "cidr": "192.168.200.0/24", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.200.1", 
+      "host_routes": [], 
+      "id": "192db52c-fbb3-45cb-bb37-47c887d0f3ad", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "member-subnet", 
+      "network_id": "cfffa829-5bef-49f8-870a-45c636202ff0", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }, 
+    "74386b85-12ef-4686-accb-decdf6f5c8a5": {
+      "allocation_pools": [
+        {
+          "end": "192.168.100.254", 
+          "start": "192.168.100.2"
+        }
+      ], 
+      "cidr": "192.168.100.0/24", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.100.1", 
+      "host_routes": [], 
+      "id": "74386b85-12ef-4686-accb-decdf6f5c8a5", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "lb-subnet", 
+      "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "8af105b8-95f3-40ef-aa5f-c61535e86b6c", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "3dd7d533-8de3-4038-b8e5-74a6c2d46da3", 
+      "loadbalancer_id": "8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+      "name": "listener1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+    "listeners": [
+      {
+        "id": "3dd7d533-8de3-4038-b8e5-74a6c2d46da3"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+    "operating_status": "OFFLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+    "vip_address": "192.168.100.26", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-159.int.lineratesystems.com:a54f31cf-6cb2-56fa-82ea-45c7d5085ad2", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "cf706bbc-4d10-5454-ad06-0ca7bb4274bb", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-192-168-100-26.openstacklocal.", 
+          "hostname": "host-192-168-100-26", 
+          "ip_address": "192.168.100.26"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "192.168.100.26", 
+          "subnet_id": "74386b85-12ef-4686-accb-decdf6f5c8a5"
+        }
+      ], 
+      "id": "aad3e4cd-74d9-455e-8308-8930f1ea73ba", 
+      "mac_address": "fa:16:3e:21:00:38", 
+      "name": "loadbalancer-8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+      "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "security_groups": [
+        "c9322869-fd20-44ae-a306-ad6b97153170"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }, 
+    "vip_port_id": "aad3e4cd-74d9-455e-8308-8930f1ea73ba", 
+    "vip_subnet_id": "74386b85-12ef-4686-accb-decdf6f5c8a5", 
+    "vxlan_vteps": [
+      "201.0.155.10", 
+      "201.0.159.1", 
+      "201.0.157.1", 
+      "201.0.160.1"
+    ]
+  }, 
+  "members": [
+    {
+      "address": "192.168.200.30", 
+      "admin_state_up": true, 
+      "gre_vteps": [], 
+      "id": "5c29c74a-8574-4525-8686-8b3d22f6f25c", 
+      "network_id": "cfffa829-5bef-49f8-870a-45c636202ff0", 
+      "operating_status": "ONLINE", 
+      "pool_id": "8af105b8-95f3-40ef-aa5f-c61535e86b6c", 
+      "port": {
+        "admin_state_up": true, 
+        "allowed_address_pairs": [], 
+        "binding:host_id": "host-159.int.lineratesystems.com:a54f31cf-6cb2-56fa-82ea-45c7d5085ad2", 
+        "binding:profile": {}, 
+        "binding:vif_details": {}, 
+        "binding:vif_type": "binding_failed", 
+        "binding:vnic_type": "normal", 
+        "device_id": "cf706bbc-4d10-5454-ad06-0ca7bb4274bb", 
+        "device_owner": "network:f5lbaasv2", 
+        "dns_assignment": [
+          {
+            "fqdn": "host-192-168-200-30.openstacklocal.", 
+            "hostname": "host-192-168-200-30", 
+            "ip_address": "192.168.200.30"
+          }
+        ], 
+        "dns_name": "", 
+        "extra_dhcp_opts": [], 
+        "fixed_ips": [
+          {
+            "ip_address": "192.168.200.30", 
+            "subnet_id": "192db52c-fbb3-45cb-bb37-47c887d0f3ad"
+          }
+        ], 
+        "id": "6ab21a5b-b392-4dca-a869-91974a8bf285", 
+        "mac_address": "fa:16:3e:85:cb:86", 
+        "name": "local-bigip1-192db52c-fbb3-45cb-bb37-47c887d0f3ad", 
+        "network_id": "cfffa829-5bef-49f8-870a-45c636202ff0", 
+        "security_groups": [], 
+        "status": "ACTIVE", 
+        "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+      }, 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "subnet_id": "192db52c-fbb3-45cb-bb37-47c887d0f3ad", 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+      "vxlan_vteps": [
+        "201.0.155.10"
+      ], 
+      "weight": 1
+    }, 
+    {
+      "address": "192.168.200.40", 
+      "admin_state_up": true, 
+      "gre_vteps": [], 
+      "id": "beb88074-b106-4754-a007-98f971211f0e", 
+      "network_id": "cfffa829-5bef-49f8-870a-45c636202ff0", 
+      "operating_status": "OFFLINE", 
+      "pool_id": "8af105b8-95f3-40ef-aa5f-c61535e86b6c", 
+      "port": {
+        "admin_state_up": true, 
+        "allowed_address_pairs": [], 
+        "binding:host_id": "host-159.int.lineratesystems.com:a54f31cf-6cb2-56fa-82ea-45c7d5085ad2", 
+        "binding:profile": {}, 
+        "binding:vif_details": {}, 
+        "binding:vif_type": "binding_failed", 
+        "binding:vnic_type": "normal", 
+        "device_id": "cf706bbc-4d10-5454-ad06-0ca7bb4274bb", 
+        "device_owner": "network:f5lbaasv2", 
+        "dns_assignment": [
+          {
+            "fqdn": "host-192-168-200-40.openstacklocal.", 
+            "hostname": "host-192-168-200-40", 
+            "ip_address": "192.168.200.40"
+          }
+        ], 
+        "dns_name": "", 
+        "extra_dhcp_opts": [], 
+        "fixed_ips": [
+          {
+            "ip_address": "192.168.200.40", 
+            "subnet_id": "192db52c-fbb3-45cb-bb37-47c887d0f3ad"
+          }
+        ], 
+        "id": "31f2a7e8-d191-4bbc-951e-251bbea7d78e", 
+        "mac_address": "fa:16:3e:e8:64:89", 
+        "name": "snat-traffic-group-local-only-192db52c-fbb3-45cb-bb37-47c887d0f3ad_0", 
+        "network_id": "cfffa829-5bef-49f8-870a-45c636202ff0", 
+        "security_groups": [], 
+        "status": "ACTIVE", 
+        "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+      }, 
+      "protocol_port": 80, 
+      "provisioning_status": "PENDING_CREATE", 
+      "subnet_id": "192db52c-fbb3-45cb-bb37-47c887d0f3ad", 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+      "vxlan_vteps": [
+        "201.0.155.10"
+      ], 
+      "weight": 1
+    }
+  ], 
+  "networks": {
+    "707f8626-ad1b-4cb0-818a-de0a74637c90": {
+      "admin_state_up": true, 
+      "id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "mtu": 0, 
+      "name": "lb-net", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 86, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "74386b85-12ef-4686-accb-decdf6f5c8a5"
+      ], 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+      "vlan_transparent": null
+    }, 
+    "cfffa829-5bef-49f8-870a-45c636202ff0": {
+      "admin_state_up": true, 
+      "id": "cfffa829-5bef-49f8-870a-45c636202ff0", 
+      "mtu": 0, 
+      "name": "member-net", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 92, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "192db52c-fbb3-45cb-bb37-47c887d0f3ad"
+      ], 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "8af105b8-95f3-40ef-aa5f-c61535e86b6c", 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listeners": [
+        {
+          "id": "3dd7d533-8de3-4038-b8e5-74a6c2d46da3"
+        }
+      ], 
+      "members": [
+        {
+          "id": "5c29c74a-8574-4525-8686-8b3d22f6f25c"
+        }, 
+        {
+          "id": "beb88074-b106-4754-a007-98f971211f0e"
+        }
+      ], 
+      "name": "pool1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "ACTIVE", 
+      "session_persistence": null, 
+      "sessionpersistence": null, 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }
+  ], 
+  "subnets": {
+    "192db52c-fbb3-45cb-bb37-47c887d0f3ad": {
+      "allocation_pools": [
+        {
+          "end": "192.168.200.254", 
+          "start": "192.168.200.2"
+        }
+      ], 
+      "cidr": "192.168.200.0/24", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.200.1", 
+      "host_routes": [], 
+      "id": "192db52c-fbb3-45cb-bb37-47c887d0f3ad", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "member-subnet", 
+      "network_id": "cfffa829-5bef-49f8-870a-45c636202ff0", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }, 
+    "74386b85-12ef-4686-accb-decdf6f5c8a5": {
+      "allocation_pools": [
+        {
+          "end": "192.168.100.254", 
+          "start": "192.168.100.2"
+        }
+      ], 
+      "cidr": "192.168.100.0/24", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.100.1", 
+      "host_routes": [], 
+      "id": "74386b85-12ef-4686-accb-decdf6f5c8a5", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "lb-subnet", 
+      "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": "8af105b8-95f3-40ef-aa5f-c61535e86b6c", 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "3dd7d533-8de3-4038-b8e5-74a6c2d46da3", 
+      "loadbalancer_id": "8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+      "name": "listener1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "sni_containers": [], 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+    "listeners": [
+      {
+        "id": "3dd7d533-8de3-4038-b8e5-74a6c2d46da3"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+    "operating_status": "OFFLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+    "vip_address": "192.168.100.26", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-159.int.lineratesystems.com:a54f31cf-6cb2-56fa-82ea-45c7d5085ad2", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "cf706bbc-4d10-5454-ad06-0ca7bb4274bb", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-192-168-100-26.openstacklocal.", 
+          "hostname": "host-192-168-100-26", 
+          "ip_address": "192.168.100.26"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "192.168.100.26", 
+          "subnet_id": "74386b85-12ef-4686-accb-decdf6f5c8a5"
+        }
+      ], 
+      "id": "aad3e4cd-74d9-455e-8308-8930f1ea73ba", 
+      "mac_address": "fa:16:3e:21:00:38", 
+      "name": "loadbalancer-8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+      "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "security_groups": [
+        "c9322869-fd20-44ae-a306-ad6b97153170"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }, 
+    "vip_port_id": "aad3e4cd-74d9-455e-8308-8930f1ea73ba", 
+    "vip_subnet_id": "74386b85-12ef-4686-accb-decdf6f5c8a5", 
+    "vxlan_vteps": [
+      "201.0.155.10", 
+      "201.0.159.1", 
+      "201.0.157.1", 
+      "201.0.160.1"
+    ]
+  }, 
+  "members": [
+    {
+      "address": "192.168.200.30", 
+      "admin_state_up": true, 
+      "gre_vteps": [], 
+      "id": "5c29c74a-8574-4525-8686-8b3d22f6f25c", 
+      "network_id": "cfffa829-5bef-49f8-870a-45c636202ff0", 
+      "operating_status": "ONLINE", 
+      "pool_id": "8af105b8-95f3-40ef-aa5f-c61535e86b6c", 
+      "port": {
+        "admin_state_up": true, 
+        "allowed_address_pairs": [], 
+        "binding:host_id": "host-159.int.lineratesystems.com:a54f31cf-6cb2-56fa-82ea-45c7d5085ad2", 
+        "binding:profile": {}, 
+        "binding:vif_details": {}, 
+        "binding:vif_type": "binding_failed", 
+        "binding:vnic_type": "normal", 
+        "device_id": "cf706bbc-4d10-5454-ad06-0ca7bb4274bb", 
+        "device_owner": "network:f5lbaasv2", 
+        "dns_assignment": [
+          {
+            "fqdn": "host-192-168-200-30.openstacklocal.", 
+            "hostname": "host-192-168-200-30", 
+            "ip_address": "192.168.200.30"
+          }
+        ], 
+        "dns_name": "", 
+        "extra_dhcp_opts": [], 
+        "fixed_ips": [
+          {
+            "ip_address": "192.168.200.30", 
+            "subnet_id": "192db52c-fbb3-45cb-bb37-47c887d0f3ad"
+          }
+        ], 
+        "id": "6ab21a5b-b392-4dca-a869-91974a8bf285", 
+        "mac_address": "fa:16:3e:85:cb:86", 
+        "name": "local-bigip1-192db52c-fbb3-45cb-bb37-47c887d0f3ad", 
+        "network_id": "cfffa829-5bef-49f8-870a-45c636202ff0", 
+        "security_groups": [], 
+        "status": "ACTIVE", 
+        "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+      }, 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "subnet_id": "192db52c-fbb3-45cb-bb37-47c887d0f3ad", 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+      "vxlan_vteps": [
+        "201.0.155.10"
+      ], 
+      "weight": 1
+    }, 
+    {
+      "address": "192.168.200.40", 
+      "admin_state_up": true, 
+      "gre_vteps": [], 
+      "id": "beb88074-b106-4754-a007-98f971211f0e", 
+      "network_id": "cfffa829-5bef-49f8-870a-45c636202ff0", 
+      "operating_status": "ONLINE", 
+      "pool_id": "8af105b8-95f3-40ef-aa5f-c61535e86b6c", 
+      "port": {
+        "admin_state_up": true, 
+        "allowed_address_pairs": [], 
+        "binding:host_id": "host-159.int.lineratesystems.com:a54f31cf-6cb2-56fa-82ea-45c7d5085ad2", 
+        "binding:profile": {}, 
+        "binding:vif_details": {}, 
+        "binding:vif_type": "binding_failed", 
+        "binding:vnic_type": "normal", 
+        "device_id": "cf706bbc-4d10-5454-ad06-0ca7bb4274bb", 
+        "device_owner": "network:f5lbaasv2", 
+        "dns_assignment": [
+          {
+            "fqdn": "host-192-168-200-40.openstacklocal.", 
+            "hostname": "host-192-168-200-40", 
+            "ip_address": "192.168.200.40"
+          }
+        ], 
+        "dns_name": "", 
+        "extra_dhcp_opts": [], 
+        "fixed_ips": [
+          {
+            "ip_address": "192.168.200.40", 
+            "subnet_id": "192db52c-fbb3-45cb-bb37-47c887d0f3ad"
+          }
+        ], 
+        "id": "31f2a7e8-d191-4bbc-951e-251bbea7d78e", 
+        "mac_address": "fa:16:3e:e8:64:89", 
+        "name": "snat-traffic-group-local-only-192db52c-fbb3-45cb-bb37-47c887d0f3ad_0", 
+        "network_id": "cfffa829-5bef-49f8-870a-45c636202ff0", 
+        "security_groups": [], 
+        "status": "ACTIVE", 
+        "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+      }, 
+      "protocol_port": 80, 
+      "provisioning_status": "ACTIVE", 
+      "subnet_id": "192db52c-fbb3-45cb-bb37-47c887d0f3ad", 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+      "vxlan_vteps": [
+        "201.0.155.10"
+      ], 
+      "weight": 1
+    }
+  ], 
+  "networks": {
+    "707f8626-ad1b-4cb0-818a-de0a74637c90": {
+      "admin_state_up": true, 
+      "id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "mtu": 0, 
+      "name": "lb-net", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 86, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "74386b85-12ef-4686-accb-decdf6f5c8a5"
+      ], 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+      "vlan_transparent": null
+    }, 
+    "cfffa829-5bef-49f8-870a-45c636202ff0": {
+      "admin_state_up": true, 
+      "id": "cfffa829-5bef-49f8-870a-45c636202ff0", 
+      "mtu": 0, 
+      "name": "member-net", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 92, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "192db52c-fbb3-45cb-bb37-47c887d0f3ad"
+      ], 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [
+    {
+      "admin_state_up": true, 
+      "description": "", 
+      "healthmonitor_id": null, 
+      "id": "8af105b8-95f3-40ef-aa5f-c61535e86b6c", 
+      "lb_algorithm": "ROUND_ROBIN", 
+      "listeners": [
+        {
+          "id": "3dd7d533-8de3-4038-b8e5-74a6c2d46da3"
+        }
+      ], 
+      "members": [
+        {
+          "id": "5c29c74a-8574-4525-8686-8b3d22f6f25c"
+        }, 
+        {
+          "id": "beb88074-b106-4754-a007-98f971211f0e"
+        }
+      ], 
+      "name": "pool1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "provisioning_status": "PENDING_DELETE", 
+      "session_persistence": null, 
+      "sessionpersistence": null, 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }
+  ], 
+  "subnets": {
+    "192db52c-fbb3-45cb-bb37-47c887d0f3ad": {
+      "allocation_pools": [
+        {
+          "end": "192.168.200.254", 
+          "start": "192.168.200.2"
+        }
+      ], 
+      "cidr": "192.168.200.0/24", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.200.1", 
+      "host_routes": [], 
+      "id": "192db52c-fbb3-45cb-bb37-47c887d0f3ad", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "member-subnet", 
+      "network_id": "cfffa829-5bef-49f8-870a-45c636202ff0", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }, 
+    "74386b85-12ef-4686-accb-decdf6f5c8a5": {
+      "allocation_pools": [
+        {
+          "end": "192.168.100.254", 
+          "start": "192.168.100.2"
+        }
+      ], 
+      "cidr": "192.168.100.0/24", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.100.1", 
+      "host_routes": [], 
+      "id": "74386b85-12ef-4686-accb-decdf6f5c8a5", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "lb-subnet", 
+      "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "listeners": [
+    {
+      "admin_state_up": true, 
+      "connection_limit": -1, 
+      "default_pool_id": null, 
+      "default_tls_container_id": null, 
+      "description": "", 
+      "id": "3dd7d533-8de3-4038-b8e5-74a6c2d46da3", 
+      "loadbalancer_id": "8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+      "name": "listener1", 
+      "operating_status": "ONLINE", 
+      "protocol": "HTTP", 
+      "protocol_port": 80, 
+      "provisioning_status": "PENDING_DELETE", 
+      "sni_containers": [], 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }
+  ], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+    "listeners": [
+      {
+        "id": "3dd7d533-8de3-4038-b8e5-74a6c2d46da3"
+      }
+    ], 
+    "name": "lb1", 
+    "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+    "operating_status": "ONLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_UPDATE", 
+    "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+    "vip_address": "192.168.100.26", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-159.int.lineratesystems.com:a54f31cf-6cb2-56fa-82ea-45c7d5085ad2", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "cf706bbc-4d10-5454-ad06-0ca7bb4274bb", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-192-168-100-26.openstacklocal.", 
+          "hostname": "host-192-168-100-26", 
+          "ip_address": "192.168.100.26"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "192.168.100.26", 
+          "subnet_id": "74386b85-12ef-4686-accb-decdf6f5c8a5"
+        }
+      ], 
+      "id": "aad3e4cd-74d9-455e-8308-8930f1ea73ba", 
+      "mac_address": "fa:16:3e:21:00:38", 
+      "name": "loadbalancer-8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+      "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "security_groups": [
+        "c9322869-fd20-44ae-a306-ad6b97153170"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }, 
+    "vip_port_id": "aad3e4cd-74d9-455e-8308-8930f1ea73ba", 
+    "vip_subnet_id": "74386b85-12ef-4686-accb-decdf6f5c8a5", 
+    "vxlan_vteps": [
+      "201.0.155.10", 
+      "201.0.159.1", 
+      "201.0.157.1", 
+      "201.0.160.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "707f8626-ad1b-4cb0-818a-de0a74637c90": {
+      "admin_state_up": true, 
+      "id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "mtu": 0, 
+      "name": "lb-net", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 86, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "74386b85-12ef-4686-accb-decdf6f5c8a5"
+      ], 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "74386b85-12ef-4686-accb-decdf6f5c8a5": {
+      "allocation_pools": [
+        {
+          "end": "192.168.100.254", 
+          "start": "192.168.100.2"
+        }
+      ], 
+      "cidr": "192.168.100.0/24", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.100.1", 
+      "host_routes": [], 
+      "id": "74386b85-12ef-4686-accb-decdf6f5c8a5", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "lb-subnet", 
+      "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }
+  }
+},{
+  "healthmonitors": [], 
+  "listeners": [], 
+  "loadbalancer": {
+    "admin_state_up": true, 
+    "description": "", 
+    "gre_vteps": [], 
+    "id": "8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+    "listeners": [], 
+    "name": "lb1", 
+    "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+    "operating_status": "ONLINE", 
+    "provider": "f5networks", 
+    "provisioning_status": "PENDING_DELETE", 
+    "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+    "vip_address": "192.168.100.26", 
+    "vip_port": {
+      "admin_state_up": true, 
+      "allowed_address_pairs": [], 
+      "binding:host_id": "host-159.int.lineratesystems.com:a54f31cf-6cb2-56fa-82ea-45c7d5085ad2", 
+      "binding:profile": {}, 
+      "binding:vif_details": {}, 
+      "binding:vif_type": "binding_failed", 
+      "binding:vnic_type": "normal", 
+      "device_id": "cf706bbc-4d10-5454-ad06-0ca7bb4274bb", 
+      "device_owner": "network:f5lbaasv2", 
+      "dns_assignment": [
+        {
+          "fqdn": "host-192-168-100-26.openstacklocal.", 
+          "hostname": "host-192-168-100-26", 
+          "ip_address": "192.168.100.26"
+        }
+      ], 
+      "dns_name": "", 
+      "extra_dhcp_opts": [], 
+      "fixed_ips": [
+        {
+          "ip_address": "192.168.100.26", 
+          "subnet_id": "74386b85-12ef-4686-accb-decdf6f5c8a5"
+        }
+      ], 
+      "id": "aad3e4cd-74d9-455e-8308-8930f1ea73ba", 
+      "mac_address": "fa:16:3e:21:00:38", 
+      "name": "loadbalancer-8b5ca217-dcbe-4b21-b4ce-6a62371eea6d", 
+      "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "security_groups": [
+        "c9322869-fd20-44ae-a306-ad6b97153170"
+      ], 
+      "status": "DOWN", 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }, 
+    "vip_port_id": "aad3e4cd-74d9-455e-8308-8930f1ea73ba", 
+    "vip_subnet_id": "74386b85-12ef-4686-accb-decdf6f5c8a5", 
+    "vxlan_vteps": [
+      "201.0.155.10", 
+      "201.0.159.1", 
+      "201.0.157.1", 
+      "201.0.160.1"
+    ]
+  }, 
+  "members": [], 
+  "networks": {
+    "707f8626-ad1b-4cb0-818a-de0a74637c90": {
+      "admin_state_up": true, 
+      "id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "mtu": 0, 
+      "name": "lb-net", 
+      "provider:network_type": "vxlan", 
+      "provider:physical_network": null, 
+      "provider:segmentation_id": 86, 
+      "router:external": false, 
+      "shared": false, 
+      "status": "ACTIVE", 
+      "subnets": [
+        "74386b85-12ef-4686-accb-decdf6f5c8a5"
+      ], 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf", 
+      "vlan_transparent": null
+    }
+  }, 
+  "pools": [], 
+  "subnets": {
+    "74386b85-12ef-4686-accb-decdf6f5c8a5": {
+      "allocation_pools": [
+        {
+          "end": "192.168.100.254", 
+          "start": "192.168.100.2"
+        }
+      ], 
+      "cidr": "192.168.100.0/24", 
+      "dns_nameservers": [], 
+      "enable_dhcp": true, 
+      "gateway_ip": "192.168.100.1", 
+      "host_routes": [], 
+      "id": "74386b85-12ef-4686-accb-decdf6f5c8a5", 
+      "ip_version": 4, 
+      "ipv6_address_mode": null, 
+      "ipv6_ra_mode": null, 
+      "name": "lb-subnet", 
+      "network_id": "707f8626-ad1b-4cb0-818a-de0a74637c90", 
+      "shared": false, 
+      "subnetpool_id": null, 
+      "tenant_id": "1385791f9db54a7bac13a41f3c33f1bf"
+    }
+  }
+}]

--- a/test/functional/testdata/service_requests/delete_pool.sh
+++ b/test/functional/testdata/service_requests/delete_pool.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+neutron lbaas-loadbalancer-create --name lb1 lb-subnet
+sleep 5s
+neutron lbaas-listener-create --name listener1 --loadbalancer lb1 --protocol HTTP --protocol-port 80 
+sleep 5s
+neutron lbaas-pool-create --name pool1 --listener listener1 --protocol HTTP --lb-algorithm ROUND_ROBIN
+sleep 5s
+neutron lbaas-member-create --address 192.168.200.30 --protocol-port 80 --subnet member-subnet pool1
+sleep 5s
+neutron lbaas-member-create --address 192.168.200.40 --protocol-port 80 --subnet member-subnet pool1
+sleep 25s
+neutron lbaas-pool-delete pool1 
+sleep 5s
+neutron lbaas-listener-delete listener1 
+sleep 5s
+neutron lbaas-loadbalancer-delete lb1 


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
#582 Deleting pool with members leaves member network config on bigip

#### What's this change do?
Rearranges how pool members are deleted and when subnet hints are processed,
to ensure that subnets and associated network config is cleaned up after deleting
a pool that has members.

#### Where should the reviewer start?
lbaas_builder.py

#### Any background context?
No.