### PR TITLE
Bugfix: handling ReferenceError

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/decorators.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/decorators.py
@@ -19,6 +19,7 @@ manipulations.
 # limitations under the License.
 #
 
+import gc
 import socket
 import sys
 import weakref
@@ -39,6 +40,10 @@ def weakref_handle(method):
                       "being deleted from the cache.  The agent will now "
                       "attempt to continue with the remaining tunnels to "
                       "be updated".format(method, args, kwargs))
+            gc.collect()
+            remaining = gc.garbage()
+            if remaining:
+                LOG.debug("garbage({})".format(remaining))
             return None
     return wrapper
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/fdb.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/fdb.py
@@ -381,6 +381,7 @@ class FdbBuilder(object):
         tunnel_handler.notify_vtep_existence(hosts)
 
     @classmethod
+    @wrapper.weakref_handle
     def handle_fdbs_by_loadbalancer_and_members(
             cls, bigip, tunnel, loadbalancer, members, remove=False):
         """Creates a list of fdb's from a loadbalancer/members values pair

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
@@ -302,6 +302,7 @@ class TunnelBuilder(object):
             "{} is not meant to be instantiated".format(self.__class__))
 
     @staticmethod
+    @wrappers.weakref_handle
     def __tm_tunnel(bigip, tunnel, action):
         # performs all actions on tm_tunnel by action
         def execute(actions, action):
@@ -394,6 +395,7 @@ class TunnelBuilder(object):
         return exe['method'](*exe['payload'])
 
     @classmethod
+    @wrappers.weakref_handle
     def __tm_fdb_tunnel(cls, bigip, tunnel, action, record={}):
         # performs all actions on tm_fdb_tunnel by action
         def execute(actions, action):
@@ -425,6 +427,7 @@ class TunnelBuilder(object):
             return firsts_result
 
     @staticmethod
+    @wrappers.weakref_handle
     def __tm_records(tm_fdb_tunnel, tunnel, action, record={}):
         if 'get_collection' in action:
             # We've got it!  Send it back...
@@ -512,6 +515,7 @@ class TunnelBuilder(object):
                 return method(cls, bigip, tunnel, fdb)
 
     @classmethod
+    @wrappers.weakref_handle
     def get_records_from_tunnel(cls, bigip, tunnel):
         records = cls.__tm_fdb_tunnel(bigip, tunnel, 'records_get_collection')
         return records
@@ -672,6 +676,7 @@ class TunnelBuilder(object):
                 cls.create_tunnel
 
     @classmethod
+    @wrappers.weakref_handle
     @wrappers.http_error(
         debug={404: "Attempted delete on non-existent record"})
     def remove_record_from_arp(cls, bigip, tunnel, fdb):
@@ -686,8 +691,7 @@ class TunnelBuilder(object):
             remove(fdb)
 
     @classmethod
-    # @_check_if_fdbs
-    # @wrappers.weakref_handle
+    @wrappers.weakref_handle
     def modify_fdb_in_tunnel(cls, bigip, tunnel, fdb):
         """Modifies a tunnel, fdb record that previously exists
 
@@ -765,6 +769,7 @@ class TunnelHandler(cache.CacheBase):
     def _get_bigips_by_hostname(bigips):
         return {x.hostname: x for x in bigips}
 
+    @wrappers.weakref_handle
     @cache.lock
     def tunnel_sync(self, bigips):
         """Checks the list of tunnels that are in pending exist status
@@ -790,6 +795,7 @@ class TunnelHandler(cache.CacheBase):
             self.notify_tunnel_existence(tunnel)
         self.__pending_exists = new_pending_exists
 
+    @wrappers.weakref_handle
     def check_fdbs(self, bigips, fdbs):
         """Checks the given fdbs against the network cache and returns hosts
 
@@ -948,6 +954,7 @@ class TunnelHandler(cache.CacheBase):
                           "{b.hostname}".format(name, partition, b=bigip))
         self.__delete_profile(bigip, 'vxlan', name, partition)
 
+    @wrappers.weakref_handle
     def create_multipoint_tunnel(self, bigip, model):
         """Creates a multipoint tunnel on the BIG-IP
 
@@ -1071,6 +1078,7 @@ class TunnelHandler(cache.CacheBase):
                         fdb_mod.FdbBuilder.create_fdbs_from_bigip_records(
                             bigip, records, tunnel), init=True)
 
+    @wrappers.weakref_handle
     def notify_tunnel_existence(self, tunnel):
         """Performs a notification on the tunnel_rpc that a tunnel is online
 
@@ -1085,6 +1093,7 @@ class TunnelHandler(cache.CacheBase):
         self.tunnel_rpc.tunnel_sync(self.context, tunnel.local_address,
                                     tunnel.tunnel_type)
 
+    @wrappers.weakref_handle
     def notify_vtep_existence(self, hosts, removed=False):
         """Notifies l2population rpc connection of vtep(s) being handled
 
@@ -1127,6 +1136,7 @@ class TunnelHandler(cache.CacheBase):
                     hosts[host] = [tunnel]
         return hosts
 
+    @wrappers.weakref_handle
     def handle_fdbs_from_loadbalancer_and_members(self, bigips, loadbalancer,
                                                   members, remove=False):
         """Handles corner-case of service request with new LB and members


### PR DESCRIPTION
Issues:
There exists a race condition that could result where a fdb gets called
interrupting things after a tunnel has been destroyed before the
tunnel's weakref gets cleared.  While there is no logistical way of
clearing this cleanly, it will result in a ReferenceError.

This change silences this weakreference failure.  At this point, it does
not matter if an FDB entry comes in on a tunnel that is being destroyed.
This includes members' vteps that come in post-destruction of the
tunnel.

This is a standard side effect of having to lock caches and a waiting
child never gets the chance to finish.

Problem:
* ReferenceError was thrown due to a destroyed tunnel before the
member's vteps are removed via deletion cycle of a Tunnel

Analysis:
* Uses a decorator to silence the ReferenceError during member deletion
  * Would only happen if a tunnel was destoryed BEFORE member teardown

Tests:
I'm not certain that there's a threat to tests; however, in my
estimation, the tunnel was acquired by the ReferenceError child, then it
released its lock, and the periodic clean-up task would come in and
potentially destroy the tunnel.  The ReferenceError child simply did not
have enough time to perform its cleanup in time.

Now, there does exist a risk that the ReferenceError was thrown before
member and other objects were destroyed appropriately on the BIG-IP.
This would simply mean that we do not have sufficient decorator
coverage handling the ReferenceError raises.

@jlongstaf 
#### What issues does this address?
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py", line 1917, in _common_service_handler
    service, all_subnet_hints)
  File "/usr/local/lib/python2.7/dist-packages/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py", line 638, in post_service_networking
    self.update_bigip_l2(service)
  File "/usr/local/lib/python2.7/dist-packages/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py", line 713, in update_bigip_l2
    remove=True)
  File "/usr/local/lib/python2.7/dist-packages/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py", line 1158, in handle_fdbs_from_loadbalancer_and_members
    bigip, tunnel, loadbalancer, members, remove=remove)
  File "/usr/local/lib/python2.7/dist-packages/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/fdb.py", line 400, in handle_fdbs_by_loadbalancer_and_members
    vtep_key = "{}_vteps".format(tunnel.tunnel_type)
ReferenceError: weakly-referenced object no longer exists
And other, potentially-linked errors.

#### What's this change do?
Performs a decorator to check for weakref(Tunnel) to then handle the exception and soak it.  This soaking is then logged along with a listing of any lingering, uncollected objects.

#### Where should the reviewer start?
tunnels.tunnel.TunnelHandler

#### Any background context?
This is in an effort to provide greater stability to tests.