### PR TITLE
Can't create loadbalancer in Global Routed Mode

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -913,7 +913,7 @@ class iControlDriver(LBaaSBaseDriver):
             ic_host['local_ip'] = bigip.local_ip
         else:
             ic_host['local_ip'] = 'VTEP disabled'
-            self.agent_configurations['tunnel_types'] = 'None'
+            self.agent_configurations['tunnel_types'] = list()
         self.agent_configurations['icontrol_endpoints'][bigip.hostname] = \
             ic_host
         if self.network_builder:


### PR DESCRIPTION
Issues:
Fixes #1215

Problem:
In an overcloud test to create a loadbalancer, the driver throws
an exception because the advertised tunnel type was initialized
to 'None' in the agent configuration.  If there is no local VTEP
ip address, this advertised tunnel type should be initialized to
an empty list.

Analysis:
Changed initialization of tunnel_type from 'None' to an empty list.

Tests:
Overcloud testing.

@<reviewer_id>
#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?
