### PR TITLE
Newton.l7policy delete return fix

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l7policy_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l7policy_service.py
@@ -90,7 +90,7 @@ class L7PolicyService(object):
                 LOG.error("L7 Policy deletion error: %s",
                           error.message)
 
-            return error
+        return error
 
     def build_policy(self, l7policy, lbaas_service):
         # build data structure for service adapter input


### PR DESCRIPTION
Fixes delete_l7policy for clusters

Issues:
Fixes: #1182

Problem:
* Clustered, 2 or more BIG IP's where l7policy has been deployed
  * Only if deployed via neutron in OpenStack
  * The LocalTraffic > Virtual Server > Policies
    * wrapper_policy_<subnet's tenant_id> policy will remain on...
      * slave or...
      * master

Analysis:
* This moves the `return error` line to outside of the BIG IP loop
  * This means that the l7policy delete change will occur on both master
    and slave

Tests:
Discovered by testing multi-BIG IP clusters in tempest tests

@richbrowne 
#### What issues does this address?
#1182 

#### What's this change do?
Makes it so that the delete l7policy will loop through all available BIG-IP's

#### Where should the reviewer start?
l7policy_service.py

#### Any background context?
This was discovered in nightly tests after the clustering capabilities began to be tested.