### PR TITLE
Bugfixes: Fixing further issues within the tunnels

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -595,8 +595,9 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
 
     def tunnel_sync(self):
         """Call into driver to advertise device tunnel endpoints."""
-        LOG.debug("manager:tunnel_sync: calling driver tunnel_sync")
-        return self.lbdriver.tunnel_sync()
+        LOG.debug("manager:tunnel_sync: calling tunnel_handler.tunnel_sync")
+        bigips = self.lbdriver.get_all_bigips()
+        self.tunnel_handler.tunnel_sync(bigips)
 
     @log_helpers.log_method_call
     def sync_state(self):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -588,7 +588,7 @@ class iControlDriver(LBaaSBaseDriver):
                               % (hostname, bigip.status, bigip.status_message))
                     self._set_agent_status(False)
         except Exception as exc:
-            LOG.error('Invalid agent configuration: %s' % exc.message)
+            LOG.exception('Invalid agent configuration: %s' % exc.message)
             raise
         self._set_agent_status(force_resync=True)
 
@@ -752,9 +752,6 @@ class iControlDriver(LBaaSBaseDriver):
 
             # Turn off tunnel syncing between BIG-IP
             # as our VTEPs properly use only local SelfIPs
-            if self.system_helper.get_tunnel_sync(bigip) == 'enable':
-                self.system_helper.set_tunnel_sync(bigip, enabled=False)
-
             LOG.debug('connected to iControl %s @ %s ver %s.%s'
                       % (self.conf.icontrol_username, hostname,
                          major_version, minor_version))
@@ -1596,22 +1593,6 @@ class iControlDriver(LBaaSBaseDriver):
     def tunnel_update(self, **kwargs):
         # Tunnel Update from Neutron Core RPC
         pass
-
-    def tunnel_sync(self):
-        # Only sync when supported types are present
-        if not [i for i in self.agent_configurations['tunnel_types']
-                if i in ['gre', 'vxlan']]:
-            return False
-
-        tunnel_ips = []
-        for bigip in self.get_all_bigips():
-            if bigip.local_ip:
-                tunnel_ips.append(bigip.local_ip)
-
-        self.network_builder.tunnel_sync(tunnel_ips)
-
-        # Tunnel sync sent.
-        return False
 
     @serialized('sync')
     @is_operational

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py
@@ -157,10 +157,6 @@ class LBaaSBaseDriver(object):
         """Neutron Core Tunnel Update."""
         raise NotImplementedError()
 
-    def tunnel_sync(self):
-        """Neutron Core Tunnel Sync Messages."""
-        raise NotImplementedError()
-
     def fdb_add(self, fdb_entries):
         """L2 Population FDB Add."""
         raise NotImplementedError()

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
@@ -60,9 +60,6 @@ class NetworkServiceBuilder(object):
         # is fully connected
         self.l2_service.post_init()
 
-    def tunnel_sync(self, tunnel_ips):
-        self.l2_service.tunnel_sync(tunnel_ips)
-
     def set_tunnel_rpc(self, tunnel_rpc):
         # Provide FDB Connector with ML2 RPC access """
         self.l2_service.set_tunnel_rpc(tunnel_rpc)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/system_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/system_helper.py
@@ -87,22 +87,6 @@ class SystemHelper(object):
     def get_platform(self, bigip):
         return ''
 
-    def get_tunnel_sync(self, bigip):
-        db = bigip.tm.sys.dbs.db.load(name='iptunnel.configsync')
-        if hasattr(db, 'value'):
-            return db.value
-
-        return ''
-
-    def set_tunnel_sync(self, bigip, enabled=False):
-
-        if enabled:
-            val = 'enable'
-        else:
-            val = 'disable'
-        db = bigip.tm.sys.dbs.db.load(name='iptunnel.configsync')
-        db.modify(value=val)
-
     def get_provision_extramb(self, bigip):
         db = bigip.tm.sys.dbs.db.load(name='provision.extramb')
         if hasattr(db, 'value'):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
@@ -335,7 +335,7 @@ class TunnelBuilder(object):
     def __tm_multipoint(bigip, tunnel_type, name, partition, action):
         def execute(actions, action):
             return actions[action]['method'](**actions[action]['payload'])
-        default_profiles = {'gre': {'name': None,
+        default_profiles = {'gre': {'name': name,
                                     'partition': const.DEFAULT_PARTITION,
                                     'defaultsFrom': 'gre',
                                     'floodingType': 'multipoint',
@@ -344,7 +344,7 @@ class TunnelBuilder(object):
                                     'tm_endpoint':
                                     bigip.tm.net.tunnels.gres.gre
                                     },
-                            'vxlan': {'name': None,
+                            'vxlan': {'name': name,
                                       'partition': const.DEFAULT_PARTITION,
                                       'defaultsFrom': 'vxlan',
                                       'floodingType': 'multipoint',
@@ -353,7 +353,7 @@ class TunnelBuilder(object):
                                       bigip.tm.net.tunnels.vxlans.vxlan}}
         create_tunnel = default_profiles[tunnel_type]
         tunnel = dict(name=name, partition=partition)
-        tm_multipoint = tunnel.pop('tm_endpoint')
+        tm_multipoint = create_tunnel.pop('tm_endpoint')
         actions = {'create': dict(
                        payload=create_tunnel, method=tm_multipoint.create),
                    'delete': dict(

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
@@ -441,7 +441,7 @@ class TunnelBuilder(object):
         network_id = params.get('network_id', None)
         tunnel_type = params.get(
             'tunnel_type', params.get(
-                'netowrk_type', None))
+                'network_type', None))
         segment_id = params.get('segment_id', '')
         bigip_host = bigip.hostname if bigip else ''
         partition = params.get('partition', None)


### PR DESCRIPTION
Issues:
Functional tests for Neutronless type were missing a tunnel_handler in
the icontrol driver
sync_state as being called periodically for tunnel_sync in a broken
logic train
multipoint profiles having issues in create

Problem:
* icontrol driver missing tunnel handler in neutronless tests
* tunnel_sync being called in AgentManager leading to broken logic
* __tm_multipoint method in TunneBuilder performed wrong reference

Analysis:
* This introduces a tunnel handler to the icontrol driver in conftest
  * fixes neutronless tests
* This strips out tunnel_sync in iControlDriver, NetworkService,
NetworkHelper, and L2Service
* Used previously-assigned create_tunnel properly in __tm_multipoint

Tests:
Trying to get system tests online and functional tests working

@jlongstaf 
#### What issues does this address?


#### What's this change do?
See above
#### Where should the reviewer start?
See above
#### Any background context?
Tunnels - getting the agent to start up and fixing test failures.