### PR TITLE
Issues: (#1248)

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -36,8 +36,8 @@ from neutron_lib import constants as plugin_const
 from neutron_lib import exceptions as q_exception
 
 from f5_openstack_agent.lbaasv2.drivers.bigip import constants_v2
+from f5_openstack_agent.lbaasv2.drivers.bigip import exceptions as f5_ex
 from f5_openstack_agent.lbaasv2.drivers.bigip import plugin_rpc
-
 
 LOG = logging.getLogger(__name__)
 
@@ -684,6 +684,8 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
             else:
                 LOG.debug("Found service definition for '{}', state is ACTIVE"
                           " move on.".format(lb_id))
+        except f5_ex.InvalidNetworkType as exc:
+            LOG.warning(exc.msg)
         except q_exception.NeutronException as exc:
             LOG.error("NeutronException: %s" % exc.msg)
         except Exception as exc:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -2213,7 +2213,12 @@ class iControlDriver(LBaaSBaseDriver):
         if 'members' in service:
             if self.network_builder:
                 # append route domain to member address
-                self.network_builder._annotate_service_route_domains(service)
+                try:
+                    self.network_builder._annotate_service_route_domains(
+                        service)
+                except f5ex.InvalidNetworkType as exc:
+                    LOG.warning(exc.msg)
+                    return
 
             # get currrent member status
             self.lbaas_builder.update_operating_status(service)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_network_service.py
@@ -355,15 +355,17 @@ class TestNetworkServiceBuilder(object):
         assert net_short_name == 'vlan-608'
 
         # invalid network type
-        with pytest.raises(f5_ex.InvalidNetworkType):
+        with pytest.raises(f5_ex.InvalidNetworkType) as excinfo:
             network['provider:network_type'] = ''
             network_service.get_route_domain_from_cache(network)
+            assert 'provider:network_type' in str(excinfo.value)
 
         # invalid segmentation ID
-        with pytest.raises(f5_ex.InvalidNetworkType):
+        with pytest.raises(f5_ex.InvalidNetworkType) as excinfo:
             network['provider:network_type'] = 'vlan'
             network['provider:segmentation_id'] = ''
             network_service.get_route_domain_from_cache(network)
+            assert 'provider:network_type - vlan' in str(excinfo.value)
 
     def test_get_route_domain_from_cache(self, network_service, network):
         # valid cache entries


### PR DESCRIPTION
@richbrowne 

Fixes: #1242

Problem:
Agent not properly handling invalid network exceptions

Analysis:
Invalid Network creation is handled properly in the following modified files

Tests:
test_network_service.py:test_get_neutron_net_short_name
