### PR TITLE
Mitaka.orphaned healthmonitor existential crisis

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -606,7 +606,7 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                       % list(known_services))
 
         except Exception as e:
-            LOG.error("Unable to sync state: %s" % e.message)
+            LOG.exception("Unable to sync state: %s" % e.message)
             resync = True
 
         return resync
@@ -821,6 +821,7 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
 
         return cleaned
 
+    @log_helpers.log_method_call
     def purge_orphaned_loadbalancers(self, lbs):
         """Gets 'unknown' loadbalancers from Neutron and purges them
 
@@ -853,6 +854,7 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
             self.lbdriver.get_all_deployed_loadbalancers(
                 purge_orphaned_folders=True)
 
+    @log_helpers.log_method_call
     def purge_orphaned_listeners(self, listeners):
         """Deletes the hanging listeners from the deleted loadbalancers"""
         listener_status = self.plugin_rpc.validate_listeners_state(
@@ -870,6 +872,7 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                     listener_id=listenerid,
                     hostnames=listeners[listenerid]['hostnames'])
 
+    @log_helpers.log_method_call
     def purge_orphaned_l7_policys(self, policies):
         """Deletes hanging l7_policies from the deleted listeners"""
         policies_used = set()
@@ -889,6 +892,7 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                     l7_policy_id=policy_key,
                     hostname=policy['hostnames'])
 
+    @log_helpers.log_method_call
     def purge_orphaned_pools(self, pools):
         """Deletes hanging pools from the deleted listeners"""
         # Ask Neutron for the status of all deployed pools
@@ -906,11 +910,13 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                     pool_id=poolid,
                     hostnames=pools[poolid]['hostnames'])
 
+    @log_helpers.log_method_call
     def purge_orphaned_health_monitors(self, monitors):
         """Deletes hanging Health Monitors from the deleted Pools"""
         # ask Neutron for for the status of all deployed monitors...
         monitors_used = set()
         pools = self.lbdriver.get_all_deployed_pools()
+        LOG.debug("pools found: {}".format(pools))
         for pool_id in pools:
             monitors_used.union(set(pools[pool_id]['monitor']))
         LOG.debug('health monitors in use: {}'.format(monitors_used))

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -918,11 +918,13 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
         pools = self.lbdriver.get_all_deployed_pools()
         LOG.debug("pools found: {}".format(pools))
         for pool_id in pools:
-            monitors_used.union(set(pools[pool_id]['monitor']))
+            monitorid = pools.get(pool_id).get('monitors', 'None')
+            monitors_used.add(monitorid)
         LOG.debug('health monitors in use: {}'.format(monitors_used))
         for monitorid in monitors:
             if monitorid not in monitors_used:
-                LOG.debug('removing orphaned health monitor %s' % monitorid)
+                LOG.debug("purging healthmonitor {} as it is not "
+                          "in ({})".format(monitorid, monitors_used))
                 self.lbdriver.purge_orphaned_health_monitor(
                     tenant_id=monitors[monitorid]['tenant_id'],
                     monitor_id=monitorid,

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1159,9 +1159,18 @@ class iControlDriver(LBaaSBaseDriver):
                         for pool in deployed_pools:
                             pool_id = \
                                 pool.name[len(self.service_adapter.prefix):]
-                            monitor = ''
-                            if pool.monitor:
+                            monitor_id = ''
+                            if hasattr(pool, 'monitor'):
                                 monitor = pool.monitor.split('/')[2].strip()
+                                monitor_id = \
+                                    monitor[len(self.service_adapter.prefix):]
+                                LOG.debug(
+                                    'pool {} has monitor {}'.format(
+                                        pool.name, monitor))
+                            else:
+                                LOG.debug(
+                                    'pool {} has no healthmonitors'.format(
+                                        pool.name))
                             if pool_id in deployed_pool_dict:
                                 deployed_pool_dict[pool_id][
                                     'hostnames'].append(bigip.hostname)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1170,12 +1170,13 @@ class iControlDriver(LBaaSBaseDriver):
                                     'id': pool_id,
                                     'tenant_id': tenant_id,
                                     'hostnames': [bigip.hostname],
-                                    'monitor': monitor
+                                    'monitors': monitor_id
                                 }
         return deployed_pool_dict
 
     @serialized('purge_orphaned_pool')
     @is_operational
+    @log_helpers.log_method_call
     def purge_orphaned_pool(self, tenant_id=None, pool_id=None,
                             hostnames=list()):
         for bigip in self.get_all_bigips():
@@ -1231,6 +1232,7 @@ class iControlDriver(LBaaSBaseDriver):
 
     @serialized('purge_orphaned_health_monitor')
     @is_operational
+    @log_helpers.log_method_call
     def purge_orphaned_health_monitor(self, tenant_id=None, monitor_id=None,
                                       hostnames=list()):
         """Purge all monitors that exist on the BIG-IP but not in Neutron"""
@@ -1294,6 +1296,7 @@ class iControlDriver(LBaaSBaseDriver):
 
     @serialized('purge_orphaned_l7_policy')
     @is_operational
+    @log_helpers.log_method_call
     def purge_orphaned_l7_policy(self, tenant_id=None, l7_policy_id=None,
                                  hostnames=list()):
         """Purge all l7_policys that exist on the BIG-IP but not in Neutron"""
@@ -1315,6 +1318,7 @@ class iControlDriver(LBaaSBaseDriver):
 
     @serialized('purge_orphaned_loadbalancer')
     @is_operational
+    @log_helpers.log_method_call
     def purge_orphaned_loadbalancer(self, tenant_id=None,
                                     loadbalancer_id=None, hostnames=list()):
         for bigip in self.get_all_bigips():
@@ -1355,6 +1359,7 @@ class iControlDriver(LBaaSBaseDriver):
 
     @serialized('purge_orphaned_listener')
     @is_operational
+    @log_helpers.log_method_call
     def purge_orphaned_listener(
             self, tenant_id=None, listener_id=None, hostnames=[]):
         for bigip in self.get_all_bigips():

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1126,7 +1126,8 @@ class iControlDriver(LBaaSBaseDriver):
                             virtual_id = \
                                 virtual.name[len(self.service_adapter.prefix):]
                             l7_policy = ''
-                            if 'items' in virtual.policyReference:
+                            if hasattr(virtual, 'policyReference') and \
+                                    'items' in virtual.policyReference:
                                 l7_policy = virtual.policyReference['items'][0]
                                 l7_policy = l7_policy['fullPath']
                             if virtual_id in deployed_virtual_dict:
@@ -1208,7 +1209,7 @@ class iControlDriver(LBaaSBaseDriver):
                 tenant_id = folder[len(adapter_prefix):]
                 if str(folder).startswith(adapter_prefix):
                     resources = map(
-                        lambda x: resource_helper.BigIpResourceHelper(
+                        lambda x: resource_helper.BigIPResourceHelper(
                             getattr(resource_helper.ResourceType, x)),
                         monitor_types)
                     for resource in resources:
@@ -1272,7 +1273,7 @@ class iControlDriver(LBaaSBaseDriver):
             for folder in folders:
                 tenant_id = folder[len(self.service_adapter.prefix):]
                 if str(folder).startswith(self.service_adapter.prefix):
-                    resource = resource_helper.BigIpResourceHelper(
+                    resource = resource_helper.BigIPResourceHelper(
                         resource_helper.ResourceType.l7policy)
                     deployed_l7_policys = resource.get_resources(bigip, folder)
                     if deployed_l7_policys:


### PR DESCRIPTION
@richbrowne @jlongstaf 
#### What issues does this address?
Fixes #1187 

#### What's this change do?
* Fixes some improper l7policy purging attribute references
* Adds more verbose logging to purge_orphaned_health_monitors
* Handles healthmonitor id/name referencing between
* Fixes problem of orphaned healthmonitors not being purged properly
  * And their pre-mature attempts when they are not orphaned...

#### Where should the reviewer start?
`icontrol_driver.iControlDriver.get_all_deployed_pools()`

#### Any background context?
Before, we would see the periodic task fail in `icontrol_driver.iControlDriver.get_all_deployed_listeners()` due to improper attribute references for l7policy extraction (when an l7policy does not exist on the listener). 

Then there was an issue of the healthmonitor deletion attempt when it was still being referenced by a pool (when it should be there).  Then properly being deleted (when it should not be there).