### PR TITLE
Consolidated names as they were expected in enviro

### DIFF
--- a/test/functional/singlebigip/conftest.py
+++ b/test/functional/singlebigip/conftest.py
@@ -3,8 +3,13 @@ import pytest
 from f5.bigip import ManagementRoot
 from pytest import symbols
 
+
 @pytest.fixture(scope="module")
-def mgmt_root ():
-    m_obj = ManagementRoot(symbols.bigip_mgmt_ip_public, symbols.bigip_username, symbols.bigip_password)
-    m_obj._meta_data['device_name'] = 'bigip1'
+def mgmt_root():
+    bigip_quantname = \
+        "host-{s.bigip_mgmt_ip}.openstacklocal".format(s=symbols)
+    m_obj = ManagementRoot(
+        symbols.bigip_mgmt_ip_public, symbols.bigip_username,
+        symbols.bigip_password)
+    m_obj._meta_data['device_name'] = bigip_quantname
     return m_obj


### PR DESCRIPTION
### Issue: Naming conflict within test environment

#### Problem:
* Tests expect the default 'bigip1' hostname, which is edited for tests

#### Analysis:
* Changes hostname for BIG-IP to what the test environment expectes

Tests:
This was tested in a newton funct-test environment with a 11.6 BIG-IP

@jlongstaf 
#### What issues does this address?
Not a product bug

#### What's this change do?
Consolidates symbols to appropriate set using appropriate hostname instead of default 'bigip1'

#### Where should the reviewer start?
conftest.py (only file) minor change...

#### Any background context?
This has been causing a lot of errors in test up to when the migration occurred.