### PR TITLE
Purge orphaned pool leaves residual nodes

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1711,6 +1711,10 @@ class iControlDriver(LBaaSBaseDriver):
             loadbalancer['tenant_id']
         )
 
+        if self.network_builder:
+            # append route domain to member address
+            self.network_builder._annotate_service_route_domains(service)
+
         # Foreach bigip in the cluster:
         for bigip in self.get_config_bigips():
             # Does the tenant folder exist?
@@ -1767,6 +1771,8 @@ class iControlDriver(LBaaSBaseDriver):
                                    "member": member,
                                    "pool": pool}
                             if not lb.pool_builder.member_exists(svc, bigip):
+                                LOG.warn("Pool member not found: %s",
+                                         svc['member'])
                                 return False
 
             # Ensure that each health monitor exists.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -19,6 +19,7 @@ import hashlib
 import json
 import logging as std_logging
 import os
+import urllib
 
 from eventlet import greenthread
 from time import strftime
@@ -1188,6 +1189,8 @@ class iControlDriver(LBaaSBaseDriver):
     @log_helpers.log_method_call
     def purge_orphaned_pool(self, tenant_id=None, pool_id=None,
                             hostnames=list()):
+        node_helper = resource_helper.BigIPResourceHelper(
+            resource_helper.ResourceType.node)
         for bigip in self.get_all_bigips():
             if bigip.hostname in hostnames:
                 try:
@@ -1196,7 +1199,21 @@ class iControlDriver(LBaaSBaseDriver):
                     pool = resource_helper.BigIPResourceHelper(
                         resource_helper.ResourceType.pool).load(
                             bigip, pool_name, partition)
+                    members = pool.members_s.get_collection()
                     pool.delete()
+                    for member in members:
+                        node_name = member.address
+                        try:
+                            node_helper.delete(bigip,
+                                               name=urllib.quote(node_name),
+                                               partition=partition)
+                        except HTTPError as e:
+                            if e.response.status_code == 404:
+                                pass
+                            if e.response.status_code == 400:
+                                LOG.warn("Failed to delete node -- in use")
+                            else:
+                                LOG.exception("Failed to delete node")
                 except HTTPError as err:
                     if err.response.status_code == 404:
                         LOG.debug('pool %s not on BIG-IP %s.'


### PR DESCRIPTION
Purge orphaned pool leaves residual nodes

    # Using the Fixes #<issueid> will close the issue on commit to repo
    Issues:
    Fixes #1192

    # Describe the issue that this change addresses
    Problem:
    This method will be given a pool id and it performs a purge on the
    pool itself, which leaves whatever node or neutron-level member that
    already existed on the BIG-IP without purging it

    # Describe the change itself and why you made the changes you did
    Analysis:
    Collect all members from the pool and delete any corresponding nodes
    once the pool is deleted.

    # Describe the tests you ran and/or created to test this change
    Tests:
    Systest delete_orphaned_pools