### PR TITLE
Fixing selfip ref in disconnected tests

### DIFF
--- a/test/functional/neutronless/disconnected_service/test_disconnected_service_creation.py
+++ b/test/functional/neutronless/disconnected_service/test_disconnected_service_creation.py
@@ -60,8 +60,10 @@ tmos_version = ManagementRoot(
     pytest.symbols.bigip_mgmt_ip_public,
     pytest.symbols.bigip_username,
     pytest.symbols.bigip_password).tmos_version
-dashed_mgmt_ip = pytest.symbols.bigip_mgmt_ip_public.replace('.', '-')
-icontrol_fqdn = 'host-' + dashed_mgmt_ip + '.openstacklocal'
+# Note, BIG-IP generates selfip based upon the net it is on (172), not the
+# public net (10)...  This is based upon testenv.
+mgmt_ip = pytest.symbols.bigip_mgmt_ip
+icontrol_fqdn = 'host-' + mgmt_ip + '.openstacklocal'
 if StrictVersion(tmos_version) >= StrictVersion('12.1.0'):
     icontrol_fqdn = 'bigip1'
 neutron_services_filename =\

--- a/test/functional/neutronless/disconnected_service/test_disconnected_service_creation.py
+++ b/test/functional/neutronless/disconnected_service/test_disconnected_service_creation.py
@@ -134,9 +134,10 @@ SEG_INDEPENDENT_LB_URIS_COMMON_NET =\
          '~TEST_128a63ef33bc4cf891d684fad58e7f2d'
          '~TEST_128a63ef33bc4cf891d684fad58e7f2d?ver='+tmos_version,
 
-         u'https://localhost/mgmt/tm/net/self/'
-         '~Common'
-         '~local-' + icontrol_fqdn + '-ce69e293-56e7-43b8-b51c-01b91d66af20?ver='+tmos_version,
+         unicode(
+            'https://localhost/mgmt/tm/net/self/~Common~local-{}'
+            '-ce69e293-56e7-43b8-b51c-01b91d66af20?ver={}').format(
+            icontrol_fqdn, tmos_version),
 
          u'https://localhost/mgmt/tm/ltm/virtual-address/'
          '~TEST_128a63ef33bc4cf891d684fad58e7f2d'
@@ -199,7 +200,8 @@ def logcall(lh, call, *cargs, **ckwargs):
 def bigip():
     LOG.debug(pytest.symbols)
     LOG.debug(pytest.symbols.bigip_mgmt_ip_public)
-    return ManagementRoot(pytest.symbols.bigip_mgmt_ip_public, 'admin', 'admin')
+    return \
+        ManagementRoot(pytest.symbols.bigip_mgmt_ip_public, 'admin', 'admin')
 
 
 @pytest.fixture
@@ -233,7 +235,7 @@ def handle_init_registry(bigip, icd_configuration,
     icontroldriver = configure_icd(icd_configuration, create_mock_rpc)
     LOG.debug(bigip.raw)
     start_registry = register_device(bigip)
-    if icd_configuration['f5_global_routed_mode'] == False:
+    if icd_configuration['f5_global_routed_mode'] is False:
         assert set(start_registry.keys()) - set(init_registry.keys()) == \
             AGENT_INIT_URIS
     return icontroldriver, start_registry


### PR DESCRIPTION
#### Problem:
* The public mgmt ip addr was used when private should be
* The address delimiter was '-' instead of '.' as the BIG-IP uses

#### Analysis:
* This changes things for both for 11.5 and 11.6 tests

#### Tests:
This was tested against a newton 11.6 funct environment

@jlongstaf 
#### What issues does this address?
selfip issues in funct tests for disconnected tests

#### What's this change do?
Changes things to use the mgmt ip of the BIG-IP rather than its floating IP.  Also delimits using `.``s instead of `-``s

#### Where should the reviewer start?
`test_disconnected_service_creation.py`

#### Any background context?
These tests have been failing for quite some time (since the migration)