### PR TITLE
Add ESD support for TCP listeners

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -139,6 +139,9 @@ class ServiceModelAdapter(object):
         listener_l7policy_ids = listener.get('l7_policies', list())
         LOG.debug("L7 debug: listener policies: %s", listener_l7policy_ids)
         for policy in listener_l7policy_ids:
+            if self.is_esd(policy.get('name')):
+                continue
+
             listener_policy = lbaas_service.get_l7policy(policy['id'])
             LOG.debug("L7 debug: listener policy: %s", listener_policy)
             if not listener_policy:
@@ -460,6 +463,7 @@ class ServiceModelAdapter(object):
         self._add_vlan_and_snat(listener, vip)
         self._add_profiles_session_persistence(listener, pool, vip)
 
+        vip['rules'] = list()
         vip['policies'] = list()
         if policies:
             self._apply_l7_and_esd_policies(listener, policies, vip)
@@ -488,7 +492,10 @@ class ServiceModelAdapter(object):
             if esd:
                 esd_composite.update(esd)
 
-        self._apply_esd(vip, esd_composite)
+        if listener['protocol'] == 'TCP':
+            self._apply_fastl4_esd(vip, esd_composite)
+        else:
+            self._apply_esd(vip, esd_composite)
 
     def get_esd(self, name):
         if self.esd:
@@ -637,7 +644,53 @@ class ServiceModelAdapter(object):
     def get_name(self, uuid):
         return self.prefix + str(uuid)
 
+    def _apply_fastl4_esd(self, vip, esd):
+        if not esd:
+            return
+
+        # Application of ESD implies some type of L7 traffic routing.  Add
+        # an HTTP profile.
+        vip['profiles'] = ["/Common/http", "/Common/fastL4"]
+
+        # persistence
+        if 'lbaas_persist' in esd:
+            if vip.get('persist'):
+                LOG.warning("Overwriting the existing VIP persist profile: %s",
+                            vip['persist'])
+            vip['persist'] = [{'name': esd['lbaas_persist']}]
+
+        if 'lbaas_fallback_persist' in esd and vip.get('persist'):
+            if vip.get('fallbackPersistence'):
+                LOG.warning(
+                    "Overwriting the existing VIP fallback persist "
+                    "profile: %s", vip['fallbackPersistence'])
+            vip['fallbackPersistence'] = esd['lbaas_fallback_persist']
+
+        # iRules
+        vip['rules'] = list()
+        if 'lbaas_irule' in esd:
+            irules = []
+            for irule in esd['lbaas_irule']:
+                irules.append('/Common/' + irule)
+            vip['rules'] = irules
+
+        # L7 policies
+        if 'lbaas_policy' in esd:
+            if vip.get('policies'):
+                LOG.warning(
+                    "LBaaS L7 policies and rules will be overridden "
+                    "by ESD policies")
+                vip['policies'] = list()
+
+            policies = list()
+            for policy in esd['lbaas_policy']:
+                policies.append({'name': policy, 'partition': 'Common'})
+            vip['policies'] = policies
+
     def _apply_esd(self, vip, esd):
+        if not esd:
+            return
+
         profiles = vip['profiles']
 
         # start with server tcp profile
@@ -673,13 +726,13 @@ class ServiceModelAdapter(object):
 
         # persistence
         if 'lbaas_persist' in esd:
-            if vip['persist']:
+            if vip.get('persist', None):
                 LOG.warning("Overwriting the existing VIP persist profile: %s",
                             vip['persist'])
             vip['persist'] = [{'name': esd['lbaas_persist']}]
 
-        if 'lbaas_fallback_persist' in esd:
-            if vip['fallbackPersistence']:
+        if 'lbaas_fallback_persist' in esd and vip.get('persist'):
+            if vip.get('fallbackPersistence', None):
                 LOG.warning(
                     "Overwriting the existing VIP fallback persist "
                     "profile: %s", vip['fallbackPersistence'])
@@ -694,12 +747,14 @@ class ServiceModelAdapter(object):
             vip['rules'] = irules
 
         # L7 policies
-        policies = list()
         if 'lbaas_policy' in esd:
-            if vip['policies']:
+            if vip.get('policies'):
                 LOG.warning(
                     "LBaaS L7 policies and rules will be overridden "
                     "by ESD policies")
+                vip['policies'] = list()
+
+            policies = list()
             for policy in esd['lbaas_policy']:
                 policies.append({'name': policy, 'partition': 'Common'})
             vip['policies'] = policies

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_service_adapter.py
@@ -307,6 +307,7 @@ class TestServiceAdapter(object):
         listener = basic_service['listener']
         description = 'description'
         target.get_resource_description = Mock(return_value=description)
+
         cx_limit = listener['connection_limit']
         proto_port = listener['protocol_port']
         vip_address = loadbalancer['vip_address'].replace('%0', '')
@@ -319,7 +320,7 @@ class TestServiceAdapter(object):
             pool="pre-_" + pool['id'], mask="255.255.255.255",
             vlansDisabled=True,
             profiles=['/Common/http', '/Common/oneconnect'],
-            vlans=[], policies=[],
+            vlans=[], policies=[], rules=[],
             fallbackPersistence='', persist=[])
         assert expected == target._map_virtual(
                 loadbalancer, listener, pool=pool)
@@ -547,6 +548,9 @@ class TestServiceAdapter(object):
 
     def test_vs_http_profiles(self, service):
         adapter = ServiceModelAdapter(mock.MagicMock())
+        adapter.esd = Mock()
+        adapter.esd.get_esd.return_value = None
+
         service['listener']['protocol'] = 'HTTPS'
 
         # should have http and oneconnect but not fastL4
@@ -557,6 +561,8 @@ class TestServiceAdapter(object):
 
     def test_vs_https_profiles(self, service):
         adapter = ServiceModelAdapter(mock.MagicMock())
+        adapter.esd = Mock()
+        adapter.esd.get_esd.return_value = None
 
         # should have http and oneconnect but not fastL4
         service['listener']['protocol'] = 'HTTPS'
@@ -567,6 +573,8 @@ class TestServiceAdapter(object):
 
     def test_vs_tcp_profiles(self, service):
         adapter = ServiceModelAdapter(mock.MagicMock())
+        adapter.esd = Mock()
+        adapter.esd.get_esd.return_value = None
 
         service['listener']['protocol'] = 'TCP'
         vs = adapter.get_virtual(service)
@@ -578,6 +586,8 @@ class TestServiceAdapter(object):
 
     def test_vs_terminated_https_profiles(self, service):
         adapter = ServiceModelAdapter(mock.MagicMock())
+        adapter.esd = Mock()
+        adapter.esd.get_esd.return_value = None
 
         # should have http and oneconnect but not fastL4
         service['listener']['protocol'] = 'TERMINATED_HTTPS'
@@ -770,6 +780,9 @@ class TestServiceAdapter(object):
 
     def test_get_listener_policies(self, basic_l7service):
         adapter = ServiceModelAdapter(mock.MagicMock())
+        adapter.esd = Mock()
+        adapter.esd.get_esd.return_value = None
+
         policies = adapter.get_listener_policies(basic_l7service)
         policy = policies[0]
 
@@ -779,6 +792,9 @@ class TestServiceAdapter(object):
 
     def test_get_listener_policies_pending_delete(self, basic_l7service):
         adapter = ServiceModelAdapter(mock.MagicMock())
+        adapter.esd = Mock()
+        adapter.esd.get_esd.return_value = None
+
         service_rules = basic_l7service['l7policy_rules']
         service_rules[2]['provisioning_status'] = "PENDING_DELETE"
         policies = adapter.get_listener_policies(basic_l7service)
@@ -792,6 +808,9 @@ class TestServiceAdapter(object):
 
     def test_get_listener_policies_2_policies(self, basic_l7service_2policies):
         adapter = ServiceModelAdapter(mock.MagicMock())
+        adapter.esd = Mock()
+        adapter.esd.get_esd.return_value = None
+
         l7service = basic_l7service_2policies
         listener = l7service.get('listener', None)
 
@@ -854,3 +873,351 @@ class TestServiceAdapter(object):
         resource.pop('description')
         description = adapter.get_resource_description(resource)
         assert description == 'test_name:'
+
+    def test_apply_empty_esd(adapter):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        esd = dict()
+        vip = dict()
+        adapter._apply_esd(vip, esd)
+
+        assert "persist" not in vip
+        assert "fallbackPersistence" not in vip
+        assert "profiles" not in vip
+        assert "rules" not in vip
+        assert "policies" not in vip
+
+    def test_apply_esd_ctcp_profile(adapter):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        esd = dict(lbaas_ctcp="tcp-mobile-optimized")
+        vip = dict(profiles=["/Common/http"])
+
+        adapter._apply_esd(vip, esd)
+
+        assert "persist" not in vip
+        assert "fallbackPersistence" not in vip
+        assert "policies" not in vip
+
+        expected = dict(profiles=["/Common/http",
+                                  dict(name="tcp-mobile-optimized",
+                                       partition="Common",
+                                       context="all")
+                                  ],
+                        rules=[])
+        assert vip == expected
+
+    def test_apply_esd_stcp_profile(adapter):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        esd = dict(lbaas_stcp="tcp-lan-optimized")
+        vip = dict(profiles=["/Common/http"])
+
+        adapter._apply_esd(vip, esd)
+
+        assert "persist" not in vip
+        assert "fallbackPersistence" not in vip
+        assert "policies" not in vip
+
+        expected = dict(profiles=["/Common/http",
+                                  dict(name="tcp-lan-optimized",
+                                       partition="Common",
+                                       context="serverside"),
+                                  dict(name="tcp",
+                                       partition="Common",
+                                       context="clientside")
+                                  ],
+                        rules=[])
+
+        assert vip == expected
+
+    def test_apply_esd_ctcp_and_stcp_profile(adapter):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        esd = dict(lbaas_ctcp="tcp-mobile-optimized",
+                   lbaas_stcp="tcp-lan-optimized")
+        vip = dict(profiles=["/Common/http"])
+
+        adapter._apply_esd(vip, esd)
+
+        assert "persist" not in vip
+        assert "fallbackPersistence" not in vip
+        assert "policies" not in vip
+
+        expected = dict(profiles=["/Common/http",
+                                  dict(name="tcp-lan-optimized",
+                                       partition="Common",
+                                       context="serverside"),
+                                  dict(name="tcp-mobile-optimized",
+                                       partition="Common",
+                                       context="clientside")
+                                  ],
+                        rules=[])
+
+        assert vip == expected
+
+    def test_apply_esd_ssl_profiles(adapter):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        esd = dict(lbaas_cssl_profile="clientssl")
+        vip = dict(profiles=["/Common/http"])
+
+        adapter._apply_esd(vip, esd)
+
+        assert "persist" not in vip
+        assert "fallbackPersistence" not in vip
+        assert "policies" not in vip
+
+        expected = dict(profiles=["/Common/http",
+                                  dict(name="tcp",
+                                       partition="Common",
+                                       context="all"),
+                                  dict(name="clientssl",
+                                       partition="Common",
+                                       context="clientside")
+                                  ],
+                        rules=[])
+
+        assert vip == expected
+
+        esd = dict(lbaas_sssl_profile="serverssl")
+        vip = dict(profiles=["/Common/http"])
+
+        adapter._apply_esd(vip, esd)
+
+        assert "persist" not in vip
+        assert "fallbackPersistence" not in vip
+        assert "policies" not in vip
+
+        expected = dict(profiles=["/Common/http",
+                                  dict(name="tcp",
+                                       partition="Common",
+                                       context="all"),
+                                  dict(name="serverssl",
+                                       partition="Common",
+                                       context="serverside")
+                                  ],
+                        rules=[])
+
+        assert vip == expected
+
+    def test_apply_esd_persist_profile(adapter):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        esd = dict(lbaas_persist="hash")
+        vip = dict(profiles=[])
+
+        adapter._apply_esd(vip, esd)
+
+        assert "fallbackPersistence" not in vip
+        assert "policies" not in vip
+
+        assert vip['persist'] == [dict(name="hash")]
+        assert vip['profiles'] == [
+            dict(name="tcp", partition="Common", context="all")]
+
+    def test_apply_esd_persist_profile_collision(adapter):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        esd = dict(lbaas_persist="hash")
+        vip = dict(profiles=[], persist=[dict(name='sourceip')])
+
+        adapter._apply_esd(vip, esd)
+
+        assert "fallbackPersistence" not in vip
+        assert "policies" not in vip
+
+        assert vip['persist'] == [dict(name="hash")]
+        assert vip['profiles'] == [dict(
+            name="tcp", partition="Common", context="all")]
+
+    def test_apply_esd_fallback_persist_profile(adapter):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        esd = dict(lbaas_fallback_persist="hash",
+                   lbaas_persist="sourceip")
+
+        vip = dict(profiles=[])
+
+        adapter._apply_esd(vip, esd)
+
+        assert "policies" not in vip
+
+        assert vip['persist'] == [dict(name="sourceip")]
+        assert vip['fallbackPersistence'] == 'hash'
+        assert vip['profiles'] == [
+            dict(name="tcp", partition="Common", context="all")]
+
+    def test_apply_esd_fallback_persist_profile_collision(adapter):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        esd = dict(lbaas_fallback_persist="hash",
+                   lbaas_persist="sourceip")
+
+        vip = dict(profiles=[], fallbackPersistence='mock')
+
+        adapter._apply_esd(vip, esd)
+
+        assert "policies" not in vip
+
+        assert vip['persist'] == [dict(name="sourceip")]
+        assert vip['fallbackPersistence'] == 'hash'
+        assert vip['profiles'] == [dict(
+            name="tcp", partition="Common", context="all")]
+
+    def test_apply_esd_fallback_persist_profile_nopersist(adapter):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        esd = dict(lbaas_fallback_persist="hash")
+
+        vip = dict(profiles=[])
+
+        adapter._apply_esd(vip, esd)
+
+        assert "policies" not in vip
+        assert "persist" not in vip
+        assert "fallbackPersistence" not in vip
+
+    def test_apply_esd_irules_empty(adapter):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        esd = dict(lbaas_irule=[])
+
+        vip = dict(profiles=[])
+
+        adapter._apply_esd(vip, esd)
+
+        assert "policies" not in vip
+        assert "persist" not in vip
+        assert "fallbackPersistence" not in vip
+        assert not vip['rules']
+
+    def test_apply_esd_irules(adapter):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        esd = dict(lbaas_irule=[
+            "_sys_https_redirect",
+            "_sys_APM_ExchangeSupport_helper"
+        ])
+        vip = dict(profiles=[])
+
+        adapter._apply_esd(vip, esd)
+
+        assert "policies" not in vip
+        assert "persist" not in vip
+        assert "fallbackPersistence" not in vip
+        assert vip['rules'] == [
+            "/Common/_sys_https_redirect",
+            "/Common/_sys_APM_ExchangeSupport_helper"]
+
+    def test_apply_esd_policy(adapter):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        esd = dict(lbaas_policy=["demo_policy"])
+        vip = dict(profiles=[])
+
+        adapter._apply_esd(vip, esd)
+
+        assert "persist" not in vip
+        assert "fallbackPersistence" not in vip
+        assert vip['rules'] == []
+        assert vip['policies'] == [dict(name='demo_policy',
+                                        partition="Common")]
+
+    def test_apply_l4_esd_persist_profile(adapter):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        esd = dict(lbaas_persist="hash")
+        vip = dict(profiles=[])
+
+        adapter._apply_fastl4_esd(vip, esd)
+
+        assert "fallbackPersistence" not in vip
+        assert "policies" not in vip
+
+        assert vip['persist'] == [dict(name="hash")]
+        assert vip['profiles'] == ["/Common/http", "/Common/fastL4"]
+
+    def test_apply_l4_esd_persist_profile_collision(adapter):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        esd = dict(lbaas_persist="hash")
+        vip = dict(profiles=[], persist=[dict(name='sourceip')])
+
+        adapter._apply_fastl4_esd(vip, esd)
+
+        assert "fallbackPersistence" not in vip
+        assert "policies" not in vip
+
+        assert vip['persist'] == [dict(name="hash")]
+        assert vip['profiles'] == ["/Common/http", "/Common/fastL4"]
+
+    def test_apply_l4_esd_fallback_persist_profile(adapter):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        esd = dict(lbaas_fallback_persist="hash",
+                   lbaas_persist="sourceip")
+
+        vip = dict(profiles=[])
+
+        adapter._apply_fastl4_esd(vip, esd)
+
+        assert "policies" not in vip
+
+        assert vip['persist'] == [dict(name="sourceip")]
+        assert vip['fallbackPersistence'] == 'hash'
+        assert vip['profiles'] == ["/Common/http", "/Common/fastL4"]
+
+    def test_apply_l4_esd_fallback_persist_profile_collision(adapter):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        esd = dict(lbaas_fallback_persist="hash",
+                   lbaas_persist="sourceip")
+
+        vip = dict(profiles=[], fallbackPersistence='mock')
+
+        adapter._apply_fastl4_esd(vip, esd)
+
+        assert "policies" not in vip
+
+        assert vip['persist'] == [dict(name="sourceip")]
+        assert vip['fallbackPersistence'] == 'hash'
+        assert vip['profiles'] == ["/Common/http", "/Common/fastL4"]
+
+    def test_apply_l4_esd_fallback_persist_profile_nopersist(adapter):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        esd = dict(lbaas_fallback_persist="hash")
+
+        vip = dict(profiles=[])
+
+        adapter._apply_fastl4_esd(vip, esd)
+
+        assert "policies" not in vip
+        assert "persist" not in vip
+        assert "fallbackPersistence" not in vip
+
+    def test_apply_l4_esd_irules_empty(adapter):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        esd = dict(lbaas_irule=[])
+
+        vip = dict(profiles=[])
+
+        adapter._apply_fastl4_esd(vip, esd)
+
+        assert "policies" not in vip
+        assert "persist" not in vip
+        assert "fallbackPersistence" not in vip
+        assert not vip['rules']
+
+    def test_apply_l4_esd_irules(adapter):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        esd = dict(lbaas_irule=[
+            "_sys_https_redirect",
+            "_sys_APM_ExchangeSupport_helper"
+        ])
+        vip = dict(profiles=[])
+
+        adapter._apply_fastl4_esd(vip, esd)
+
+        assert "policies" not in vip
+        assert "persist" not in vip
+        assert "fallbackPersistence" not in vip
+        assert vip['rules'] == [
+            "/Common/_sys_https_redirect",
+            "/Common/_sys_APM_ExchangeSupport_helper"]
+
+    def test_apply_l4_esd_policy(adapter):
+        adapter = ServiceModelAdapter(mock.MagicMock())
+        esd = dict(lbaas_policy=["demo_policy"])
+        vip = dict(profiles=[])
+
+        adapter._apply_fastl4_esd(vip, esd)
+
+        assert "persist" not in vip
+        assert "fallbackPersistence" not in vip
+        assert vip['rules'] == []
+        assert vip['policies'] == [dict(name='demo_policy',
+                                        partition="Common")]


### PR DESCRIPTION
Issues:
Fixes #672

Problem:
Currently, the ESD application changes the  virtual server mode
of operation from fastl4 to standard.

Analysis:
This keeps the virtual in fastl4 mode while adding the 'http'
profile that are required by some iRules

Tests:
functional/neutronless/esd
test/test_service_adapter.py

@<reviewer_id>
#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?
