### PR TITLE
Tunnel bugfixes2

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1018,6 +1018,10 @@ class iControlDriver(LBaaSBaseDriver):
             return highest_metric
         return 0
 
+    def set_tunnel_handler(self, tunnel_handler):
+        """Provides Tunnel Handling support to the driver"""
+        self.tunnel_handler = tunnel_handler
+
     def set_plugin_rpc(self, plugin_rpc):
         # Provide Plugin RPC access
         self.plugin_rpc = plugin_rpc
@@ -1912,9 +1916,8 @@ class iControlDriver(LBaaSBaseDriver):
                     self.network_builder.post_service_networking(
                         service, all_subnet_hints)
                 except Exception as error:
-                    LOG.error("Post-network exception: icontrol_driver: %s",
-                              error.message)
-
+                    LOG.exception("Post-network exception: "
+                                  "icontrol_driver: {}".format(error))
                     if lb_provisioning_status != f5const.F5_PENDING_DELETE:
                         loadbalancer['provisioning_status'] = \
                             f5const.F5_ERROR

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
@@ -39,7 +39,7 @@ def _get_tunnel_name(network):
     return 'tunnel-' + str(tunnel_type) + '-' + str(tunnel_id)
 
 
-def _get_tunnel_fake_mac(network, local_ip):
+def get_tunnel_fake_mac(network, local_ip):
     # create a fake mac for l2 records for tunnels
     network_id = str(network['provider:segmentation_id']).rjust(4, '0')
     mac_prefix = '02:' + network_id[:2] + ':' + network_id[2:4] + ':'
@@ -505,7 +505,7 @@ class L2ServiceBuilder(object):
         tunnel_name = _get_tunnel_name(network)
 
         try:
-            self.driver.tunnel_handler.remove_tunnel(
+            self.driver.tunnel_handler.remove_multipoint_tunnel(
                 bigip,
                 tunnel_name,
                 partition=network_folder)
@@ -520,7 +520,7 @@ class L2ServiceBuilder(object):
         tunnel_name = _get_tunnel_name(network)
 
         try:
-            self.driver.tunnel_handler.remove_tunnel(
+            self.driver.tunnel_handler.remove_multipoint_tunnel(
                 bigip,
                 tunnel_name,
                 partition=network_folder)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
@@ -738,11 +738,11 @@ class NetworkServiceBuilder(object):
                     subnet_hints['check_for_delete_subnets'].pop(
                         in_use_subnetid, None)
             except f5_ex.F5NeutronException as exc:
-                LOG.error("assure_delete_nets_shared: exception: %s"
-                          % str(exc.msg))
+                LOG.exception("assure_delete_nets_shared: exception: %s"
+                              % str(exc.msg))
             except Exception as exc:
-                LOG.error("assure_delete_nets_shared: exception: %s"
-                          % str(exc.message))
+                LOG.exception("assure_delete_nets_shared: exception: %s"
+                              % str(exc.message))
 
         return deleted_names
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/cache.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/cache.py
@@ -122,7 +122,7 @@ class CacheBase(object):
                 self.__workers_waiting += 1
                 self.__workers_locks.wait()
                 self.__workers_waiting -= 1
-            self._lock_acquired = threading.current_thread()
+            self.__lock_acquired = threading.current_thread()
 
     def release_lock(self):
         """Releases an afore-created lock
@@ -140,7 +140,7 @@ class CacheBase(object):
         with self.__mechanism:
             my_thread = threading.current_thread()
             # lock sanity checking...
-            if self._lock_acquired is None:
+            if self.__lock_acquired is None:
                 raise RuntimeError("We can't release a non-acquired lock!")
             elif not self.__lock_acquired:
                 self.logger.error("Shying away from unlocking an "
@@ -150,6 +150,6 @@ class CacheBase(object):
                     "We can't release another's lock "
                     "(lock({}), thread({}))".format(
                         self.__lock_acquired, my_thread))
-            self._lock_acquired = None
+            self.__lock_acquired = None
             if self.__workers_waiting > 0:
                 self.__workers_locks.notify()

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/decorators.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/decorators.py
@@ -20,6 +20,7 @@ manipulations.
 #
 
 import socket
+import sys
 import weakref
 
 from requests import HTTPError
@@ -86,6 +87,7 @@ def http_error(*args, **exc_specs):
                         message = "{} (kwargs: {})".format(message, wkwargs)
                     message = "From {}: {}".format(method, message)
                     msg_type(message)
+                    sys.exc_clear()
                     break
                 else:
                     raise
@@ -110,19 +112,24 @@ def not_none(method):
 
 def ip_address(method):
     """A decorator function that adds the is_ip_address_wrapper"""
-    def is_ip_address_wrapper(inst, value):
+    def is_ip_address_wrapper(inst, value, force=False):
         """Checks the method under wrap's value to validate IP Address
 
         This wrapper will check validity of the IP Address in the value given
         to the method under wrap.  If it is not a valid IP Address, then a
         TypeError is raised.
+
+        Optional:
+            Caller may provide a force kwarg.  If true, then this decorator
+            will ignore what tyep of object is passed.
         """
-        try:
-            socket.inet_aton(value)
-            return method(inst, value)
-        except socket.error:
-            raise TypeError(
-                "method {} is expecting an IP address!".format(method))
+        if not force:
+            try:
+                socket.inet_aton(value)
+            except socket.error:
+                raise TypeError(
+                    "method {} is expecting an IP address!".format(method))
+        return method(inst, value)
     return is_ip_address_wrapper
 
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/test/test_fdb_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/test/test_fdb_builder.py
@@ -47,6 +47,7 @@ class TestFdbMockBuilder(MockBuilderBase):
 
     def fully_mocked_target(self, mocked_target):
         """Creates and returns a fully mocked Fdb object"""
+        mocked_target.logger = mock.Mock()
         mocked_target._Fdb__ip_address = '192.168.1.6'
         mocked_target._Fdb__segment_id = 33
         mocked_target._Fdb__mac_address = 'ma:ca:dd:re:ss:es'

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/test/test_tunnel.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/test/test_tunnel.py
@@ -182,7 +182,7 @@ class TestTunnelMocker(object):
         fake_mac = 'aa:bb:cc:dd:ee:ff'
         bigip.local_ip = '192.168.10.1'
         tm_fdb_tunnel = bigip.tm.net.fdb.tunnels.tunnel
-        tm_tunnel = bigip.tm.net.tunnels.tunnel
+        tm_tunnel = bigip.tm.net.tunnels.tunnels.tunnel
         tm_arp = bigip.tm.net.arps.arp
         fdb_tunnel.records = [{'name': fake_mac, 'endpoint': bigip.local_ip}]
         tm_fdb_tunnel.load.return_value = fdb_tunnel
@@ -272,7 +272,7 @@ class TestTunnel(ClassTesterBase, TestTunnelMocker):
         record = mock.Mock()
         record.endpoint = '10.22.22.6'
         record.name = mac
-        fdb_tunnel.records_s.get_collection.return_value = [record]
+        fdb_tunnel.records = [record]
         target = fully_mocked_target
         multipoint_tunnel = bigip.multipoint_tunnel
         multipoint_tunnel.name = 'vxlan_multipoint'
@@ -283,7 +283,6 @@ class TestTunnel(ClassTesterBase, TestTunnelMocker):
         assert bigip.tm.net.tunnels.tunnels.get_collection.call_count
         assert bigip.tm.net.fdb.tunnels.tunnel.load.call_count
         assert bigip.tm.net.arps.get_collection.call_count
-        assert fdb_tunnel.records_s.get_collection.call_count
         assert target._TunnelHandler__profiles
         assert \
             target._TunnelHandler__network_cache_handler.\

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
@@ -967,6 +967,7 @@ class TunnelHandler(cache.CacheBase):
             if error.response.status_code == 409:
                 self.logger.debug("Attempted to create a new tunnel ({}) "
                                   "where one already existed".format(model))
+            return
         self.__add_pending_exists(tunnel)
 
     @cache.lock
@@ -1137,13 +1138,17 @@ class TunnelHandler(cache.CacheBase):
 
         Args:
             bigips - [f5.bigip.ManagementRoot] instances
-            loadbalancer - service request's loadbalancer
+            loadbalancer - service request's loadbalancer | None
             members - service request's members associated with that
-                loadbalancer
+                loadbalancer | []
         Returns:
             None
         """
-        by_host_names = self._get_tunnels_by_network(loadbalancer['network'])
+        if loadbalancer:
+            network = loadbalancer.get('network', None)
+        else:
+            network = members[0]['network']
+        by_host_names = self._get_tunnels_by_network(network)
         hosts = self._get_bigips_by_hostname(bigips)
         for host_name in by_host_names:
             bigip = hosts[host_name]

--- a/test/functional/neutronless/conftest.py
+++ b/test/functional/neutronless/conftest.py
@@ -45,6 +45,8 @@ import traceback
 
 from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import \
     iControlDriver
+from f5_openstack_agent.lbaasv2.drivers.bigip.tunnels.tunnel import \
+    TunnelHandler
 
 from .bigip_interaction import BigIpInteraction
 from .testlib.bigip_client import BigIpClient
@@ -153,6 +155,7 @@ class TestConfig(object):
 
         icd = iControlDriver(ConfFake(self.OSLO_CONF),
                              registerOpts=False)
+        icd.tunnel_handler = TunnelHandler(1, 2, 3)
 
         icd.plugin_rpc = self.fake_plugin_rpc()
         icd.connect()
@@ -437,6 +440,7 @@ def icontrol_driver(icd_config, fake_plugin_rpc):
 
     icd = iControlDriver(ConfFake(icd_config),
                          registerOpts=False)
+    icd.tunnel_handler = TunnelHandler(1, 2, 3)
 
     icd.plugin_rpc = fake_plugin_rpc
     icd.connect()

--- a/test/functional/neutronless/conftest.py
+++ b/test/functional/neutronless/conftest.py
@@ -427,7 +427,12 @@ def fake_plugin_rpc(services):
 
 
 @pytest.fixture
-def icontrol_driver(icd_config, fake_plugin_rpc):
+def fake_tunnel_handler():
+    return TunnelHandler(1, 2, 3)
+
+
+@pytest.fixture
+def icontrol_driver_base(icd_config):
     class ConfFake(object):
         def __init__(self, params):
             self.__dict__ = params
@@ -440,8 +445,14 @@ def icontrol_driver(icd_config, fake_plugin_rpc):
 
     icd = iControlDriver(ConfFake(icd_config),
                          registerOpts=False)
-    icd.tunnel_handler = TunnelHandler(1, 2, 3)
+    return icd
 
+
+@pytest.fixture
+def icontrol_driver(icontrol_driver_base, fake_plugin_rpc,
+                    fake_tunnel_handler):
+    icd = icontrol_driver_base
+    icd.tunnel_handler = fake_tunnel_handler
     icd.plugin_rpc = fake_plugin_rpc
     icd.connect()
     return icd

--- a/test/functional/neutronless/loadbalancer/conftest.py
+++ b/test/functional/neutronless/loadbalancer/conftest.py
@@ -12,29 +12,3 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-
-
-from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import \
-    iControlDriver
-import pytest
-
-
-@pytest.fixture
-def icontrol_driver(icd_config, fake_plugin_rpc):
-    class ConfFake(object):
-        def __init__(self, params):
-            self.__dict__ = params
-            for k, v in self.__dict__.items():
-                if isinstance(v, unicode):
-                    self.__dict__[k] = v.encode('utf-8')
-
-        def __repr__(self):
-            return repr(self.__dict__)
-
-    icd = iControlDriver(ConfFake(icd_config),
-                         registerOpts=False)
-
-    icd.plugin_rpc = fake_plugin_rpc
-    icd.connect()
-
-    return icd

--- a/test/functional/neutronless/loadbalancer/test_f5_common_networks.py
+++ b/test/functional/neutronless/loadbalancer/test_f5_common_networks.py
@@ -66,21 +66,6 @@ def fake_plugin_rpc(services):
     return rpcObj
 
 
-@pytest.fixture
-def icontrol_driver(icd_config, fake_plugin_rpc):
-    class ConfFake(object):
-        def __init__(self, params):
-            self.__dict__ = params
-            for k, v in self.__dict__.items():
-                if isinstance(v, unicode):
-                    self.__dict__[k] = v.encode('utf-8')
-
-        def __repr__(self):
-            return repr(self.__dict__)
-
-    icd = iControlDriver(ConfFake(icd_config),
-                         registerOpts=False)
-
     icd.plugin_rpc = fake_plugin_rpc
     icd.connect()
 

--- a/test/functional/neutronless/loadbalancer/test_purge_folder.py
+++ b/test/functional/neutronless/loadbalancer/test_purge_folder.py
@@ -13,8 +13,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import \
-    iControlDriver
 from f5_openstack_agent.lbaasv2.drivers.bigip.system_helper import \
     SystemHelper
 
@@ -59,29 +57,8 @@ def fake_plugin_rpc(services):
     return rpcObj
 
 
-@pytest.fixture
-def icontrol_driver(icd_config, fake_plugin_rpc):
-    class ConfFake(object):
-        def __init__(self, params):
-            self.__dict__ = params
-            for k, v in self.__dict__.items():
-                if isinstance(v, unicode):
-                    self.__dict__[k] = v.encode('utf-8')
-
-        def __repr__(self):
-            return repr(self.__dict__)
-
-    icd = iControlDriver(ConfFake(icd_config),
-                         registerOpts=False)
-
-    icd.plugin_rpc = fake_plugin_rpc
-    icd.connect()
-
-    return icd
-
-
 def test_purge_folder(track_bigip_cfg, bigip, services, icd_config,
-                     icontrol_driver):
+                      icontrol_driver):
     env_prefix = icd_config['environment_prefix']
     service_iter = iter(services)
     validator = ResourceValidator(bigip, env_prefix)
@@ -119,4 +96,3 @@ def test_purge_folder(track_bigip_cfg, bigip, services, icd_config,
     # delete folder and check that it does not exist
     sh.purge_folder(bigip.bigip, folder)
     assert not bigip.folder_exists(folder)
-

--- a/test/functional/neutronless/loadbalancer/test_snat_common_network.py
+++ b/test/functional/neutronless/loadbalancer/test_snat_common_network.py
@@ -13,8 +13,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import \
-    iControlDriver
 import json
 import logging
 import os
@@ -50,27 +48,6 @@ def fake_plugin_rpc(services):
     rpcObj = FakeRPCPlugin(services)
 
     return rpcObj
-
-
-@pytest.fixture
-def icontrol_driver(icd_config, fake_plugin_rpc):
-    class ConfFake(object):
-        def __init__(self, params):
-            self.__dict__ = params
-            for k, v in self.__dict__.items():
-                if isinstance(v, unicode):
-                    self.__dict__[k] = v.encode('utf-8')
-
-        def __repr__(self):
-            return repr(self.__dict__)
-
-    icd = iControlDriver(ConfFake(icd_config),
-                         registerOpts=False)
-
-    icd.plugin_rpc = fake_plugin_rpc
-    icd.connect()
-
-    return icd
 
 
 def test_snat_common_network(track_bigip_cfg, bigip, services, icd_config,

--- a/test/functional/neutronless/pool/test_delete_pool.py
+++ b/test/functional/neutronless/pool/test_delete_pool.py
@@ -13,8 +13,6 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-from f5_openstack_agent.lbaasv2.drivers.bigip.icontrol_driver import \
-    iControlDriver
 import json
 import logging
 import os
@@ -54,27 +52,6 @@ def fake_plugin_rpc(services):
     rpcObj = FakeRPCPlugin(services)
 
     return rpcObj
-
-
-@pytest.fixture
-def icontrol_driver(icd_config, fake_plugin_rpc):
-    class ConfFake(object):
-        def __init__(self, params):
-            self.__dict__ = params
-            for k, v in self.__dict__.items():
-                if isinstance(v, unicode):
-                    self.__dict__[k] = v.encode('utf-8')
-
-        def __repr__(self):
-            return repr(self.__dict__)
-
-    icd = iControlDriver(ConfFake(icd_config),
-                         registerOpts=False)
-
-    icd.plugin_rpc = fake_plugin_rpc
-    icd.connect()
-
-    return icd
 
 
 def test_single_pool(track_bigip_cfg, bigip, services, icd_config,


### PR DESCRIPTION
Fixes further bugs and incorporates logger items.

Also refactored the icontrol_driver fixture in the neutronless tests to be under ./neutron/conftest.py only as other tests that overwrote this fixture did not do anything different.

@jlongstaf 
#### What issues does this address?
Several of the functional tests

#### What's this change do?
Besides bugfixes, it addresses better logging by calling on more logger.debug() instances.

#### Where should the reviewer start?
anywhere... though tunnels/tunnel.py is a good central focus

#### Any background context?
neutronless/ports/ are still failing and a loadbalancer neutronless test is failing both appear to be due to the multiple subnets issue with members not cleaning up the additional subnet's tunnel (pre-existing and was masked by the folder purge).