### PR TITLE
Fixes Agent startup issues

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -305,8 +305,6 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
         # Setup RPC for communications to and from controller
         self._setup_rpc()
 
-        # Set driver context for RPC.
-        lbdriver.set_context(self.context)
         # Allow the driver to make callbacks to the LBaaS driver plugin
         lbdriver.set_plugin_rpc(self.plugin_rpc)
         # Allow the driver to force and agent state report to the controller

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1021,11 +1021,6 @@ class iControlDriver(LBaaSBaseDriver):
             return highest_metric
         return 0
 
-    def set_context(self, context):
-        # Context to keep for database access
-        if self.network_builder:
-            self.network_builder.set_context(context)
-
     def set_plugin_rpc(self, plugin_rpc):
         # Provide Plugin RPC access
         self.plugin_rpc = plugin_rpc

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
@@ -922,9 +922,6 @@ class NetworkServiceBuilder(object):
     def update_bigip_fdb(self, bigip, fdb):
         self.l2_service.update_bigip_fdb(bigip, fdb)
 
-    def set_context(self, context):
-        self.l2_service.set_context(context)
-
     def vlan_exists(self, bigip, network, folder='Common'):
         return self.vlan_manager.exists(bigip, name=network, partition=folder)
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/network_cache_handler.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/network_cache_handler.py
@@ -98,6 +98,9 @@ class NetworkCacheHandler(cache.CacheBase):
                         partition == tunnel.partition:
                     retval = self.__existing_tunnels.pop(cnt)
                     break
+        else:
+            raise ValueError("Cannot operate without name & partition or "
+                             "tunnel")
         return retval
 
     @handle_weakref

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/test/test_fdb_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/test/test_fdb_builder.py
@@ -32,6 +32,37 @@ from ...test.mock_builder_base_class import MockBuilderBase
 target_mod = 'f5_openstack_agent.lbaasv2.drivers.bigip.tunnels.fdb.FdbBuilder'
 
 
+class TestFdbMockBuilder(MockBuilderBase):
+    """This is the MockBuilder for the Fdb object
+
+    This follows the standard mock factory framework for unit testing in the
+    agent.
+    """
+    @mock.patch('f5_openstack_agent.lbaasv2.drivers.bigip.tunnels.fdb.'
+                'Fdb.__init__')
+    def mocked_target(self, init):
+        """Creates and returns a mocked Fdb object"""
+        init.return_value = None
+        return fdb.Fdb()
+
+    def fully_mocked_target(self, mocked_target):
+        """Creates and returns a fully mocked Fdb object"""
+        mocked_target._Fdb__ip_address = '192.168.1.6'
+        mocked_target._Fdb__segment_id = 33
+        mocked_target._Fdb__mac_address = 'ma:ca:dd:re:ss:es'
+        mocked_target._Fdb__vtep_ip = '10.22.22.6'
+        mocked_target._Fdb__network_type = 'vxlan'
+        return mocked_target
+
+    def set_network_id(self, target, network_id):
+        """Wrapper to set the target's network_id bypassing prod"""
+        target._Fdb__network_id = network_id
+
+    def set_network_type(self, target, m_type):
+        """Wrapper to set the target's network_type bypassing prod"""
+        target._Fdb__network_type = m_type
+
+
 class TestFdbBuilderMockBuilder(MockBuilderBase):
     """This is the MockBuilder for the FdbBuilder object
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/test/test_tunnel.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/test/test_tunnel.py
@@ -25,29 +25,53 @@ import f5_openstack_agent.lbaasv2.drivers.bigip.tunnels.tunnel as target_mod
 from ...test.class_tester_base_class import ClassTesterBase
 from ...test.conftest import TestingWithServiceConstructor
 from ...test.mock_builder_base_class import MockBuilderBase
+from .test_fdb_builder import TestFdbMockBuilder
 from .test_network_cache_handler import TestNetworkCacheHandlerMockBuilder
 
 
 class TestTunnelMockBuilder(MockBuilderBase):
     """Hosts a MockBuilder for Tunnels"""
-    _other_builders = {
-        '_TunnelHandler__network_cache_handler':
-        TestNetworkCacheHandlerMockBuilder}
+    _other_builders = {}
 
-    @mock.patch('f5_openstack_agent.lbaasv2.drivers.bigip.tunnels.tunnel.'
-                'Tunnel.__init__')
-    def mock_target(self, init):
+    @mock.patch("{}.Tunnel.__init__".format(target_mod.__name__))
+    def mocked_target(self, init):
+        """Creates a mocked Tunnel object"""
         init.return_value = None
-        return target_mod.TunnelHandler()
+        return target_mod.Tunnel(1, 2, 3, 4, 5, 6, 7)
 
     def fully_mocked_target(self, mocked_target):
+        """Creates a fully-mocked Tunnel object"""
         mocked_target._CacheBase__lock_acquired = mock.Mock()
-        mocked_target._CacheBase__mechanism = mock.Mock()
+        mechanism = mock.Mock()
+        mechanism.__exit__ = mock.Mock()
+        mechanism.__enter__ = mock.Mock()
+        mechanism.__enter__.return_value = mechanism
+        mocked_target._CacheBase__mechanism = mechanism
         mocked_target._CacheBase__workers_waiting = mock.Mock()
         mocked_target._CacheBase__workers_locks = mock.Mock()
         mocked_target._CacheBase__my_pid = 33
-        super(TestTunnelMockBuilder, self).fully_mocked_target(mocked_target)
+        mocked_target._Tunnel__local_address = '192.168.1.1'
+        mocked_target._Tunnel__remote_address = '10.22.22.1'
+        mocked_target._Tunnel__bigip_host = 'host'
+        mocked_target._Tunnel__segment_id = 33
+        mocked_target._Tunnel__tunnel_type = 'vxlan'
+        mocked_target._Tunnel__partition = 'vxlan'
+        mocked_target._Tunnel__exists = False
+        mocked_target._Tunnel__fdbs = []
+        mocked_target.logger = mock.Mock()
         return mocked_target
+
+    def set_partition(self, target, partition):
+        """Sets the partition on the target Tunnel object"""
+        target._Tunnel__partition = partition
+
+    def set_network_id(self, target, network_id):
+        """Sets the network_id on the target Tunnel object"""
+        target._Tunnel__network_id = network_id
+
+    def add_fdb(self, target, fdb):
+        """Bypasses production in adding an fdb to the provided target"""
+        target._Tunnel__fdbs.append(fdb)
 
 
 class TestTunnelHandlerMockBuilder(MockBuilderBase,
@@ -57,13 +81,14 @@ class TestTunnelHandlerMockBuilder(MockBuilderBase,
         '_TunnelHandler__network_cache_handler':
         TestNetworkCacheHandlerMockBuilder}
 
-    @mock.patch('f5_openstack_agent.lbaasv2.drivers.bigip.tunnels.tunnel.'
-                'TunnelHandler.__init__')
+    @mock.patch("{}.TunnelHandler.__init__".format(target_mod.__name__))
     def mocked_target(self, init):
+        """Creates a mocked TunnelHandler"""
         init.return_value = None
         return target_mod.TunnelHandler()
 
     def fully_mocked_target(self, mocked_target):
+        """Creates a fully mocked TunnelHandler"""
         mocked_target._CacheBase__lock_acquired = mock.Mock()
         mocked_target._CacheBase__mechanism = mock.Mock()
         mocked_target._CacheBase__mechanism.__enter__ = mock.Mock()
@@ -82,14 +107,48 @@ class TestTunnelHandlerMockBuilder(MockBuilderBase,
             mocked_target)
         return mocked_target
 
+    def add_pending_exists(self, target, tunnel):
+        """Adds a tunnel to the pending_exists array on the target"""
+        target._TunnelHandler__pending_exists.append(tunnel)
+
 
 class TestTunnelMocker(object):
     @pytest.fixture
     def mock_bigip(self):
+        """Creates a mock BIG-IP"""
         return mock.Mock()
 
     @pytest.fixture
+    def tunnel_mock_builder(self):
+        """Establishes a test-instance based TestTunnelMockBuilder"""
+        self.tunnel_builder = TestTunnelMockBuilder()
+        return self.tunnel_builder
+
+    @pytest.fixture
+    def fully_mocked_tunnel(self, tunnel_mock_builder):
+        """Creates and returns a fully-mocked Tunnel object"""
+        return tunnel_mock_builder.new_fully_mocked_target()
+
+    @pytest.fixture
+    def fdb_mock_builder(self):
+        """Establishes a test-instance based FdbMockBuilder"""
+        self.fdb_builder = TestFdbMockBuilder()
+        return self.fdb_builder
+
+    @pytest.fixture
+    def fully_mocked_fdb(self, fdb_mock_builder):
+        return fdb_mock_builder.new_fully_mocked_target()
+
+    @pytest.fixture
     def mock_bigip_with_multipoint_vxlan_tunnel_profile(self, mock_bigip):
+        """Creates a mock multipoint vxlan tunnel on a mock BIG-IP
+
+        Shortcuts:
+            mock_bigip.multipoint_tunnel is
+                mock_bigip.tm.net.tunnels.vxlans.vxlan.load()
+            mock_bigip.tm_multipoint is
+                mock_bigip.tm.net.tunnels.vxlans.vxlan
+        """
         multipoint = mock.Mock()
         mock_bigip.tm.net.tunnels.vxlans.vxlan.create.return_value = \
             multipoint
@@ -102,6 +161,20 @@ class TestTunnelMocker(object):
     @pytest.fixture
     def mock_bigip_with_vxlan_tunnel(
             self, mock_bigip_with_multipoint_vxlan_tunnel_profile):
+        """Makes referencing tunnel access points on a bigip mock easier
+
+        Shortcuts:
+            mock_bigip.tm_fdb_tunnel is mock_bigip.tm.net.fdb.tunnels.tunnel
+            mock_bigip.fdb_tunnel is
+                mock_bigip.tm.net.fdb.tunnels.tunnel.load()
+            mock_bigip.tm_tunnel is mock_bigip.tm.net.tunnels.tunnels.tunnel
+            mock_bigip.tunnel is
+                mock_bigip.tm.net.tunnels.tunnels.tunnel.load()
+            mock_bigip.arp is
+                mock_bigip.tm.net.arps.arp.load()
+            mock_bigip.tm_arp is
+                mock_bigip.tm.net.arps.arp
+        """
         bigip = mock_bigip_with_multipoint_vxlan_tunnel_profile
         fdb_tunnel = mock.Mock()
         tunnel = mock.Mock()
@@ -128,6 +201,10 @@ class TestTunnelMocker(object):
 
     @pytest.fixture
     def mock_bigip_without_vxlan_fdbs(self, mock_bigip_with_vxlan_tunnel):
+        """Dopes a BIG-IP without an fdb tunnel for easy access
+
+        Places existential returns as False
+        """
         bigip = mock_bigip_with_vxlan_tunnel
         bigip.tm_tunnel.exists.return_value = False
         bigip.tm_fdb_tunnel.exists.return_value = False
@@ -136,6 +213,11 @@ class TestTunnelMocker(object):
 
     @pytest.fixture
     def mock_bigip_with_vxlan_fdbs(self, mock_bigip_with_vxlan_tunnel):
+        """Dopes a BIG-IP with all necessary vxlan fdb tunnel levels
+
+        Places existential returns as True for tunnels and multipoint profiles
+        Places [object] get_collection returns for ""
+        """
         bigip = mock_bigip_with_vxlan_tunnel
         bigip.tm_tunnel.exists.return_value = True
         bigip.tm_fdb_tunnel.exists.return_value = True
@@ -151,6 +233,11 @@ class TestTunnelMocker(object):
 
     @pytest.fixture
     def mock_bigip_with_vxlan_arp(self, mock_bigip_with_vxlan_fdbs):
+        """Dopes a BIG-IP with all necessary ARP levels
+
+        Places existential returns as True for arp
+        Places [object] get_collection returns for arp
+        """
         bigip = mock_bigip_with_vxlan_fdbs
         bigip.tm.net.arps.arp.exists.return_value = True
         bigip.tm.net.arps.get_collection.return_value = [bigip.arp]
@@ -162,6 +249,13 @@ class TestTunnel(ClassTesterBase, TestTunnelMocker):
 
     def test_agent_init(self, standalone_builder, fully_mocked_target,
                         mock_bigip_with_vxlan_arp):
+        """This populates the network cache via agent's init
+
+        This test will test the auto-doping of the network cache from what is
+        stored on the BIG-IP.  This unit tests is a standalone test; however,
+        it simulates what the SDK's ManagementRoot object would do.  Thus,
+        this test should be quite close to a functional test in this arena.
+        """
         bigip = mock_bigip_with_vxlan_arp
         tunnel = bigip.tunnel
         tunnel.name = 'vxlan_tunnel'
@@ -194,3 +288,34 @@ class TestTunnel(ClassTesterBase, TestTunnelMocker):
         assert \
             target._TunnelHandler__network_cache_handler.\
             _NetworkCacheHandler__network_cache
+
+    def test_bb_tunnel_remove(self, standalone_builder, fully_mocked_target,
+                              mock_bigip_with_vxlan_arp,
+                              fully_mocked_tunnel, fully_mocked_fdb):
+        """This test will perform all necessary tasks on deleting a tunnel
+
+        This test will perform the following:
+            1. Dope a 'bigip' mock object with a vxlan tunnel
+            2. Dope the TunnelHandler with the same tunnel
+            3. Remove the tunnel from the TunnelHandler
+        As part of this, this tests the scenario where the tunnel does not yet
+        exist.
+        """
+        target = fully_mocked_target
+        bigip = mock_bigip_with_vxlan_arp
+        tunnel_obj = fully_mocked_tunnel
+        fdb_obj = fully_mocked_fdb
+        partition = 'partition'
+        self.tunnel_builder.set_partition(tunnel_obj, partition)
+        self.tunnel_builder.add_fdb(tunnel_obj, fdb_obj)
+        self.tunnel_builder.set_network_id(tunnel_obj, 'network_id')
+        self.fdb_builder.set_network_id(fdb_obj, 'network_id')
+        standalone_builder.add_pending_exists(target, tunnel_obj)
+        target.remove_multipoint_tunnel(bigip, tunnel_obj.tunnel_name,
+                                        partition)
+        tm_tunnel = bigip.tm_tunnel
+        tunnel = bigip.tunnel
+        arp = bigip.arp
+        assert tm_tunnel.load.call_count
+        assert tunnel.delete.call_count
+        assert arp.delete.call_count

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
@@ -717,6 +717,7 @@ class TunnelHandler(cache.CacheBase):
         self.__multipoint_profiles = []
         self.__pending_exists = []
         self.__profiles = []
+        super(TunnelHandler, self).__init__()
 
     @staticmethod
     def _get_bigips_by_hostname(bigips):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
@@ -211,8 +211,6 @@ class Tunnel(cache.CacheBase):
         elif isinstance(fdbs, list):
             pass
         elif isinstance(fdbs, fdb_mod.Fdb):
-            import pdb
-            pdb.set_trace()
             if not self.exists:
                 self.__fdbs.append(fdb)
             add_fdb(fdb)
@@ -228,24 +226,28 @@ class Tunnel(cache.CacheBase):
         """
         def remove_fdb(fdb):
             self.logger.debug("{}: removing {}".format(self.tunnel_name, fdb))
-            TunnelBuilder.remove_fdb_from_tunnel(bigip, self, fdb)
-            fdb_mod.FdbBuilder.remove_arp(bigip, fdb)
+            TunnelBuilder.remove_record_from_arp(bigip, self, fdb)
+            fdb_mod.FdbBuilder.remove_fdb_from_arp(bigip, self, fdb)
             self.__fdbs = filter(lambda x: x.mac_address != fdb.mac_address,
                                  self.__fdbs)
 
         if isinstance(fdbs, list) and fdbs and \
                 isinstance(fdbs[0], fdb_mod.Fdb):
             for fdb in fdbs:
-                remove_fdb(fdb)
+                remove_fdb(fdbs)
         elif isinstance(fdbs, list):
             for fdb in self.__fdbs:
                 remove_fdb(fdb)
-        elif isinstance(fdbs, fdb_mod.Fb):
-            remove_fdb(fdb)
+        elif isinstance(fdbs, fdb_mod.Fdb):
+            remove_fdb(fdbs)
 
     @property
     def fdbs(self):
         return self.__fdbs
+
+    @property
+    def profile(self):
+        return "{}_ovs".format(self.tunnel_type)
 
     @property
     def key(self):
@@ -293,6 +295,8 @@ class TunnelBuilder(object):
     @staticmethod
     def __tm_tunnel(bigip, tunnel, action):
         # performs all actions on tm_tunnel by action
+        def execute(actions, action):
+            return actions[action]['method'](**actions[action]['payload'])
         tm_tunnel = bigip.tm.net.tunnels.tunnel
         description = json.dumps(
             dict(partition=tunnel.partition, network_id=tunnel.network_id,
@@ -307,11 +311,15 @@ class TunnelBuilder(object):
         actions = {'create': dict(payload=create_payload,
                                   method=tm_tunnel.create),
                    'delete': dict(payload=load_payload,
-                                  method=tm_tunnel.delete),
+                                  method=tm_tunnel.load),
                    'exists': dict(payload=load_payload,
                                   method=tm_tunnel.exists)}
-        execute = actions[action]
-        return execute['method'](**execute['payload'])
+        result = execute(actions, action)
+        second_actions = {'delete': dict(payload={},
+                                         method=result.delete)}
+        if action in second_actions:
+            result = execute(second_actions, action)
+        return result
 
     @staticmethod
     def __tm_multipoints(bigip, action, tunnel_type='vxlan'):
@@ -325,7 +333,8 @@ class TunnelBuilder(object):
 
     @staticmethod
     def __tm_multipoint(bigip, tunnel_type, name, partition, action):
-        # performs all actions on tm_multipoint by action
+        def execute(actions, action):
+            return actions[action]['method'](**actions[action]['payload'])
         default_profiles = {'gre': {'name': None,
                                     'partition': const.DEFAULT_PARTITION,
                                     'defaultsFrom': 'gre',
@@ -348,11 +357,13 @@ class TunnelBuilder(object):
         actions = {'create': dict(
                        payload=create_tunnel, method=tm_multipoint.create),
                    'delete': dict(
-                       payload=tunnel, method=tm_multipoint.delete),
+                       payload=tunnel, method=tm_multipoint.load),
                    'exists': dict(
                        payload=tunnel, method=tm_multipoint.exists)}
-        execute = actions[action]
-        return execute['method'](**execute['payload'])
+        result = execute(actions, action)
+        second_actions = {'delete': {'payload': {}, 'method': result.delete}}
+        if action in second_actions:
+            result = execute(second_actions, action)
 
     @staticmethod
     def __tm_tunnels(bigip, action, partition=None):
@@ -624,6 +635,13 @@ class TunnelBuilder(object):
                     "not have the associated tunnel... creating it ({}, {})".
                     format(tunnel, fdb))
                 cls.create_tunnel
+
+    @classmethod
+    @wrappers.http_error(
+        debug={404: "Attempted delete on non-existent record"})
+    def remove_record_from_arp(cls, bigip, tunnel, fdb):
+        record = fdb.record
+        cls.__tm_fdb_tunnel(bigip, tunnel, 'delete_record', record=record)
 
     @classmethod
     # @_check_if_fdbs
@@ -907,11 +925,11 @@ class TunnelHandler(cache.CacheBase):
             None
         """
         tunnel = self.__network_cache_handler.remove_tunnel(
-            bigip.hostname, name=name, partiiton=partition)  # fix me
+            bigip.hostname, name=name, partition=partition)
         if not tunnel:
             for itunnel in self.__pending_exists:
-                if tunnel.tunnel_name == name and \
-                        tunnel.partition == partition:
+                if itunnel.tunnel_name == name and \
+                        itunnel.partition == partition:
                     tunnel = itunnel
                     break
             else:


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
The Traceback (discovered in testing):
```2018-03-13 21:32:17.751 34 ERROR neutron   File "/usr/local/lib/python2.7/dist-packages/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/cache.py", line 107, in acquire_lock
2018-03-13 21:32:17.751 34 ERROR neutron     if self.__lock_acquired == threading.current_thread():
2018-03-13 21:32:17.751 34 ERROR neutron AttributeError: 'TunnelHandler' object has no attribute '_CacheBase__lock_acquired'```

The delete functionality for tunnels.

#### What's this change do?
Adds a `super().__init__` call to `TunnelHandler.__init__()` this initializes the Cache object's locking attributes that are missing in the AttributeError

#### Where should the reviewer start?
`test_tunnel.py` for the delete tunnels fix.  `...tunnels.tunnel.TunnelHandler` for the init fix.

#### Any background context?
This is part of the steps getting the L2 Population refactor off the ground.