### PR TITLE
Fixes variable name for symbols reference to icontrol host

### DIFF
--- a/test/functional/singlebigip/test_cluster.py
+++ b/test/functional/singlebigip/test_cluster.py
@@ -3,7 +3,7 @@ test_requirements = {'devices':         [VE],
                      'openstack_infra': []}
 
 '''
-# Copyright 2015-2016 F5 Networks Inc.
+# Copyright 2015-2018 F5 Networks Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ def test_devices(mgmt_root, symbols):
     for k, v in symbols.__dict__.items():
         print('key: {}'.format(k))
         print('value: {}'.format(v))
-    assert devices[0].managementIp == symbols.bigip_mgmt_ip_public
+    assert devices[0].managementIp == symbols.bigip_mgmt_ip
 
 
 def test_get_sync_status(mgmt_root):


### PR DESCRIPTION
Issues:
Fixes #1188

Problem:
* The iControl host was referencing the outside subnet's floating ip
  * This was then compared to the internal IP

Analysis:
* This change makes the test reference the interal IP

Tests:
This is a test change and has been tested to verify that the fix works.

@jlongstaf 
#### What issues does this address?
Fixes #1188 

#### What's this change do?
Changes the symbols global to the appropriate key/value pairing

#### Where should the reviewer start?
`test_clusters.py`

#### Any background context?
This has been failing in nightly for some time now pretty consistently (since the advent of the new funct-test environment change).