### PR TITLE
Agent manager raises KeyError exception during load balancer sync

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -647,7 +647,11 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                     self.service_timeout(lb_id)
 
             if not lb_pending:
-                del self.pending_services[lb_id]
+                try:
+                    del self.pending_services[lb_id]
+                except KeyError as error:
+                    LOG.error("LB not found in pending services: {0}".
+                        format(e.message))
 
         # If there are services in the pending cache resync
         if self.pending_services:


### PR DESCRIPTION

@richbrowne 
#### What issues does this address?
Fixes #1228 

#### What's this change do?
Adds a try/except block to catch KeyError exception when removing pending LB from collection of pending services.

#### Where should the reviewer start?
agent_manager.py

#### Any background context?
No.
