### PR TITLE
Many bug-fixes to get functional tests back online

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1018,6 +1018,10 @@ class iControlDriver(LBaaSBaseDriver):
             return highest_metric
         return 0
 
+    def set_tunnel_handler(self, tunnel_handler):
+        """Provides Tunnel Handling support to the driver"""
+        self.tunnel_handler = tunnel_handler
+
     def set_plugin_rpc(self, plugin_rpc):
         # Provide Plugin RPC access
         self.plugin_rpc = plugin_rpc
@@ -1912,9 +1916,8 @@ class iControlDriver(LBaaSBaseDriver):
                     self.network_builder.post_service_networking(
                         service, all_subnet_hints)
                 except Exception as error:
-                    LOG.error("Post-network exception: icontrol_driver: %s",
-                              error.message)
-
+                    LOG.exception("Post-network exception: "
+                                  "icontrol_driver: {}".format(error))
                     if lb_provisioning_status != f5const.F5_PENDING_DELETE:
                         loadbalancer['provisioning_status'] = \
                             f5const.F5_ERROR

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
@@ -39,7 +39,7 @@ def _get_tunnel_name(network):
     return 'tunnel-' + str(tunnel_type) + '-' + str(tunnel_id)
 
 
-def _get_tunnel_fake_mac(network, local_ip):
+def get_tunnel_fake_mac(network, local_ip):
     # create a fake mac for l2 records for tunnels
     network_id = str(network['provider:segmentation_id']).rjust(4, '0')
     mac_prefix = '02:' + network_id[:2] + ':' + network_id[2:4] + ':'
@@ -505,7 +505,7 @@ class L2ServiceBuilder(object):
         tunnel_name = _get_tunnel_name(network)
 
         try:
-            self.driver.tunnel_handler.remove_tunnel(
+            self.driver.tunnel_handler.remove_multipoint_tunnel(
                 bigip,
                 tunnel_name,
                 partition=network_folder)
@@ -520,7 +520,7 @@ class L2ServiceBuilder(object):
         tunnel_name = _get_tunnel_name(network)
 
         try:
-            self.driver.tunnel_handler.remove_tunnel(
+            self.driver.tunnel_handler.remove_multipoint_tunnel(
                 bigip,
                 tunnel_name,
                 partition=network_folder)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/cache.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/cache.py
@@ -122,7 +122,7 @@ class CacheBase(object):
                 self.__workers_waiting += 1
                 self.__workers_locks.wait()
                 self.__workers_waiting -= 1
-            self._lock_acquired = threading.current_thread()
+            self.__lock_acquired = threading.current_thread()
 
     def release_lock(self):
         """Releases an afore-created lock
@@ -140,7 +140,7 @@ class CacheBase(object):
         with self.__mechanism:
             my_thread = threading.current_thread()
             # lock sanity checking...
-            if self._lock_acquired is None:
+            if self.__lock_acquired is None:
                 raise RuntimeError("We can't release a non-acquired lock!")
             elif not self.__lock_acquired:
                 self.logger.error("Shying away from unlocking an "
@@ -150,6 +150,6 @@ class CacheBase(object):
                     "We can't release another's lock "
                     "(lock({}), thread({}))".format(
                         self.__lock_acquired, my_thread))
-            self._lock_acquired = None
+            self.__lock_acquired = None
             if self.__workers_waiting > 0:
                 self.__workers_locks.notify()

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/decorators.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/decorators.py
@@ -20,6 +20,7 @@ manipulations.
 #
 
 import socket
+import sys
 import weakref
 
 from requests import HTTPError
@@ -86,6 +87,7 @@ def http_error(*args, **exc_specs):
                         message = "{} (kwargs: {})".format(message, wkwargs)
                     message = "From {}: {}".format(method, message)
                     msg_type(message)
+                    sys.exc_clear()
                     break
                 else:
                     raise
@@ -110,19 +112,24 @@ def not_none(method):
 
 def ip_address(method):
     """A decorator function that adds the is_ip_address_wrapper"""
-    def is_ip_address_wrapper(inst, value):
+    def is_ip_address_wrapper(inst, value, force=False):
         """Checks the method under wrap's value to validate IP Address
 
         This wrapper will check validity of the IP Address in the value given
         to the method under wrap.  If it is not a valid IP Address, then a
         TypeError is raised.
+
+        Optional:
+            Caller may provide a force kwarg.  If true, then this decorator
+            will ignore what tyep of object is passed.
         """
-        try:
-            socket.inet_aton(value)
-            return method(inst, value)
-        except socket.error:
-            raise TypeError(
-                "method {} is expecting an IP address!".format(method))
+        if not force:
+            try:
+                socket.inet_aton(value)
+            except socket.error:
+                raise TypeError(
+                    "method {} is expecting an IP address!".format(method))
+        return method(inst, value)
     return is_ip_address_wrapper
 
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/test/test_fdb_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/test/test_fdb_builder.py
@@ -47,6 +47,7 @@ class TestFdbMockBuilder(MockBuilderBase):
 
     def fully_mocked_target(self, mocked_target):
         """Creates and returns a fully mocked Fdb object"""
+        mocked_target.logger = mock.Mock()
         mocked_target._Fdb__ip_address = '192.168.1.6'
         mocked_target._Fdb__segment_id = 33
         mocked_target._Fdb__mac_address = 'ma:ca:dd:re:ss:es'

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/test/test_tunnel.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/test/test_tunnel.py
@@ -182,7 +182,7 @@ class TestTunnelMocker(object):
         fake_mac = 'aa:bb:cc:dd:ee:ff'
         bigip.local_ip = '192.168.10.1'
         tm_fdb_tunnel = bigip.tm.net.fdb.tunnels.tunnel
-        tm_tunnel = bigip.tm.net.tunnels.tunnel
+        tm_tunnel = bigip.tm.net.tunnels.tunnels.tunnel
         tm_arp = bigip.tm.net.arps.arp
         fdb_tunnel.records = [{'name': fake_mac, 'endpoint': bigip.local_ip}]
         tm_fdb_tunnel.load.return_value = fdb_tunnel
@@ -272,7 +272,7 @@ class TestTunnel(ClassTesterBase, TestTunnelMocker):
         record = mock.Mock()
         record.endpoint = '10.22.22.6'
         record.name = mac
-        fdb_tunnel.records_s.get_collection.return_value = [record]
+        fdb_tunnel.records = [record]
         target = fully_mocked_target
         multipoint_tunnel = bigip.multipoint_tunnel
         multipoint_tunnel.name = 'vxlan_multipoint'
@@ -283,7 +283,6 @@ class TestTunnel(ClassTesterBase, TestTunnelMocker):
         assert bigip.tm.net.tunnels.tunnels.get_collection.call_count
         assert bigip.tm.net.fdb.tunnels.tunnel.load.call_count
         assert bigip.tm.net.arps.get_collection.call_count
-        assert fdb_tunnel.records_s.get_collection.call_count
         assert target._TunnelHandler__profiles
         assert \
             target._TunnelHandler__network_cache_handler.\

--- a/test/functional/neutronless/conftest.py
+++ b/test/functional/neutronless/conftest.py
@@ -45,6 +45,8 @@ import traceback
 
 from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import \
     iControlDriver
+from f5_openstack_agent.lbaasv2.drivers.bigip.tunnels.tunnel import \
+    TunnelHandler
 
 from .bigip_interaction import BigIpInteraction
 from .testlib.bigip_client import BigIpClient
@@ -153,6 +155,7 @@ class TestConfig(object):
 
         icd = iControlDriver(ConfFake(self.OSLO_CONF),
                              registerOpts=False)
+        icd.tunnel_handler = TunnelHandler(1, 2, 3)
 
         icd.plugin_rpc = self.fake_plugin_rpc()
         icd.connect()
@@ -437,6 +440,7 @@ def icontrol_driver(icd_config, fake_plugin_rpc):
 
     icd = iControlDriver(ConfFake(icd_config),
                          registerOpts=False)
+    icd.tunnel_handler = TunnelHandler(1, 2, 3)
 
     icd.plugin_rpc = fake_plugin_rpc
     icd.connect()


### PR DESCRIPTION
Issues:
TestFix - ICD is given a tunnel_handler in conftest
handling tunnel_handler passing to the icontrol_driver
handling fdbs from loadbalancer/members creation via service_request
refresh in fixing unit tests
fixing creation of fdbs from loadbalancer and members in SR
fixing flake8 errors
fixing bad method name and properly handling hosts
fixing bad method name and properly handling hosts

Problems:
* Handling of initial loadbalancer create was not handled for FDB's
* Creation of loadbalancer was causing infinite lock deadlock loop

Solutions:
* Created an LB-create FDB handler for LB's and members
* Assigned the correct variable name for deadlock prevention

Tests:
Funcitonal tests should now pass, though not all have been tested (yet).

Things should be improved now.

@<reviewer_id>
#### What issues does this address?
Missing tunnel_handler attribute in driver
Fixes initial workflow for a new loadbalancer/members pair in a service request (fdb's handling)
logical flows for CRUD of records

#### What's this change do?
Gets neutronless/listeners/test_tcp*.py tests working

#### Where should the reviewer start?
AgentManager changes for interaction for tunnel_handler into the driver
Fixes initial workflow for a new loadbalancer/members pair in a service request (fdb's handling)
FdbBuilder for CRUD changes on records

#### Any background context?
This is in context of fixing the functional tests.