### PR TITLE
Listener service fails to create SSL client profile

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
@@ -69,7 +69,7 @@ class ListenerServiceBuilder(object):
             self.service_adapter.get_vlan(vip, bigip, network_id)
             try:
                 if tls:
-                    self.add_ssl_profile(tls, bigip)
+                    self.add_ssl_profile(tls, vip, bigip)
                 if persist and persist.get('type', "") == "APP_COOKIE":
                     self._add_cookie_persist_rule(vip, persist, bigip)
                 self.vs_helper.create(bigip, vip)
@@ -158,10 +158,7 @@ class ListenerServiceBuilder(object):
 
         return error
 
-    def add_ssl_profile(self, tls, bigip):
-        # add profile to virtual server
-        vip = {'name': tls['name'],
-               'partition': tls['partition']}
+    def add_ssl_profile(self, tls, vip, bigip):
 
         if "default_tls_container_id" in tls:
             container_ref = tls["default_tls_container_id"]
@@ -190,6 +187,9 @@ class ListenerServiceBuilder(object):
             del key
 
         # add ssl profile to virtual server
+        if 'profiles' not in vip:
+            vip['profiles'] = list()
+
         vip['profiles'].append({'name': name, 'context': "clientside"})
 
     def remove_ssl_profiles(self, tls, bigip):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_listener_services.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_listener_services.py
@@ -402,8 +402,9 @@ class TestListenerServiceBuilder(TestListenerServiceBuilderBuilder):
             tls = dict(name='name', partition='partition')
             bigip = Mock()
             target._create_ssl_profile = Mock()
+            vip = {}
 
-            target.add_ssl_profile(tls, bigip)
+            target.add_ssl_profile(tls, vip, bigip)
 
             assert not target._create_ssl_profile.called
 
@@ -413,8 +414,9 @@ class TestListenerServiceBuilder(TestListenerServiceBuilderBuilder):
             tls['default_tls_container_id'] = '12345'
             bigip = Mock()
             target._create_ssl_profile = Mock()
+            vip = dict(name='name', partition='partition')
 
-            target.add_ssl_profile(tls, bigip)
+            target.add_ssl_profile(tls, vip, bigip)
 
             assert target._create_ssl_profile.call_count == 1
             target._create_ssl_profile.assert_called_once_with(
@@ -428,8 +430,9 @@ class TestListenerServiceBuilder(TestListenerServiceBuilderBuilder):
             tls['sni_containers'] = [sni_container]
             bigip = Mock()
             target._create_ssl_profile = Mock()
+            vip = dict(name='name', partition='partition')
 
-            target.add_ssl_profile(tls, bigip)
+            target.add_ssl_profile(tls, vip, bigip)
 
             assert target._create_ssl_profile.call_count == 1
             target._create_ssl_profile.assert_called_once_with(


### PR DESCRIPTION
Issues:
Fixes #1164

Problem:
Creating a TERMINATED_HTTPS listener fails and results in a
service in an error state.

Analysis:
As part of the code refactor much of the implementation of the SSL
creation/addition was retained from the previous implementation; however,
the real vip object was not updated by the add_ssl_profile function.

The dummy vip has no profiles element and so we get a key error
when we try to configure the attribute.  This changes passes the vip
configuration object created by map_virtual into the add_ssl_profile
function.

Tests:
functional testing for listener.

@<reviewer_id>
#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?
