### PR TITLE
Remove references to internal F5 sites.

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/esd_filehandler.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/esd_filehandler.py
@@ -199,10 +199,9 @@ class EsdTagProcessor(EsdJSONValidation):
             msg = 'Tag {0} is not valid.'.format(tag)
             raise f5_ex.esdJSONFileInvalidException(msg)
 
-    # this dictionary contains all the tags
-    # that are listed in the esd confluence page:
-    # https://docs.f5net.com/display/F5OPENSTACKPROJ/Enhanced+Service+Definition
-    # we are implementing the tags that can be applied only to listeners
+    # This dictionary contains all the tags
+    # that are listed in the esd confluence page.
+    # We are implementing the tags that can be applied only to listeners.
 
     valid_esd_tags = {
         'lbaas_ctcp': {

--- a/requirements.functest.txt
+++ b/requirements.functest.txt
@@ -14,6 +14,3 @@ enum34===1.1.2
 oslo.i18n===3.5.0
 oslo.messaging===4.6.1
 decorator===4.0.9
-
-#using testenv symbols to run functional single bigip tests
-git+https://gitlab.pdbld.f5net.com/tools/pytest-symbols.git@5fe78c9f


### PR DESCRIPTION
@szakeri 

#### What's this change do?
Because this code lives in a public repo, we need to remove all references to internal F5 sites. Removed two references, one a requirements file, and the other a doc string comment.

#### Where should the reviewer start?
requirements.functest.txt

#### Any background context?
This is a requirement from F5 IT security. Users who run func tests must remember to install pytest symbols and not rely on the requirements file to do so. This happens automatically as part of testenv func tests setup.
