### PR TITLE
Master.purge orphaned policies and monitors

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -851,6 +851,12 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                                 pool_id=poolid,
                                 hostnames=pools[poolid]['hostnames'])
 
+                # Ask the BIG-IP for all deployed monitors not associated
+                # to a pool
+                monitors = self.lbdriver.get_all_deployed_health_monitors()
+                if monitors:
+                    self.purge_orphaned_health_monitors(monitors)
+
             else:
                 LOG.debug('the global agent is %s' % (global_agent['host']))
                 return True
@@ -861,6 +867,24 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
             cleaned = True
 
         return cleaned
+
+    def purge_orphaned_health_monitors(self, monitors):
+        """Deletes hanging Health Monitors from the deleted Pools"""
+        # ask Neutron for for the status of all deployed monitors...
+        monitors_used = set()
+        pools = self.lbdriver.get_all_deployed_pools()
+        for pool_id in pools:
+            monitors_used.union(set(pools[pool_id]['monitors']))
+        LOG.debug('validated_monitors_state returned: %s'
+                  % monitors_status)
+        for monitorid in monitors:
+            monitor = monitors[monitorid]
+            if monitorid not in monitors_used:
+                LOG.debug('removing orphaned health monitor %s' % monitorid)
+                self.lbdriver.purge_orphaned_health_monitor(
+                    tenant_id=monitors[monitorid]['tenant_id'],
+                    monitor_id=monitorid,
+                    hostnames=monitors[monitorid]['hostnames'])
 
     ######################################################################
     #

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -785,71 +785,20 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                 lbs = self.lbdriver.get_all_deployed_loadbalancers(
                     purge_orphaned_folders=True)
                 if lbs:
-                    # Ask Neutron for the status of each deployed loadbalancer
-                    lbs_status = self.plugin_rpc.validate_loadbalancers_state(
-                        list(lbs.keys()))
-                    LOG.debug('validate_loadbalancers_state returned: %s'
-                              % lbs_status)
-                    lbs_removed = False
-                    for lbid in lbs_status:
-                        # If the statu is Unknown, it no longer exists
-                        # in Neutron and thus should be removed from the BIG-IP
-                        if lbs_status[lbid] in ['Unknown']:
-                            LOG.debug('removing orphaned loadbalancer %s'
-                                      % lbid)
-                            # This will remove pools, virtual servers and
-                            # virtual addresses
-                            self.lbdriver.purge_orphaned_loadbalancer(
-                                tenant_id=lbs[lbid]['tenant_id'],
-                                loadbalancer_id=lbid,
-                                hostnames=lbs[lbid]['hostnames'])
-                            lbs_removed = True
-                    if lbs_removed:
-                        # If we have removed load balancers, then scrub
-                        # for tenant folders we can delete because they
-                        # no longer contain loadbalancers.
-                        self.lbdriver.get_all_deployed_loadbalancers(
-                            purge_orphaned_folders=True)
+                    self.purge_orphaned_loadbalancers(lbs)
 
                 # Ask the BIG-IP for all deployed listeners to make
                 # sure we are not orphaning listeners which have
                 # valid loadbalancers in a OK state
                 listeners = self.lbdriver.get_all_deployed_listeners()
                 if listeners:
-                    # Ask Neutron for the status of all deployed listeners
-                    listener_status = self.plugin_rpc.validate_listeners_state(
-                        list(listeners.keys()))
-                    LOG.debug('validated_pools_state returned: %s'
-                              % listener_status)
-                    for listenerid in listener_status:
-                        # If the pool status is Unknown, it no longer exists
-                        # in Neutron and thus should be removed from BIG-IP
-                        if listener_status[listenerid] in ['Unknown']:
-                            LOG.debug('removing orphaned listener %s'
-                                      % listenerid)
-                            self.lbdriver.purge_orphaned_listener(
-                                tenant_id=listeners[listenerid]['tenant_id'],
-                                listener_id=listenerid,
-                                hostnames=listeners[listenerid]['hostnames'])
+                    self.purge_orphaned_listeners(listeners)
 
                 # Ask the BIG-IP for all deployed pools not associated
                 # to a virtual server
                 pools = self.lbdriver.get_all_deployed_pools()
                 if pools:
-                    # Ask Neutron for the status of all deployed pools
-                    pools_status = self.plugin_rpc.validate_pools_state(
-                        list(pools.keys()))
-                    LOG.debug('validated_pools_state returned: %s'
-                              % pools_status)
-                    for poolid in pools_status:
-                        # If the pool status is Unknown, it no longer exists
-                        # in Neutron and thus should be removed from BIG-IP
-                        if pools_status[poolid] in ['Unknown']:
-                            LOG.debug('removing orphaned pool %s' % poolid)
-                            self.lbdriver.purge_orphaned_pool(
-                                tenant_id=pools[poolid]['tenant_id'],
-                                pool_id=poolid,
-                                hostnames=pools[poolid]['hostnames'])
+                    self.purge_orphaned_pools(pools)
 
                 # Ask the BIG-IP for all deployed monitors not associated
                 # to a pool
@@ -867,6 +816,72 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
             cleaned = True
 
         return cleaned
+
+    def purge_orphaned_loadbalancers(self, lbs):
+        """Gets 'unknown' loadbalancers from Neutron and purges them
+
+        Provisioning status of 'unknown' on loadbalancers means that the object
+        does not exist in Neutron.  These should be deleted to consolidate
+        hanging objects.
+        """
+        lbs_status = self.plugin_rpc.validate_loadbalancers_state(
+            list(lbs.keys()))
+        LOG.debug('validate_loadbalancers_state returned: %s'
+                  % lbs_status)
+        lbs_removed = False
+        for lbid in lbs_status:
+            # If the statu is Unknown, it no longer exists
+            # in Neutron and thus should be removed from the BIG-IP
+            if lbs_status[lbid] in ['Unknown']:
+                LOG.debug('removing orphaned loadbalancer %s'
+                          % lbid)
+                # This will remove pools, virtual servers and
+                # virtual addresses
+                self.lbdriver.purge_orphaned_loadbalancer(
+                    tenant_id=lbs[lbid]['tenant_id'],
+                    loadbalancer_id=lbid,
+                    hostnames=lbs[lbid]['hostnames'])
+                lbs_removed = True
+        if lbs_removed:
+            # If we have removed load balancers, then scrub
+            # for tenant folders we can delete because they
+            # no longer contain loadbalancers.
+            self.lbdriver.get_all_deployed_loadbalancers(
+                purge_orphaned_folders=True)
+
+    def purge_orphaned_listeners(self, listeners):
+        """Deletes the hanging listeners from the deleted loadbalancers"""
+        listener_status = self.plugin_rpc.validate_listeners_state(
+            list(listeners.keys()))
+        LOG.debug('validated_pools_state returned: %s'
+                  % listener_status)
+        for listenerid in listener_status:
+            # If the pool status is Unknown, it no longer exists
+            # in Neutron and thus should be removed from BIG-IP
+            if listener_status[listenerid] in ['Unknown']:
+                LOG.debug('removing orphaned listener %s'
+                          % listenerid)
+                self.lbdriver.purge_orphaned_listener(
+                    tenant_id=listeners[listenerid]['tenant_id'],
+                    listener_id=listenerid,
+                    hostnames=listeners[listenerid]['hostnames'])
+
+    def purge_orphaned_pools(self, pools):
+        """Deletes hanging pools from the deleted listeners"""
+        # Ask Neutron for the status of all deployed pools
+        pools_status = self.plugin_rpc.validate_pools_state(
+            list(pools.keys()))
+        LOG.debug('validated_pools_state returned: %s'
+                  % pools_status)
+        for poolid in pools_status:
+            # If the pool status is Unknown, it no longer exists
+            # in Neutron and thus should be removed from BIG-IP
+            if pools_status[poolid] in ['Unknown']:
+                LOG.debug('removing orphaned pool %s' % poolid)
+                self.lbdriver.purge_orphaned_pool(
+                    tenant_id=pools[poolid]['tenant_id'],
+                    pool_id=poolid,
+                    hostnames=pools[poolid]['hostnames'])
 
     def purge_orphaned_health_monitors(self, monitors):
         """Deletes hanging Health Monitors from the deleted Pools"""

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -794,6 +794,10 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                 if listeners:
                     self.purge_orphaned_listeners(listeners)
 
+                policies = self.lbdriver.get_all_deployed_l7_policys()
+                if policies:
+                    self.purge_orphaned_l7_policys(policies)
+
                 # Ask the BIG-IP for all deployed pools not associated
                 # to a virtual server
                 pools = self.lbdriver.get_all_deployed_pools()
@@ -865,6 +869,22 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                     tenant_id=listeners[listenerid]['tenant_id'],
                     listener_id=listenerid,
                     hostnames=listeners[listenerid]['hostnames'])
+
+    def purge_orphaned_l7_policys(self, policies):
+        """Deletes hanging l7_policies from the deleted listeners"""
+        policies_used = set()
+        listeners = self.lbdriver.get_all_deployed_listeners()
+        for li_id in listeners:
+            pools_used.union(set(listeners[li_id]['l7policies']))
+        # Ask Neutron for the status of all deployed l7_policys
+        for policy_key in policies:
+            policy = policies.get(policy_key)
+            if policy_key not in policies_used:
+                LOG.debug('removing orphaned policy {}'.format(policy_key))
+                self.lbdriver.purge_orphaned_l7_policy(
+                    tenant_id=policy['tenant_id'],
+                    l7_policy_id=policy_key,
+                    hostname=policy['hostnames'])
 
     def purge_orphaned_pools(self, pools):
         """Deletes hanging pools from the deleted listeners"""

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1240,6 +1240,57 @@ class iControlDriver(LBaaSBaseDriver):
                 except Exception as exc:
                     LOG.exception('Exception purging monitor %s' % str(exc))
 
+    @serialized('get_all_deployed_l7_policys')
+    @is_operational
+    def get_all_deployed_l7_policys(self):
+        """Retrieve a list of all Health Monitors deployed"""
+        LOG.debug('getting all deployed l7_policys on BIG-IP\'s')
+        deployed_l7_policy_dict = {}
+        for bigip in self.get_all_bigips():
+            folders = self.system_helper.get_folders(bigip)
+            for folder in folders:
+                tenant_id = folder[len(self.service_adapter.prefix):]
+                if str(folder).startswith(self.service_adapter.prefix):
+                    resource = resource_helper.BigIpResourceHelper(
+                        resource_helper.ResourceType.l7policy)
+                    deployed_l7_policys = resource.get_resources(bigip, folder)
+                    if deployed_l7_policys:
+                        for l7_policy in deployed_l7_policys:
+                            l7_policy_id = \
+                                l7_policy.name[
+                                    len(self.service_adapter.prefix):]
+                            if l7_policy_id in deployed_l7_policy_dict:
+                                deployed_l7_policy_dict[l7_policy_id][
+                                    'hostnames'].append(bigip.hostname)
+                            else:
+                                deployed_l7_policy_dict[l7_policy_id] = {
+                                    'id': l7_policy_id,
+                                    'tenant_id': tenant_id,
+                                    'hostnames': [bigip.hostname]
+                                }
+        return deployed_l7_policy_dict
+
+    @serialized('purge_orphaned_l7_policy')
+    @is_operational
+    def purge_orphaned_l7_policy(self, tenant_id=None, l7_policy_id=None,
+                                 hostnames=list()):
+        """Purge all l7_policys that exist on the BIG-IP but not in Neutron"""
+        for bigip in self.get_all_bigips():
+            if bigip.hostname in hostnames:
+                try:
+                    l7_policy_name = self.service_adapter.prefix + l7_policy_id
+                    partition = self.service_adapter.prefix + tenant_id
+                    l7_policy = resource_helper.BigIPResourceHelper(
+                        resource_helper.ResourceType.l7_policy).load(
+                            bigip, l7_policy_name, partition)
+                    l7_policy.delete()
+                except HTTPError as err:
+                    if err.response.status_code == 404:
+                        LOG.debug('l7_policy %s not on BIG-IP %s.'
+                                  % (l7_policy_id, bigip.hostname))
+                except Exception as exc:
+                    LOG.exception('Exception purging l7_policy %s' % str(exc))
+
     @serialized('purge_orphaned_loadbalancer')
     @is_operational
     def purge_orphaned_loadbalancer(self, tenant_id=None,

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1184,6 +1184,62 @@ class iControlDriver(LBaaSBaseDriver):
                 except Exception as exc:
                     LOG.exception('Exception purging pool %s' % str(exc))
 
+    @serialized('get_all_deployed_monitors')
+    @is_operational
+    def get_all_deployed_health_monitors(self):
+        """Retrieve a list of all Health Monitors deployed"""
+        LOG.debug('getting all deployed monitors on BIG-IP\'s')
+        monitor_types = ['http_monitor', 'https_monitor', 'tcp_monitor',
+                         'ping_monitor']
+        deployed_monitor_dict = {}
+        adapter_prefix = self.service_adapter.prefix
+        for bigip in self.get_all_bigips():
+            folders = self.system_helper.get_folders(bigip)
+            for folder in folders:
+                tenant_id = folder[len(adapter_prefix):]
+                if str(folder).startswith(adapter_prefix):
+                    resources = map(
+                        lambda x: resource_helper.BigIpResourceHelper(
+                            getattr(resource_helper.ResourceType, x)),
+                        monitor_types)
+                    for resource in resources:
+                        deployed_monitors = resource.get_resources(
+                            bigip, folder)
+                        if deployed_monitors:
+                            for monitor in deployed_monitors:
+                                monitor_id = monitor.name[len(adapter_prefix):]
+                                if monitor_id in deployed_monitor_dict:
+                                    deployed_monitor_dict[monitor_id][
+                                        'hostnames'].append(bigip.hostname)
+                                else:
+                                    deployed_monitor_dict[monitor_id] = {
+                                        'id': monitor_id,
+                                        'tenant_id': tenant_id,
+                                        'hostnames': [bigip.hostname]
+                                    }
+        return deployed_monitor_dict
+
+    @serialized('purge_orphaned_health_monitor')
+    @is_operational
+    def purge_orphaned_health_monitor(self, tenant_id=None, monitor_id=None,
+                                      hostnames=list()):
+        """Purge all monitors that exist on the BIG-IP but not in Neutron"""
+        for bigip in self.get_all_bigips():
+            if bigip.hostname in hostnames:
+                try:
+                    monitor_name = self.service_adapter.prefix + monitor_id
+                    partition = self.service_adapter.prefix + tenant_id
+                    monitor = resource_helper.BigIPResourceHelper(
+                        resource_helper.ResourceType.monitor).load(
+                            bigip, monitor_name, partition)
+                    monitor.delete()
+                except HTTPError as err:
+                    if err.response.status_code == 404:
+                        LOG.debug('monitor %s not on BIG-IP %s.'
+                                  % (monitor_id, bigip.hostname))
+                except Exception as exc:
+                    LOG.exception('Exception purging monitor %s' % str(exc))
+
     @serialized('purge_orphaned_loadbalancer')
     @is_operational
     def purge_orphaned_loadbalancer(self, tenant_id=None,

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py
@@ -144,6 +144,15 @@ class LBaaSBaseDriver(object):
         """LBaaS Purge Health Monitor."""
         raise NotImplementedError()
 
+    def get_all_deployed_l7_policys(self):
+        """Get listing of all deployed Health Monitors"""
+        raise NotImplementedError()
+
+    def purge_orphaned_l7_policy(self, tenant_id=None, monitor_id=None,
+                                      hostnames=list()):
+        """LBaaS Purge Health Monitor."""
+        raise NotImplementedError()
+
     def tunnel_update(self, **kwargs):
         """Neutron Core Tunnel Update."""
         raise NotImplementedError()

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py
@@ -127,8 +127,21 @@ class LBaaSBaseDriver(object):
         """LBaaS Update Health Monitor."""
         raise NotImplementedError()
 
+    def delete_health_monitor(self, health_monitor, pool, service):
+        """LBaaS Delete Health Monior."""
+        raise NotImplementedError()
+
     def delete_pool_health_monitor(self, health_monitor, pool, service):
         """LBaaS Delete Health Monitor."""
+        raise NotImplementedError()
+
+    def get_all_deployed_health_monitors(self):
+        """Get listing of all deployed Health Monitors"""
+        raise NotImplementedError()
+
+    def purge_orphaned_health_monitor(self, tenant_id=None, monitor_id=None,
+                                      hostnames=list()):
+        """LBaaS Purge Health Monitor."""
         raise NotImplementedError()
 
     def tunnel_update(self, **kwargs):


### PR DESCRIPTION
@richbrowne 
#### What issues does this address?
orphaned monitors and orphaned policies without tests

#### What's this change do?
Simply provides the functionality to purge orphaned l7 policies and health monitors

#### Where should the reviewer start?
Agent manager then move into icontrol driver and plugin rpc

#### Any background context?
This has to do with the purge orphaned objects initiative.  There is no unit tests incorporated with these as this is without the new unit test structure.