### PR TITLE
Fixing purge orphaned l7policy feature

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
@@ -698,3 +698,20 @@ class LBaaSv2PluginRPC(object):
                       "get_pools_members")
 
         return pools_members
+
+    @log_helpers.log_method_call
+    def validate_l7policys_state_by_listener(self, listeners):
+        """Get the status of a list of l7policys IDs in Neutron"""
+        l7policy_status = {}
+        try:
+            l7policy_status = self._call(
+                self.context,
+                self._make_msg('validate_l7policys_state_by_listener',
+                               listeners=listeners),
+                topic=self.topic
+            )
+        except messaging.MessageDeliveryFailure:
+            LOG.error("agent->plugin RPC exception caught: ",
+                      "validate_l7policys_state_by_listener")
+
+        return l7policy_status

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
@@ -147,7 +147,8 @@ class BigIPResourceHelper(object):
 
         return resource
 
-    def get_resources(self, bigip, partition=None):
+    def get_resources(self, bigip, partition=None,
+                      expand_subcollections=False):
         u"""Retrieve a collection BIG-IP of resources from a BIG-IP.
 
         Generates a list of resources objects on a BIG-IP system.
@@ -165,10 +166,15 @@ class BigIPResourceHelper(object):
             raise err
 
         if collection:
+            params = {'params': ''}
             if partition:
-                params = {
-                    'params': get_filter(bigip, 'partition', 'eq', partition)
-                }
+                params['params'] = get_filter(
+                    bigip, 'partition', 'eq', partition)
+                if expand_subcollections and \
+                        isinstance(params['params'], dict):
+                    params['params']['expandSubcollections'] = 'true'
+                elif expand_subcollections:
+                    params['params'] += '&expandSubCollections=true'
                 resources = collection.get_collection(requests_params=params)
             else:
                 resources = collection.get_collection()


### PR DESCRIPTION
Fixes purge orphaned l7policy_objects

Issues:
Fixes #895 for newton

Problem:
* Validation method needed for l7policy objects in the driver

Analysis:
* This includes a validate method

Tests:

@jlongstaf 
#### What issues does this address?
Fixes #895 for newton

#### What's this change do?
Introduces a validate functionality to go back to neutron for l7policies listing

#### Where should the reviewer start?
agent_manager.py

#### Any background context?
This was already approved for Agent and fixes the orphaned l7policies