### PR TITLE
Fixes #1223 - docs prep for release

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -31,7 +31,7 @@ version |release|
 |release-notes|
 
 The |agent-long| (``f5-openstack-agent``) is an OpenStack `Neutron plugin agent <https://docs.openstack.org/security-guide/networking/architecture.html>`_.
-It works in conjunction with the `F5 Driver for OpenStack LBaaS </products/openstack/lbaasv2-driver/latest/index.html>`_ to manage F5 BIG-IP `Local Traffic Manager <https://f5.com/products/big-ip/local-traffic-manager-ltm>`_ (LTM) services via the OpenStack Neutron API.
+It works in conjunction with the `F5 Driver for OpenStack LBaaS`_ to manage F5 BIG-IP `Local Traffic Manager <https://f5.com/products/big-ip/local-traffic-manager-ltm>`_ (LTM) services via the OpenStack Neutron API.
 
 .. seealso::
 
@@ -146,7 +146,7 @@ Architecture
 The |driver-long| assigns LBaaS tasks from the Neutron RPC Messaging queue to the |agent-long|.
 The |agent-short| translates the Neutron LBaaS API calls to iControl REST API calls and `configures the requested objects`_ on the BIG-IP device(s) identified in the :ref:`F5 Agent Configuration File <agent-config-file>`.
 
-When the |agent-short| and |driver-short| run on your OpenStack Neutron Controller, you can use the standard ``neutron lbaas`` commands to manage BIG-IP LTM objects. [#neutroncli]_
+When the |agent-short| and |driver-short| run on your OpenStack Neutron Controller, you can use the native OpenStack CLI commands to manage BIG-IP LTM objects. [#oscli]_
 The table below shows the corresponding iControl endpoint and BIG-IP object for each :code:`neutron lbaas-* create` command.
 
 .. table:: OpenStack Neutron to F5 iControl REST/BIG-IP command mapping
@@ -278,7 +278,7 @@ Perform the steps below on every server running |agent-short|.
       Your configuration file (:file:`/etc/neutron/services/f5/f5-openstack-agent.ini` gets overwritten when you install a new package.
       If you don't save a copy elsewhere, you will lose your config settings.
 
-   .. code-block:: bash
+   .. code-block:: console
 
       $ cp /etc/neutron/services/f5/f5-openstack-agent.ini ~/f5-upgrade-temp
 
@@ -287,19 +287,19 @@ Perform the steps below on every server running |agent-short|.
    Your new |agent-short| will not start if it finds an existing |agent| .log file.
    You can either move the log file to a new location, or rename it.
 
-   .. code-block:: bash
+   .. code-block:: console
 
       $ mv /var/log/neutron/f5-openstack-agent.log ~/f5-upgrade-temp
 
 #. Stop and remove the current version of the |agent-short|.
 
-   .. code-block:: bash
+   .. code-block:: console
       :caption: Debian/Ubuntu
 
       $ sudo service f5-oslbaasv2-agent stop
       $ pip uninstall f5-openstack-agent
 
-   .. code-block:: bash
+   .. code-block:: console
       :caption: Red Hat/CentOS
 
       $ sudo systemctl stop f5-openstack-agent
@@ -316,13 +316,13 @@ Perform the steps below on every server running |agent-short|.
       Verify that the only differences between the two are those required for your deployment.
       If new options appear in the config file, see :ref:`supported features <agent-supported-features>` and :ref:`configuration parameters <agent-config-parameters>` for explanations and config instructions.
 
-   .. code-block:: bash
+   .. code-block:: console
 
       $ cp ~/f5-upgrade-temp/f5-openstack-agent.ini /etc/neutron/services/f5/f5-openstack-agent.ini
 
 
-.. rubric:: Footnotes
-.. [#neutroncli] See the `Neutron LBaaS documentation <https://docs.openstack.org/mitaka/networking-guide/config-lbaas.html>`_
+.. rubric:: **Footnotes**
+.. [#oscli] See the `OpenStack CLI documentation <https://docs.openstack.org/python-openstackclient/newton/>`_
 .. [#agent] Similar to BIG-IP :term:`high availability`, but applies to the |agent-short| processes.
 
 .. |Build Status| image:: https://travis-ci.org/F5Networks/f5-openstack-agent.svg?branch=liberty
@@ -337,7 +337,6 @@ Perform the steps below on every server running |agent-short|.
 .. _OpenStack Keystone: https://wiki.openstack.org/wiki/Keystone
 .. _Binds VLANs to BIG-IP interfaces: https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-routing-administration-13-0-0/4.html
 .. _automap SNAT: https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-routing-administration-13-0-0/7.html
-.. _configures the requested objects: /cloud/openstack/latest/lbaas/bigip-command-mapping.html
 .. _Distributed Virtual Router: https://specs.openstack.org/openstack/neutron-specs/specs/juno/neutron-ovs-dvr.html
 .. _Role Based Access Control: http://specs.openstack.org/openstack/neutron-specs/specs/liberty/rbac-networks.html
 .. _f5-openstack-ansible: https://github.com/f5devcentral/f5-openstack-ansible

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -418,3 +418,8 @@ rst_epilog = '''
   'openstack_release_l': openstack_release.lower(),
   'base_url': 'http://clouddocs.f5.com'
 }
+
+# Links to external sites (i.e., outside of clouddocs)
+# Use: :issues:`287` would transform to "issue 287" and link to issue #287 in GitHub
+extlinks = {'issues': ('https://github.com/F5Networks/f5-openstack-agent/issues/%s',
+                          'issue ')}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -389,8 +389,8 @@ rst_epilog = '''
     <a class="btn btn-info" href="https://github.com/F5Networks/f5-openstack-agent/releases/download/v%(version)s/f5-openstack-agent-%(version)s-1.el7.noarch.rpm">RPM package</a>
 .. |release-notes| raw:: html
 
-    <a class="btn btn-success" href="https://github.com/F5Networks/f5-openstack-agent/releases/tag/v%(version)s/">Release Notes</a>
-.. _Hierarchical Port Binding: /cloud/openstack/latest/lbaas/hierarchical-port-binding.html
+    <a class="btn btn-success" href="%(base_url)s/products/openstack/agent/v%(version)s/RELEASE_NOTES.html">Release Notes</a>
+.. _Hierarchical Port Binding: %(base_url)s/cloud/openstack/latest/lbaas/hierarchical-port-binding.html
 .. _external provider network: https://docs.openstack.org/newton/networking-guide/intro-os-networking.html#provider-networks
 .. _Cisco ACI: http://www.cisco.com/c/en/us/solutions/data-center-virtualization/application-centric-infrastructure/index.html
 .. _system configuration: https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-system-initial-configuration-13-0-0/2.html
@@ -401,14 +401,20 @@ rst_epilog = '''
 .. _self IP: https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-routing-administration-13-0-0/6.html
 .. _Better or Best license: https://f5.com/products/how-to-buy/simplified-licensing
 .. _secure network address translation: https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-routing-administration-13-0-0/8.html
-.. _F5 Integration for OpenStack: /cloud/openstack/latest/lbaas
-.. _Install the F5 LBaaSv2 Driver: /products/openstack/f5-openstack-lbaasv2-driver/v%(version)s/index.html#installation
-.. _F5 Agent modes: /cloud/openstack/latest/lbaas/f5-agent-modes.html
-.. _Differentiated service environments: /cloud/openstack/latest/lbaas/differentiated-service-environments.html
+.. _F5 Integration for OpenStack: %(base_url)s/cloud/openstack/latest/lbaas
+.. _Install the F5 LBaaSv2 Driver: %(base_url)s/products/openstack/f5-openstack-lbaasv2-driver/v%(version)s/index.html#installation
+.. _F5 Agent modes: %(base_url)s/cloud/openstack/latest/lbaas/f5-agent-modes.html
+.. _Differentiated service environments: %(base_url)s/cloud/openstack/latest/lbaas/differentiated-service-environments.html
+.. _F5 Driver for OpenStack LBaaS: %(base_url)s/products/openstack/lbaasv2-driver/%(version)s/
+.. _configures the requested objects: %(base_url)s/cloud/openstack/latest/lbaas/bigip-command-mapping.html
+.. _How to set up the F5 Agent for Hierarchical Port Binding: %(base_url)s/cloud/openstack/v1/lbaas/set-up-agent-hpb.html
+.. _Manage BIG-IP Clusters with F5 LBaaSv2: %(base_url)s/cloud/openstack/latest/lbaas/manage-bigip-clusters
+.. _vCMP: %(base_url)s/cloud/openstack/v1/lbaas/lbaas-manage-vcmp.html
 ''' % {
   'version': version,
   'f5_sdk_version': f5_sdk_version,
   'f5_icontrol_version': f5_icontrol_version,
   'openstack_release': openstack_release,
   'openstack_release_l': openstack_release.lower(),
+  'base_url': 'http://clouddocs.f5.com'
 }

--- a/docs/device-driver-settings.rst
+++ b/docs/device-driver-settings.rst
@@ -21,7 +21,7 @@ The |agent-short| can manage a :term:`standalone` device or a :term:`device serv
 
 .. seealso::
 
-   `Manage BIG-IP Clusters with F5 LBaaSv2 </cloud/openstack/latest/lbaas/manage-bigip-clusters>`_
+   `Manage BIG-IP Clusters with F5 LBaaSv2`_
 
 
 Configuration
@@ -38,19 +38,19 @@ Configuration
 
    .. code-block:: text
 
-   ###############################################################################
-   #  Device Driver - iControl Driver Setting
-   ###############################################################################
-   #
-   icontrol_hostname = 10.190.7.232 \\ replace with the IP address(es) of your BIG-IP(s)
-   #
-   # icontrol_vcmp_hostname = 192.168.1.245
-   #
-   icontrol_username = admin
-   #
-   icontrol_password = admin
-   #
+      ###############################################################################
+      #  Device Driver - iControl Driver Setting
+      ###############################################################################
+      #
+      icontrol_hostname = 10.190.7.232 \\ replace with the IP address(es) of your BIG-IP(s)
+      #
+      # icontrol_vcmp_hostname = 192.168.1.245
+      #
+      icontrol_username = admin
+      #
+      icontrol_password = admin
+      #
 
 #. Set up the |agent-long| to use :ref:`L2-adjacent mode <l2-adjacent-setup>` or :ref:`Global Routed mode <global-routed-setup>`.
 
-.. _vCMP: /cloud/openstack/v1/lbaas/lbaas-manage-vcmp.html
+

--- a/docs/l2-adjacent-mode.rst
+++ b/docs/l2-adjacent-mode.rst
@@ -74,7 +74,7 @@ What's Next
 -----------
 
 - See `F5 Agent modes`_ for detailed information regarding each of the Agent's modes of operation and example use cases.
-- See `How to set up the F5 Agent for Hierarchical Port Binding </cloud/openstack/v1/lbaas/set-up-agent-hpb.html>`_ for information about standard and Cisco ACI HPB deployments.
+- See `How to set up the F5 Agent for Hierarchical Port Binding`_ for information about standard and Cisco ACI HPB deployments.
 
 .. todo:: add Cisco APIC/ACI deployment solution guide and link to it here
 


### PR DESCRIPTION
@jlongstaf 

#### What issues does this address?
Fixes #1223 

#### What's this change do?
- updates the URL for the release notes to point to a clouddocs location instead of GitHub
- changes how relative links to other clouddocs locations are handled so they're not ignored by the linkcheck
- updates the highlight format used for code-blocks
- adds ability to easily reference GitHub issues using the following syntax:
```
:issues:`1224`
```
 
#### Where should the reviewer start?

#### Any background context?
