### PR TITLE
Reducing neutron footprint in the agent code

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/constants_v2.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/constants_v2.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from neutron.common import constants as q_const
+from neutron_lbaas.services.loadbalancer import constants as lb_const
+from neutron_lib import constants as plugin_const
 
 # Service resync interval
 RESYNC_INTERVAL = 300
@@ -59,3 +62,23 @@ DEVICE_HEALTH_SCORE_CPS_PERIOD = 5
 DEVICE_HEALTH_SCORE_CPS_MAX = 100
 
 DEVICE_CONNECTION_TIMEOUT = 5
+
+# Neutron-lbaas and Neutron constants
+F5_AGENT_TYPE_LOADBALANCERV2 = lb_const.AGENT_TYPE_LOADBALANCERV2
+F5_STATS_IN_BYTES = lb_const.STATS_IN_BYTES
+F5_STATS_OUT_BYTES = lb_const.STATS_OUT_BYTES
+F5_STATS_ACTIVE_CONNECTIONS = lb_const.STATS_ACTIVE_CONNECTIONS
+F5_STATS_TOTAL_CONNECTIONS = lb_const.STATS_TOTAL_CONNECTIONS
+F5_OFFLINE = lb_const.OFFLINE
+F5_ONLINE = lb_const.ONLINE
+F5_DISABLED = lb_const.DISABLED
+F5_NO_MONITOR = lb_const.NO_MONITOR
+
+F5_ACTIVE = plugin_const.ACTIVE
+F5_PENDING_CREATE = plugin_const.PENDING_CREATE
+F5_PENDING_UPDATE = plugin_const.PENDING_UPDATE
+F5_PENDING_DELETE = plugin_const.PENDING_DELETE
+F5_ERROR = plugin_const.ERROR
+
+
+F5_FLOODING_ENTRY = q_const.FLOODING_ENTRY

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/exceptions.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/exceptions.py
@@ -16,6 +16,7 @@
 import errno
 import inspect
 import logging
+from neutron_lib import exceptions as q_exception
 import os
 import re
 import sys
@@ -495,4 +496,12 @@ class F5MissingDependencies(F5AgentException):
 
 
 class RouteDomainCacheMiss(F5AgentException):
+    pass
+
+
+class F5NeutronException(q_exception.NeutronException):
+    pass
+
+
+class F5InvalidConfigurationOption(q_exception.InvalidConfigurationOption):
     pass

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/fdb_connector_ml2.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/fdb_connector_ml2.py
@@ -13,8 +13,7 @@
 # limitations under the License.
 #
 
-from neutron.common import constants as q_const
-
+from f5_openstack_agent.lbaasv2.drivers.bigip import constants_v2
 from oslo_log import log as logging
 
 from fdb_connector import FDBConnector
@@ -68,7 +67,8 @@ class FDBConnectorML2(FDBConnector):
         if self.conf.l2_population and self._l2pop_rpc:
             fdb_entries = {network['id']:
                            {'ports':
-                            {vtep_ip_address: [q_const.FLOODING_ENTRY]},
+                            {vtep_ip_address:
+                                [constants_v2.F5_FLOODING_ENTRY]},
                             'network_type': network['provider:network_type'],
                             'segment_id': network['provider:segmentation_id']}}
             self._l2pop_rpc.add_fdb_entries(self._context, fdb_entries)
@@ -79,7 +79,8 @@ class FDBConnectorML2(FDBConnector):
         if self.conf.l2_population and self._l2pop_rpc:
             fdb_entries = {network['id']:
                            {'ports':
-                            {vtep_ip_address: [q_const.FLOODING_ENTRY]},
+                            {vtep_ip_address:
+                                [constants_v2.F5_FLOODING_ENTRY]},
                             'network_type': network['provider:network_type'],
                             'segment_id': network['provider:segmentation_id']}}
             self._l2pop_rpc.remove_fdb_entries(self._context, fdb_entries)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
@@ -17,11 +17,9 @@ import itertools
 import netaddr
 from requests import HTTPError
 
-from neutron.plugins.common import constants as plugin_const
-from neutron_lib.exceptions import NeutronException
-
 from oslo_log import log as logging
 
+from f5_openstack_agent.lbaasv2.drivers.bigip import constants_v2
 from f5_openstack_agent.lbaasv2.drivers.bigip import exceptions as f5_ex
 from f5_openstack_agent.lbaasv2.drivers.bigip.l2_service import \
     L2ServiceBuilder
@@ -702,7 +700,7 @@ class NetworkServiceBuilder(object):
             return
 
         if loadbalancer.get('provisioning_status', None) == \
-                plugin_const.PENDING_DELETE:
+                constants_v2.F5_PENDING_DELETE:
             delete_loadbalancer = loadbalancer
         else:
             update_loadbalancer = loadbalancer
@@ -712,7 +710,7 @@ class NetworkServiceBuilder(object):
             member['network'] = service_adapter.get_network_from_service(
                 service, member['network_id'])
             if member.get('provisioning_status', None) == \
-                    plugin_const.PENDING_DELETE:
+                    constants_v2.F5_PENDING_DELETE:
                 delete_members.append(member)
             else:
                 update_members.append(member)
@@ -752,7 +750,7 @@ class NetworkServiceBuilder(object):
                 for in_use_subnetid in my_in_use_subnets:
                     subnet_hints['check_for_delete_subnets'].pop(
                         in_use_subnetid, None)
-            except NeutronException as exc:
+            except f5_ex.F5NeutronException as exc:
                 LOG.error("assure_delete_nets_shared: exception: %s"
                           % str(exc.msg))
             except Exception as exc:
@@ -828,7 +826,7 @@ class NetworkServiceBuilder(object):
                         bigip.assured_tenant_snat_subnets[tenant_id]
                     if subnet['id'] in tenant_snat_subnets:
                         tenant_snat_subnets.remove(subnet['id'])
-            except NeutronException as exc:
+            except f5_ex.F5NeutronException as exc:
                 LOG.error("assure_delete_nets_nonshared: exception: %s"
                           % str(exc.msg))
             except Exception as exc:
@@ -936,7 +934,7 @@ class NetworkServiceBuilder(object):
         loadbalancer = service['loadbalancer']
         service_adapter = self.service_adapter
         lb_status = loadbalancer['provisioning_status']
-        if lb_status != plugin_const.PENDING_DELETE:
+        if lb_status != constants_v2.F5_PENDING_DELETE:
             if 'network_id' in loadbalancer:
                 network = service_adapter.get_network_from_service(
                     service,
@@ -951,7 +949,7 @@ class NetworkServiceBuilder(object):
                                           'is_for_member': False}
 
         for member in service['members']:
-            if member['provisioning_status'] != plugin_const.PENDING_DELETE:
+            if member['provisioning_status'] != constants_v2.F5_PENDING_DELETE:
                 if 'network_id' in member:
                     network = service_adapter.get_network_from_service(
                         service,

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
@@ -19,8 +19,6 @@ from oslo_log import log as logging
 import oslo_messaging as messaging
 
 from neutron.common import rpc
-from neutron.plugins.common import constants as plugin_const
-from neutron_lbaas.services.loadbalancer import constants as lb_const
 
 from f5_openstack_agent.lbaasv2.drivers.bigip import constants_v2 as constants
 
@@ -129,8 +127,8 @@ class LBaaSv2PluginRPC(object):
     @log_helpers.log_method_call
     def update_listener_status(self,
                                listener_id,
-                               provisioning_status=plugin_const.ERROR,
-                               operating_status=lb_const.OFFLINE):
+                               provisioning_status=constants.F5_ERROR,
+                               operating_status=constants.F5_OFFLINE):
         """Update the database with listener status."""
         return self._cast(
             self.context,
@@ -154,8 +152,8 @@ class LBaaSv2PluginRPC(object):
     @log_helpers.log_method_call
     def update_pool_status(self,
                            pool_id,
-                           provisioning_status=plugin_const.ERROR,
-                           operating_status=lb_const.OFFLINE):
+                           provisioning_status=constants.F5_ERROR,
+                           operating_status=constants.F5_OFFLINE):
         """Update the database with pool status."""
         return self._cast(
             self.context,
@@ -205,8 +203,8 @@ class LBaaSv2PluginRPC(object):
     def update_health_monitor_status(
             self,
             health_monitor_id,
-            provisioning_status=plugin_const.ERROR,
-            operating_status=lb_const.OFFLINE):
+            provisioning_status=constants.F5_ERROR,
+            operating_status=constants.F5_OFFLINE):
         """Update the database with health_monitor status."""
         return self._cast(
             self.context,
@@ -232,8 +230,8 @@ class LBaaSv2PluginRPC(object):
             self,
             l7rule_id,
             l7policy_id,
-            provisioning_status=plugin_const.ERROR,
-            operating_status=lb_const.OFFLINE):
+            provisioning_status=constants.F5_ERROR,
+            operating_status=constants.F5_OFFLINE):
         return self._cast(
             self.context,
             self._make_msg('update_l7rule_status',
@@ -258,8 +256,8 @@ class LBaaSv2PluginRPC(object):
     def update_l7policy_status(
             self,
             l7policy_id,
-            provisioning_status=plugin_const.ERROR,
-            operating_status=lb_const.OFFLINE):
+            provisioning_status=constants.F5_ERROR,
+            operating_status=constants.F5_OFFLINE):
         return self._cast(
             self.context,
             self._make_msg('update_l7policy_status',

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/conftest.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/conftest.py
@@ -19,7 +19,7 @@ import pytest
 import sys
 import uuid
 
-from neutron.plugins.common import constants as plugin_const
+from f5_openstack_agent.lbaasv2.drivers.bigip import constants_v2
 
 
 class TestingWithServiceConstructor(object):
@@ -125,7 +125,7 @@ class TestingWithServiceConstructor(object):
             dict(admin_state_up=True, description='', gre_vteps=[],
                  id=new_id, listeners=[], name='lb1', network_id=network_id,
                  operating_status='OFFLINE', provider=None, vip_port=vip_port,
-                 provisioning_status=plugin_const.PENDING_CREATE,
+                 provisioning_status=constants_v2.F5_PENDING_CREATE,
                  vip_address=vip_address, dns_name=None,
                  dns_assignment=[dns_assignment],
                  tenant_id=tenant_id, vip_id=vip_port['id'],
@@ -147,14 +147,14 @@ class TestingWithServiceConstructor(object):
         lb['listeners'].append(new_id)
         tenant_id = lb['tenant_id']
         lb_id = lb['id']
-        lb['provisioning_status'] = plugin_const.PENDING_UPDATE
+        lb['provisioning_status'] = constants_v2.F5_PENDING_UPDATE
         new_listener = \
             dict(admin_state_up=True, connection_limit=-1,
                  default_pool_id=None, default_tls_container_id=None,
                  description='', id=new_id, loadbalaner_id=lb_id,
                  name='l1', operating_status='OFFLINE', protocol='HTTP',
                  protocol_port=8080, sni_containers=[], tenant_id=tenant_id,
-                 provisioning_status=plugin_const.PENDING_CREATE)
+                 provisioning_status=constants_v2.F5_PENDING_CREATE)
         svc['listeners'].append(new_listener)
         return svc
 
@@ -195,9 +195,9 @@ class TestingWithServiceConstructor(object):
         li = svc['listeners'][0]
         tenant_id = li['tenant_id']
         li['default_pool_id'] = new_id
-        li['provisioning_status'] = plugin_const.PENDING_UPDATE
+        li['provisioning_status'] = constants_v2.F5_PENDING_UPDATE
         new_pool = {'id': new_id, 'listeners': [dict(id=li['id'])],
-                    'provisioning_status': plugin_const.PENDING_CREATE,
+                    'provisioning_status': constants_v2.F5_PENDING_CREATE,
                     'tenant_id': tenant_id}
         svc['pools'].append(new_pool)
         return svc

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager_LbaasAgentManager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager_LbaasAgentManager.py
@@ -20,7 +20,7 @@ import pytest
 from mock import Mock
 from mock import patch
 
-from neutron.plugins.common import constants as plugin_const
+from f5_openstack_agent.lbaasv2.drivers.bigip import constants_v2
 
 import f5_openstack_agent.lbaasv2.drivers.bigip.agent_manager as agent_manager
 import f5_openstack_agent.lbaasv2.drivers.bigip.plugin_rpc as plugin_rpc
@@ -311,32 +311,32 @@ class TestLbaasAgentManager(TestLbaasAgentManagerBuilder):
         def reset_svc(svc):
             listener = svc['listeners'][0]
             loadbalancer = svc['loadbalancer']
-            listener['provisioning_status'] = plugin_const.ACTIVE
-            loadbalancer['provisioning_status'] = plugin_const.ACTIVE
+            listener['provisioning_status'] = constants_v2.F5_ACTIVE
+            loadbalancer['provisioning_status'] = constants_v2.F5_ACTIVE
 
         def negative_list_scenario(target, svc):
             reset_svc(svc)
-            svc['listeners'][0]['provisioning_status'] = plugin_const.ERROR
+            svc['listeners'][0]['provisioning_status'] = constants_v2.F5_ERROR
             assert target.has_provisioning_status_of_error(svc)
             assert svc['loadbalancer']['provisioning_status'] == \
-                plugin_const.ERROR
+                constants_v2.F5_ERROR
 
         def negative_dict_scenario(target, svc):
             reset_svc(svc)
-            svc['loadbalancer']['provisioning_status'] = plugin_const.ERROR
+            svc['loadbalancer']['provisioning_status'] = constants_v2.F5_ERROR
             assert target.has_provisioning_status_of_error(svc)
             assert svc['loadbalancer']['provisioning_status'] == \
-                plugin_const.ERROR
+                constants_v2.F5_ERROR
 
         def awkward_network_nest(target, svc):
             reset_svc(svc)
-            svc['loadbalancer']['provisioning_status'] = plugin_const.ERROR
+            svc['loadbalancer']['provisioning_status'] = constants_v2.F5_ERROR
             listener_id = svc['listeners'][0]['id']
             awkward = {listener_id: svc['listeners'][0]}
             svc['listeners'][0] = awkward
             assert target.has_provisioning_status_of_error(svc)
             assert svc['loadbalancer']['provisioning_status'] == \
-                plugin_const.ERROR
+                constants_v2.F5_ERROR
 
         negative_list_scenario(target_class, svc)
         negative_dict_scenario(target_class, svc)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_icontrol_driver.py
@@ -21,8 +21,7 @@ from mock import Mock
 from mock import patch
 from requests import HTTPError
 
-import neutron.plugins.common.constants as plugin_const
-import neutron_lbaas.services.loadbalancer.constants as lb_const
+from f5_openstack_agent.lbaasv2.drivers.bigip import constants_v2
 
 import f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver as target_mod
 import f5_openstack_agent.lbaasv2.drivers.bigip.resource_helper
@@ -260,19 +259,19 @@ class TestiControlDriverMocker(object):
     @classmethod
     @pytest.fixture
     def svc_obj_pending_update(cls):
-        svc_obj = cls.basic_svc_obj(plugin_const.PENDING_UPDATE)
+        svc_obj = cls.basic_svc_obj(constants_v2.F5_PENDING_UPDATE)
         return [svc_obj]
 
     @classmethod
     @pytest.fixture
     def svc_obj_pending_create(cls):
-        svc_obj = cls.basic_svc_obj(plugin_const.PENDING_CREATE)
+        svc_obj = cls.basic_svc_obj(constants_v2.F5_PENDING_CREATE)
         return [svc_obj]
 
     @classmethod
     @pytest.fixture
     def svc_obj_active(cls):
-        svc_obj = cls.basic_svc_obj(plugin_const.ACTIVE)
+        svc_obj = cls.basic_svc_obj(constants_v2.F5_ACTIVE)
         return [svc_obj]
 
     @staticmethod
@@ -345,7 +344,7 @@ class TestiControlDriverMocker(object):
             called_method = getattr(target.plugin_rpc, test_method)
             args_list = called_method.call_args_list
             assert called_method.call_count == 3
-            all(map(lambda x: lb_const.ONLINE in x, args_list))
+            all(map(lambda x: constants_v2.F5_ONLINE in x, args_list))
 
     @pytest.fixture
     def mock_resource_helper(self, request):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_listener_services.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_listener_services.py
@@ -18,7 +18,7 @@ import pytest
 
 from mock import Mock
 
-from neutron.plugins.common import constants as plugin_const
+from f5_openstack_agent.lbaasv2.drivers.bigip import constants_v2
 from requests import HTTPError
 
 import f5_openstack_agent.lbaasv2.drivers.bigip.listener_service \
@@ -64,9 +64,9 @@ class TestListenerServiceBuilderConstructor(ct.TestingWithServiceConstructor):
     @staticmethod
     def creation_mode_listener(svc, listener):
         svc['listener'] = listener
-        svc['listener']['provisioning_status'] = plugin_const.PENDING_CREATE
+        svc['listener']['provisioning_status'] = constants_v2.F5_PENDING_CREATE
         svc['loadbalancer']['provisioning_status'] = \
-            plugin_const.PENDING_UPDATE
+            constants_v2.F5_PENDING_UPDATE
 
 
 class TestListenerServiceBuilderBuilder(TestListenerServiceBuilderConstructor):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_pool_services.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_pool_services.py
@@ -19,7 +19,7 @@ import urllib
 
 from mock import Mock
 
-from neutron.plugins.common import constants as plugin_const
+from f5_openstack_agent.lbaasv2.drivers.bigip import constants_v2
 from requests import HTTPError
 
 import f5_openstack_agent.lbaasv2.drivers.bigip.pool_service \
@@ -65,9 +65,9 @@ class TestPoolServiceBuilderConstructor(ct.TestingWithServiceConstructor):
     @staticmethod
     def creation_mode_pool(svc, pool):
         svc['pool'] = pool
-        svc['pool']['provisioning_status'] = plugin_const.PENDING_CREATE
+        svc['pool']['provisioning_status'] = constants_v2.F5_PENDING_CREATE
         svc['loadbalancer']['provisioning_status'] = \
-            plugin_const.PENDING_UPDATE
+            constants_v2.F5_PENDING_UPDATE
 
 
 class TestPoolServiceBuilderBuilder(TestPoolServiceBuilderConstructor):


### PR DESCRIPTION
@jlongstaf 
Fixes: #1261

Problem:
There are neutron imports throughout the agent code and we need to move them into one file.

Analysis:
This change moves all the neutron constants to F5 agent constants file. Also it moves the neutron exceptions to F5 agent exception file.
The changes are made in both unit tests as well as bigip/ directory.

Tests:
To test the changes, I started my local agent on my stack and ran the community api and scenario tests as well as systest-common api and scenario tests. I also ran the agent functional tests against a bigip. All of the results are consistent with the trtl results.

@<reviewer_id>
#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?
