### PR TITLE
Mitaka.cherry picking bugfixes ae3428639.68e424a41.2a64216dc

### DIFF
--- a/test/functional/neutronless/disconnected_service/test_disconnected_service_creation.py
+++ b/test/functional/neutronless/disconnected_service/test_disconnected_service_creation.py
@@ -60,8 +60,10 @@ tmos_version = ManagementRoot(
     pytest.symbols.bigip_mgmt_ip_public,
     pytest.symbols.bigip_username,
     pytest.symbols.bigip_password).tmos_version
-dashed_mgmt_ip = pytest.symbols.bigip_mgmt_ip_public.replace('.', '-')
-icontrol_fqdn = 'host-' + dashed_mgmt_ip + '.openstacklocal'
+# Note, BIG-IP generates selfip based upon the net it is on (172), not the
+# public net (10)...  This is based upon testenv.
+mgmt_ip = pytest.symbols.bigip_mgmt_ip
+icontrol_fqdn = 'host-' + mgmt_ip + '.openstacklocal'
 if StrictVersion(tmos_version) >= StrictVersion('12.1.0'):
     icontrol_fqdn = 'bigip1'
 neutron_services_filename =\

--- a/test/functional/neutronless/disconnected_service/test_disconnected_service_creation.py
+++ b/test/functional/neutronless/disconnected_service/test_disconnected_service_creation.py
@@ -134,9 +134,10 @@ SEG_INDEPENDENT_LB_URIS_COMMON_NET =\
          '~TEST_128a63ef33bc4cf891d684fad58e7f2d'
          '~TEST_128a63ef33bc4cf891d684fad58e7f2d?ver='+tmos_version,
 
-         u'https://localhost/mgmt/tm/net/self/'
-         '~Common'
-         '~local-' + icontrol_fqdn + '-ce69e293-56e7-43b8-b51c-01b91d66af20?ver='+tmos_version,
+         unicode(
+            'https://localhost/mgmt/tm/net/self/~Common~local-{}'
+            '-ce69e293-56e7-43b8-b51c-01b91d66af20?ver={}').format(
+            icontrol_fqdn, tmos_version),
 
          u'https://localhost/mgmt/tm/ltm/virtual-address/'
          '~TEST_128a63ef33bc4cf891d684fad58e7f2d'
@@ -199,7 +200,8 @@ def logcall(lh, call, *cargs, **ckwargs):
 def bigip():
     LOG.debug(pytest.symbols)
     LOG.debug(pytest.symbols.bigip_mgmt_ip_public)
-    return ManagementRoot(pytest.symbols.bigip_mgmt_ip_public, 'admin', 'admin')
+    return \
+        ManagementRoot(pytest.symbols.bigip_mgmt_ip_public, 'admin', 'admin')
 
 
 @pytest.fixture
@@ -233,7 +235,7 @@ def handle_init_registry(bigip, icd_configuration,
     icontroldriver = configure_icd(icd_configuration, create_mock_rpc)
     LOG.debug(bigip.raw)
     start_registry = register_device(bigip)
-    if icd_configuration['f5_global_routed_mode'] == False:
+    if icd_configuration['f5_global_routed_mode'] is False:
         assert set(start_registry.keys()) - set(init_registry.keys()) == \
             AGENT_INIT_URIS
     return icontroldriver, start_registry

--- a/test/functional/singlebigip/conftest.py
+++ b/test/functional/singlebigip/conftest.py
@@ -3,8 +3,13 @@ import pytest
 from f5.bigip import ManagementRoot
 from pytest import symbols
 
+
 @pytest.fixture(scope="module")
-def mgmt_root ():
-    m_obj = ManagementRoot(symbols.bigip_mgmt_ip_public, symbols.bigip_username, symbols.bigip_password)
-    m_obj._meta_data['device_name'] = 'bigip1'
+def mgmt_root():
+    bigip_quantname = \
+        "host-{s.bigip_mgmt_ip}.openstacklocal".format(s=symbols)
+    m_obj = ManagementRoot(
+        symbols.bigip_mgmt_ip_public, symbols.bigip_username,
+        symbols.bigip_password)
+    m_obj._meta_data['device_name'] = bigip_quantname
     return m_obj


### PR DESCRIPTION
Cherry-picks master commits:
* ae3428639ee3e27828c902c5afa1ca6c70fb97bb
* 68e424a4145f553cdf7da0c7b14c0da889d1fcb7
* 2a64216dc073f1ae5b68d446011f1045ada49f2f
This migrates the following PR's into Newton:
* #1249 
* #1250 

@jlongstaf 
#### What issues does this address?
* Tests expect the default 'bigip1' hostname, which is edited for tests
* The modified test did not conform
* The public mgmt ip addr was used when private should be for selfip referencing in singlebigip tests
* The address delimiter was '-' instead of '.' as the BIG-IP uses for selfip referencing in singlebigip tests

#### What's this change do?
* Changes hostname for BIG-IP to what the test environment expectes
* Changed the import order
* Changed things to be restricted to 80 columns per line
* This changes things for both for 11.5 and 11.6 tests

#### Where should the reviewer start?
Re-referencing the previous PR's:
* #1249 
* #1250 

#### Any background context?
This is part of the effort to get agent funct tests cleaned up.