### PR TITLE
Tagmode incorrectly set when creating VLANs

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
@@ -395,7 +395,6 @@ class NetworkHelper(object):
                 payload = {'name': interface}
                 if tag:
                     payload['tagged'] = True
-                    payload['tagMode'] = "service"
                 else:
                     payload['untagged'] = True
 
@@ -405,7 +404,6 @@ class NetworkHelper(object):
                 except TagModeDisallowedForTMOSVersion as e:
                     # Providing the tag-mode is not supported
                     LOG.warn(e.message)
-                    payload.pop('tagMode')
                     i.create(**payload)
 
             if not partition == const.DEFAULT_PARTITION:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_vlan.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_vlan.py
@@ -141,7 +141,7 @@ class TestVLANCreate(object):
             name='test_vlan', partition='Project_123456789', tag=1000)
 
         v.interfaces_s.interfaces.create.assert_called_with(
-            name='1.3', tagged=True, tagMode="service")
+            name='1.3', tagged=True)
 
     def test_create_vlan_with_tagged_int_11_5(self, bigip, network_helper):
         """Test vlan create when model contains tagged interface (TMOS 11.5)
@@ -150,7 +150,7 @@ class TestVLANCreate(object):
         expected args.
 
         2) Assert that create vlan interface called once with
-        expected args including tagMode.
+        expected args not including tagMode.
         3) The first call to create vlan interface results in exception
         that is caught.
         4) The subsequent call to create vlan interface does not have
@@ -182,9 +182,9 @@ class TestVLANCreate(object):
         # is called only twice.
         assert(call_count == 2)
 
-        # Check that tagMode was used in first call
+        # Check that tagMode was not used in first call
         args, kwargs = call_list[0]
-        assert("tagMode" in kwargs)
+        assert("tagMode" not in kwargs)
 
         # Check that tagMode was not used in second call.
         args, kwargs = call_list[1]


### PR DESCRIPTION

@richbrowne 
#### What issues does this address?
Fixes #1291

#### What's this change do?
Removes tagMode attribute for VLANs

#### Where should the reviewer start?
network_helper.py

#### Any background context?
See https://support.f5.com/csp/article/K64040012 for more information.