### PR TITLE
Adding HTTPError handling for remove_multipoint

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
@@ -1006,7 +1006,14 @@ class TunnelHandler(cache.CacheBase):
             else:
                 raise cache.CacheError("Could not find tunnel({}, {}) "
                                        "to delete".format(name, partition))
-        TunnelBuilder.delete_tunnel(bigip, tunnel)
+        try:
+            TunnelBuilder.delete_tunnel(bigip, tunnel)
+        except HTTPError as error:
+            tunnel.logger.error(
+                "Attempted self destruction, but ran into a REST error: "
+                "{}".format(error))
+            # re-apply tunnel
+            self.__network_cache_handler.network_cache = tunnel
 
     @cache.lock
     def purge_multipoint_profiles(self, bigips):


### PR DESCRIPTION
Issues:
Virtuals were found to be lingering in tests while
remove_multipoint_tunnel was executed.  This handler will cause the NCH
to continue to track the tunnel, but also log the redundant attempt.

Problem:
* ICD will execute code that will attempt to del tunnel before the VS

Analysis:
* This results in a 400 error for a dependency conflict on big-ip

Tests:
Our tests ran into this.  Note that this is a patch of sorts and should
be corrected appropriately at the VS level as well to prevent other
types of potential conflicts.

@<reviewer_id>
#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?
