### PR TITLE
Fixing ESD error in the agent log file

### DIFF
--- a/etc/neutron/services/f5/esd/demo.json
+++ b/etc/neutron/services/f5/esd/demo.json
@@ -5,7 +5,7 @@
     "lbaas_cssl_profile": "clientssl",
     "lbaas_sssl_profile": "serverssl",
     "lbaas_irule": ["_sys_https_redirect"],
-    "lbaas_policy": ["demo_policy"],
+    "lbaas_policy": [],
     "lbaas_persist": "hash",
     "lbaas_fallback_persist": "source_addr"
   },


### PR DESCRIPTION
Issues: fixing ESD error in the agent log file.
Fixes #<issueid>

Problem: The value of "lbaas_policy" in the demo.json file under
docker/agent-1/esd/ was responsible for ESD error in the agent log
file

Analysis: The issue was fixed by removing the value of the key "lbaas_policy"
in the demo.json file. After making the changes, the agents were restarted
and there were no more issues/errors in the agent log files.

Tests: Issued commands like creating loadbalancer in the neutron cli and
all the commands were executed without any issues/errors.

@jlongstaf 
#### What issues does this address? Errors related to ESD in agent log file.
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?
Fixing ESD error in the agent log file.

#### Where should the reviewer start?

#### Any background context?
