### PR TITLE
Agent portability feature implementation

### DIFF
--- a/requirements.functest.txt
+++ b/requirements.functest.txt
@@ -1,27 +1,11 @@
 -e .
 
-# OpenStack dependencies, Za doesn't know how pip-over-git interacts with
-# constraints.txt's .
 git+https://github.com/openstack/neutron@newton-eol
 git+https://github.com/openstack/neutron-lbaas.git@newton-eol
 
-# F5 LBaaS dependancies
-git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@stable/newton
-
-# COMMUNITY CONSTRAINED SECTION
-# Community constrained packages, packages specified here MUST not specify a
-# version.  The versions of these packages are specified at the constraints
-# URL.  If you add a version here it will be ignored, and therefore be
-# misleading to readers of this file.
-#
-# NOTE: As of 26-OCT-2017, upper-constraints is still at stable/newton, not newton-eol. This
-# is likely to change.
--c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/newton
-
-git+https://github.com/openstack/oslo.log.git@newton-eol
-pytest==IGNORED    # See section comment
-mock==IGNORED      # See section comment
-coverage==IGNORED  # See section comment
+mock==2.0.0
+ coverage==4.2
+ pytest==3.0.1
 
 # Test utilities
 pytest-cov>=2.4.0,<3

--- a/requirements.unittest.txt
+++ b/requirements.unittest.txt
@@ -2,23 +2,12 @@
 
 # app
 git+https://github.com/openstack/neutron@newton-eol
-git+https://github.com/openstack/oslo.log.git@newton-eol
 git+https://github.com/openstack/neutron-lbaas.git@newton-eol
-git+https://github.com/F5Networks/f5-openstack-lbaasv2-driver.git@stable/newton
 
 pytest-cov==2.5.1
 python-coveralls==2.9.1
 
-# COMMUNITY CONSTRAINED SECTION
-# Community constrained packages, packages specified here MUST not specify a
-# version.  The versions of these packages are specified at the constraints
-# URL.  If you add a version here it will be ignored, and therefore be
-# misleading to readers of this file.
-#
-# NOTE: As of 26-OCT-2017, upper-constraints is still at stable/newton, not newton-eol. This
-# is likely to change.
--c https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt?h=stable/newton
 
-mock==IGNORED      # See section comment
-coverage==IGNORED  # See section comment
-pytest==IGNORED    # See section comment
+mock==2.0.0
+ coverage==4.2
+ pytest==3.0.1


### PR DESCRIPTION
@jlongstaf 
Fixes: #1266

Problem:
As part of implementing agent portability feature, we need to remove the dependency to the openstack releases from the requirement files.
Analysis:
After running tests against both unit tests and functional tests requirement files, I modified the files so that we get only the required packages.

Tests:
unit tests and functional tests. I ran these tests for both newton and mitaka branches in master branch.

@<reviewer_id>
#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?
