### PR TITLE
Fixing further issues within the system

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -595,8 +595,9 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
 
     def tunnel_sync(self):
         """Call into driver to advertise device tunnel endpoints."""
-        LOG.debug("manager:tunnel_sync: calling driver tunnel_sync")
-        return self.lbdriver.tunnel_sync()
+        LOG.debug("manager:tunnel_sync: calling tunnel_handler.tunnel_sync")
+        bigips = self.lbdriver.get_all_bigips()
+        self.tunnel_handler.tunnel_sync(bigips)
 
     @log_helpers.log_method_call
     def sync_state(self):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -545,6 +545,8 @@ class iControlDriver(LBaaSBaseDriver):
 
             self.__last_connect_attempt = datetime.datetime.now()
 
+            import pdb
+            pdb.set_trace()
             for hostname in self.hostnames:
                 # connect to each BIG-IP and set it status
                 bigip = self._open_bigip(hostname)
@@ -588,7 +590,7 @@ class iControlDriver(LBaaSBaseDriver):
                               % (hostname, bigip.status, bigip.status_message))
                     self._set_agent_status(False)
         except Exception as exc:
-            LOG.error('Invalid agent configuration: %s' % exc.message)
+            LOG.exception('Invalid agent configuration: %s' % exc.message)
             raise
         self._set_agent_status(force_resync=True)
 
@@ -752,9 +754,6 @@ class iControlDriver(LBaaSBaseDriver):
 
             # Turn off tunnel syncing between BIG-IP
             # as our VTEPs properly use only local SelfIPs
-            if self.system_helper.get_tunnel_sync(bigip) == 'enable':
-                self.system_helper.set_tunnel_sync(bigip, enabled=False)
-
             LOG.debug('connected to iControl %s @ %s ver %s.%s'
                       % (self.conf.icontrol_username, hostname,
                          major_version, minor_version))
@@ -1596,22 +1595,6 @@ class iControlDriver(LBaaSBaseDriver):
     def tunnel_update(self, **kwargs):
         # Tunnel Update from Neutron Core RPC
         pass
-
-    def tunnel_sync(self):
-        # Only sync when supported types are present
-        if not [i for i in self.agent_configurations['tunnel_types']
-                if i in ['gre', 'vxlan']]:
-            return False
-
-        tunnel_ips = []
-        for bigip in self.get_all_bigips():
-            if bigip.local_ip:
-                tunnel_ips.append(bigip.local_ip)
-
-        self.network_builder.tunnel_sync(tunnel_ips)
-
-        # Tunnel sync sent.
-        return False
 
     @serialized('sync')
     @is_operational

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py
@@ -157,10 +157,6 @@ class LBaaSBaseDriver(object):
         """Neutron Core Tunnel Update."""
         raise NotImplementedError()
 
-    def tunnel_sync(self):
-        """Neutron Core Tunnel Sync Messages."""
-        raise NotImplementedError()
-
     def fdb_add(self, fdb_entries):
         """L2 Population FDB Add."""
         raise NotImplementedError()

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
@@ -60,9 +60,6 @@ class NetworkServiceBuilder(object):
         # is fully connected
         self.l2_service.post_init()
 
-    def tunnel_sync(self, tunnel_ips):
-        self.l2_service.tunnel_sync(tunnel_ips)
-
     def set_tunnel_rpc(self, tunnel_rpc):
         # Provide FDB Connector with ML2 RPC access """
         self.l2_service.set_tunnel_rpc(tunnel_rpc)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/system_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/system_helper.py
@@ -87,21 +87,6 @@ class SystemHelper(object):
     def get_platform(self, bigip):
         return ''
 
-    def get_tunnel_sync(self, bigip):
-        db = bigip.tm.sys.dbs.db.load(name='iptunnel.configsync')
-        if hasattr(db, 'value'):
-            return db.value
-
-        return ''
-
-    def set_tunnel_sync(self, bigip, enabled=False):
-
-        if enabled:
-            val = 'enable'
-        else:
-            val = 'disable'
-        db = bigip.tm.sys.dbs.db.load(name='iptunnel.configsync')
-        db.modify(value=val)
 
     def get_provision_extramb(self, bigip):
         db = bigip.tm.sys.dbs.db.load(name='provision.extramb')

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
@@ -353,7 +353,9 @@ class TunnelBuilder(object):
                                       bigip.tm.net.tunnels.vxlans.vxlan}}
         create_tunnel = default_profiles[tunnel_type]
         tunnel = dict(name=name, partition=partition)
-        tm_multipoint = tunnel.pop('tm_endpoint')
+        import pdb
+        pdb.set_trace()
+        tm_multipoint = create_tunnel.pop('tm_endpoint')
         actions = {'create': dict(
                        payload=create_tunnel, method=tm_multipoint.create),
                    'delete': dict(


### PR DESCRIPTION
Issues:
tunnel sync methods not going as planned from LbaasAgentManager directly to TunnelHandler

Problem:
* Lingering, broken deprecated code existed that called methods that were no longer linked for tunnel Sync

Analysis:
* This removes these redundant method calls and reverts them to simply calling `TunnelHandler.tunnel_sync`

Tests:
This gets the agent back online for our integration tests.

@jlongstaf 
#### What issues does this address?
Please see comments above

#### What's this change do?
Please see comments above

#### Where should the reviewer start?
agent_manager and removed sync methods in `icontrol_driver.py`, `l2_service.py`, and `network*.py` for old code removal.

#### Any background context?
This is part of the tunnel refactor that allows the agent to validate that the tunnels exist on the BIG-IP before reporting back to the l2 population fdb that we are ready on the tunnel(s).  The records and arp entries should be immediate, but tunnel creation has been proven to be a delayed change on the BIG-IP (as with other objects).