### PR TITLE
Fix functional test failures for demo policy def in 11.5/6

### DIFF
--- a/test/functional/neutronless/esd/conftest.py
+++ b/test/functional/neutronless/esd/conftest.py
@@ -57,13 +57,13 @@ def demo_policy(request, bigip):
     mgmt_root = bigip.bigip
     name = "demo_policy"
     partition = "Common"
+
     rules = [
         dict(
             name='demo_rule',
             ordinal=0,
             actions=[],
-            conditions=[],
-            description='This is a rule description')
+            conditions=[])
     ]
 
     def teardown_policy():
@@ -74,10 +74,13 @@ def demo_policy(request, bigip):
             pol.delete()
 
     pc = mgmt_root.tm.ltm.policys
+
+    # setting legacy to True inorder for the test
+    # to work for BIGIP versions 11.5, 11.6, 12.1 and 13
+
     policy = pc.policy.create(name=name, partition=partition,
                               strategy="first-match",
-                              subPath="Drafts", rules=rules)
-    policy.publish()
+                              rules=rules, legacy=True)
     request.addfinalizer(teardown_policy)
     return policy
 


### PR DESCRIPTION
@jlongstaf 
Fixes an issue in openstack-systest-common

Problem:
test_esd.py fails because of difference between bigip 11 and bigip 12 on how to create and handle policy.

Analysis:
setting legacy to True inorder for the test to work for all versions of bigip. Also removing the description field from rule creation
Tests:
test_esd.py
