### PR TITLE
Fixing purge orphaned l7policy feature

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
@@ -707,8 +707,7 @@ class LBaaSv2PluginRPC(object):
             l7policy_status = self._call(
                 self.context,
                 self._make_msg('validate_l7policys_state_by_listener',
-                               listeners=listeners,
-                               host=self.host),
+                               listeners=listeners),
                 topic=self.topic
             )
         except messaging.MessageDeliveryFailure:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
@@ -698,3 +698,16 @@ class LBaaSv2PluginRPC(object):
                       "get_pools_members")
 
         return pools_members
+
+    @log_helpers.log_method_call
+    def validate_l7policys_state_by_listener(self, listeners):
+        """Get the status of a list of l7policys IDs in Neutron"""
+        l7policy_status = {}
+        try:
+            l7policy_status = self._call(
+                self.context,
+                self._make_msg('validate_l7policys_state_by_listener',
+                               listeners=listeners,
+                      "validate_l7policys_state_by_listener")
+
+        return l7policy_status

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
@@ -708,6 +708,11 @@ class LBaaSv2PluginRPC(object):
                 self.context,
                 self._make_msg('validate_l7policys_state_by_listener',
                                listeners=listeners,
+                               host=self.host),
+                topic=self.topic
+            )
+        except messaging.MessageDeliveryFailure:
+            LOG.error("agent->plugin RPC exception caught: ",
                       "validate_l7policys_state_by_listener")
 
         return l7policy_status

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
@@ -147,7 +147,8 @@ class BigIPResourceHelper(object):
 
         return resource
 
-    def get_resources(self, bigip, partition=None):
+    def get_resources(self, bigip, partition=None,
+                      expand_subcollections=False):
         u"""Retrieve a collection BIG-IP of resources from a BIG-IP.
 
         Generates a list of resources objects on a BIG-IP system.
@@ -165,10 +166,17 @@ class BigIPResourceHelper(object):
             raise err
 
         if collection:
+            expand_subcollections_param = ''
+            params = {'params': ''}
+            partition_filter = ''
             if partition:
-                params = {
-                    'params': get_filter(bigip, 'partition', 'eq', partition)
-                }
+                params['params'] =  get_filter(
+                    bigip, 'partition', 'eq', partition)
+                if expand_subcollections and \
+                        isinstance(params['params'], dict):
+                    params['params']['expandSubcollections'] = 'true'
+                elif expand_subcollections:
+                    params['params'] += '&expandSubCollections=true'
                 resources = collection.get_collection(requests_params=params)
             else:
                 resources = collection.get_collection()

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
@@ -166,11 +166,9 @@ class BigIPResourceHelper(object):
             raise err
 
         if collection:
-            expand_subcollections_param = ''
             params = {'params': ''}
-            partition_filter = ''
             if partition:
-                params['params'] =  get_filter(
+                params['params'] = get_filter(
                     bigip, 'partition', 'eq', partition)
                 if expand_subcollections and \
                         isinstance(params['params'], dict):


### PR DESCRIPTION
Issues:
Fixes #1209

Problem:
* Orphaned l7policies were not getting purged
  * Conditions where this would occur:
    * l7policy added to listener on neutron config
    * The BIG-IP is taken down (temporarily)
    * The l7policy is removed in then neutron config
    * The BIG-IP is brought back online
  * Symptoms
    * The policies on the virtual remain on the BIG-IP indefinitely

Analysis:
* This will query the Neutron config via the f5lbaasdriver library
  * Via RPC
  * If neutron no longer has any l7policies referencing the listener...
    * Then the policy pointing to the virtual are de-referenced
    * The policy is deleted on the BIG-IP
* This will grab a list of policies that are referenced by virtual
  * If there is a policy that is no longer referenced by a virtual...
    * Then the policy is deleted on the BIG-IP
  * This covers the scenario where the orphaned listener is purged

Tests:
Look to systest test

@richbrowne 
#### What issues does this address?
Fixes #1209 

#### What's this change do?
* If the BIG-IP is unaware of the fact that...
  * On Neutron, no l7policies exist anymore on a listener...
* Then the agent will execute a purge by...
  * Unlinking the virtual (listener) on the BIG-IP from the policy (l7policy)
  * Deleting the policy (l7policy) off of the BIG-IP

#### What's this change not do?
* If more than 1 l7policies exist on a listener
  * And if one of these l7policies (and its rules) are deleted off of the network controller
  * And a BIG-IP in the cluster is down or made to be unaware of this change
* Then the agent cannot know to delete this l7policy and consolidate it on the BIG-IP policy that is linked to the listener in question

##### Workaround
1. Make sure that the BIG-IP in question remains online...
2. Change the name of the listener temporarily to include an arbitrary sub-string (or remove an arbitrary substring from it) on the Controller
3. Return that substring on the controller

###### How this works
What this does is cause the neutron_lbaas to prompt a listener update in the form of a service object on the f5-openstack-agent.  This will include all present l7policies and re-sync the whole state on the BIG-IP.  Due to the current design of the f5-openstack-agent, there is no means to handle this specific case, **and it is recommended**, though not required to keep only 1 l7policy per listener, if at all possible.  If not, please be aware of this work around.

#### Where should the reviewer start?
agent_manager's `purge_orphaned_l7_policys()` method

#### Any background context?
Please see what it does do versus what it doesn't...
