### PR TITLE
Post unit test coverage data to coveralls.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,15 @@ deps = -r{toxinidir}/requirements.style.txt
 commands = flake8 {toxinidir}/f5_openstack_agent
 
 [testenv:unit]
+passenv = COVERALLS_REPO_TOKEN
+whitelist_externals=bash
 deps = -r{toxinidir}/requirements.unittest.txt
-commands = py.test --ignore {toxinidir}/f5_openstack_agent/tests/functional --cov {toxinidir}/f5_openstack_agent {toxinidir}/f5_openstack_agent
+commands =
+    py.test \
+        --ignore {toxinidir}/f5_openstack_agent/tests/functional \
+        --cov {toxinidir}/f5_openstack_agent \
+        {toxinidir}/f5_openstack_agent
+    bash -c "if [ ! -z $COVERALLS_REPO_TOKEN ]; then coveralls; fi"
 
 [testenv:disconnected_service]
 deps = -r{toxinidir}/requirements.functest.txt


### PR DESCRIPTION
- This change will only post unit test coverage data to coveralls if the
  environment variable COVERALLS_REPO_TOKEN is set.