### PR TITLE
Format fix for lvl of dict:dict:list:list for port

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager.py
@@ -734,7 +734,7 @@ class TestLbaasAgentManager(LBaasAgentManagerMocker,
             fdb_entry = {
                 network_id: {
                     'network_type': 'vxlan',
-                    'ports': [{arp_address: [[fake_mac, vtep_ip]]}],
+                    'ports': {arp_address: [[fake_mac, vtep_ip]]},
                     'segment_id': 23}}
             context = mock.Mock()
             target.add_fdb_entries(context, fdb_entry)


### PR DESCRIPTION
Issues:
Was getting a list attribute error for 'get()'

Problem:
* Abstract level for dict(dict(list(list()))) was mistakenly placed
  * Discovered in end-to-end testing

Analysis:
* This fixes the issue by putting the de-reference in the right
placement

Tests:
* test_agent_manager.py has been modified to match the correct pattern

@jlongstaf 
#### What issues does this address?
Fixes the attribute error of 'get()' for a list logs that were being seen in end-to-end tests.

#### What's this change do?
Gets the format right versus what was given in user end-to-end tests
#### Where should the reviewer start?
tunnels.fdb.FdbBuilder._consolidate_fdbs

#### Any background context?
This is for L2 population.