### PR TITLE
Fixing key error for new member vtep handling

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py
@@ -157,10 +157,6 @@ class LBaaSBaseDriver(object):
         """Neutron Core Tunnel Update."""
         raise NotImplementedError()
 
-    def fdb_add(self, fdb_entries):
-        """L2 Population FDB Add."""
-        raise NotImplementedError()
-
     def fdb_remove(self, fdb_entries):
         """L2 Population FDB Remove."""
         raise NotImplementedError()

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
@@ -328,13 +328,14 @@ class TunnelBuilder(object):
             "executing {} on tm_tunnel({t.bigip_host}, {t.partition}, "
             "{t.tunnel_name})".format(laction, b=bigip, t=tunnel))
         result = execute(actions, action)
+        if action in ['create', 'exists', 'load']:
+            return result
         second_actions = {'delete': dict(payload={},
                                          method=result.delete)}
-        if action in second_actions:
-            tunnel.logger.debug(
-                "executing {} on tm_tunnel({t.bigip_host}, {t.partition}, "
-                "{t.tunnel_name})".format(action, b=bigip, t=tunnel))
-            result = execute(second_actions, action)
+        tunnel.logger.debug(
+            "executing {} on tm_tunnel({t.bigip_host}, {t.partition}, "
+            "{t.tunnel_name})".format(action, b=bigip, t=tunnel))
+        result = execute(second_actions, action)
         return result
 
     @staticmethod


### PR DESCRIPTION
Issues:
```python
Traceback (most recent call last):
  File "./f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py", line 1917, in _common_service_handler
    service, all_subnet_hints)
  File "./f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py", line 638, in post_service_networking
    self.update_bigip_l2(service)
  File "./f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py", line 713, in update_bigip_l2
    remove=True)
  File "./f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py", line 1157, in handle_fdbs_from_loadbalancer_and_members
    bigip, tunnel, loadbalancer, members, remove=remove)
  File "./f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/fdb.py", line 417, in handle_fdbs_by_loadbalancer_and_members
    mac = member['port']['mac_address']
KeyError: 'port'
```
- and -
```python
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/oslo_service/periodic_task.py", line 220, in run_periodic_tasks
    task(self, context)
  File "/usr/local/lib/python2.7/dist-packages/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py", line 589, in periodic_resync
    if self.tunnel_sync():
  File "/usr/local/lib/python2.7/dist-packages/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py", line 612, in tunnel_sync
    self.__tunnel_handler.tunnel_sync(bigips)
  File "/usr/local/lib/python2.7/dist-packages/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/cache.py", line 41, in lock_wrapper
    ret_val = method(cache, *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py", line 784, in tunnel_sync
    by_hostname[tunnel.bigip_host], tunnel)
  File "/usr/local/lib/python2.7/dist-packages/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/decorators.py", line 36, in wrapper
    return method(*args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py", line 621, in check_exists
    return cls.__tm_tunnel(bigip, tunnel, 'exists')
  File "/usr/local/lib/python2.7/dist-packages/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py", line 332, in __tm_tunnel
    method=result.delete)}
AttributeError: 'bool' object has no attribute 'delete'
```

Problem:
* Some members may not have a port resulting in the inability to get mac
* Sending 'exists' to `__tm_tunnel` produces a bool, not a `tm` object
  * This was understood, but mitakenly not caught

Analysis:
* Implemented a chain of `dict().get()` calls to extract this
  * Default values provided soak the `exc`
  * However, added `LOG.error` if/when `vteps` are associated
This will allow us to troubleshoot if/when we're supposed to create `Fdb` entries
but are unable to
* Second fix returns the exists result before `tm` interactions
  * Should also reduce runtime cost for create and load as well

Tests:
These were caught in a test

@jlongstaf 
#### What issues does this address?
Please see above

#### What's this change do?
Introduces further logging for special conditions and handles exists case for tm tunnels.

#### Where should the reviewer start?
tunnel.py and fdb.py

#### Any background context?
Continued efforts to get the tunnel refactor working.