### PR TITLE
Adding 2018 to all copyright notices

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2015 F5 Networks Inc.
+Copyright (c) 2015-2018, F5 Networks, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 .. raw:: html
 
    <!--
-   Copyright 2015-2017 F5 Networks Inc.
+   Copyright (c) 2015-2018, F5 Networks, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -168,7 +168,7 @@ They do require access to a BIG-IP device or BIG-IP Virtual Edition (VE) instanc
 Copyright
 ---------
 
-Copyright 2015-2017 F5 Networks Inc.
+Copyright (c) 2015-2018, F5 Networks, Inc.
 
 Support
 -------

--- a/bin/debug_bundler.py
+++ b/bin/debug_bundler.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/_static/config_examples/f5-openstack-agent.gre.ini
+++ b/docs/_static/config_examples/f5-openstack-agent.gre.ini
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2017 F5 Networks Inc.
+# Copyright (c) 2015-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/_static/config_examples/f5-openstack-agent.grm.ini
+++ b/docs/_static/config_examples/f5-openstack-agent.grm.ini
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2017 F5 Networks Inc.
+# Copyright (c) 2015-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/_static/config_examples/f5-openstack-agent.vlan.ini
+++ b/docs/_static/config_examples/f5-openstack-agent.vlan.ini
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2017 F5 Networks Inc.
+# Copyright (c) 2015-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/_static/config_examples/f5-openstack-agent.vxlan.ini
+++ b/docs/_static/config_examples/f5-openstack-agent.vxlan.ini
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2017 F5 Networks Inc.
+# Copyright (c) 2015-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/etc/neutron/services/f5/f5-openstack-agent.ini
+++ b/etc/neutron/services/f5/f5-openstack-agent.ini
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright 2015-2016 F5 Networks Inc.
+# Copyright (c) 2015-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5-openstack-agent-dist/scripts/configure.py
+++ b/f5-openstack-agent-dist/scripts/configure.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5-openstack-agent-dist/scripts/construct_setups.py
+++ b/f5-openstack-agent-dist/scripts/construct_setups.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5-openstack-agent-dist/scripts/universal_truth.py
+++ b/f5-openstack-agent-dist/scripts/universal_truth.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -1,6 +1,6 @@
 """Agent manager to handle plugin to agent RPC and periodic tasks."""
 # coding=utf-8
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/barbican_cert.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/barbican_cert.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/cluster_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/cluster_manager.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/constants_v2.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/constants_v2.py
@@ -1,5 +1,5 @@
 """F5 LBaaSv2 constants for agent."""
-# Copyright 2014 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/esd_filehandler.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/esd_filehandler.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014-2017 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/exceptions.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/exceptions.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2017 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/fdb_connector.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/fdb_connector.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/fdb_connector_ml2.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/fdb_connector_ml2.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1,5 +1,5 @@
 # coding=utf-8#
-# Copyright 2014-2017 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l3_binding.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l3_binding.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l7policy_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l7policy_adapter.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l7policy_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l7policy_service.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014-2017 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py
@@ -1,4 +1,4 @@
-# Copyright 2014 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_service.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014-2017 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/plugin_rpc.py
@@ -1,5 +1,5 @@
 """RPC API for calls back to the plugin."""
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016-2017 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014-2017 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/ssl_profile.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/ssl_profile.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/stat_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/stat_helper.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/system_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/system_helper.py
@@ -1,4 +1,4 @@
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tenants.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tenants.py
@@ -1,5 +1,5 @@
 """Tenants Manager."""
-# Copyright 2014 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/class_tester_base_class.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/class_tester_base_class.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/conftest.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/conftest.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/mock_builder_base_class.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/mock_builder_base_class.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager_LbaasAgentManager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_agent_manager_LbaasAgentManager.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_esd_filehandler.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_esd_filehandler.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_exceptions.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_exceptions.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_icontrol_driver.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_icontrol_driver_opts.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_icontrol_driver_opts.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_l2_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_l2_service.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_l7policy_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_l7policy_service.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_lbaas_builder.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_listener_services.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_listener_services.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_network_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_network_helper.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_network_service.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_plugin_rpc.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_plugin_rpc.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_pool_services.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_pool_services.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_service_adapter.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_ssl_profile.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_ssl_profile.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_stat_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_stat_helper.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_utils.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_utils.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_vcmp.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_vcmp.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_virtual_address.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_virtual_address.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_vlan.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_vlan.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/cache.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/cache.py
@@ -3,7 +3,7 @@
 This library hosts a cache base class for tunnels.  This cache base allows for
 additional, shared functionalities between classes.
 """
-# Copyright 2018 F5 Networks Inc.
+# Copyright (c) 2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/decorators.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/decorators.py
@@ -4,7 +4,7 @@ This is a decorator library, and as such, all method within this library are
 decorator methods that either add wrappers or handle specific cases for method
 manipulations.
 """
-# Copyright 2018 F5 Networks Inc.
+# Copyright (c) 2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/fdb.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/fdb.py
@@ -4,7 +4,7 @@ This library houses the appropriate classes to orchestrate updating fdb vtep
 entries.  This library utilizes other, neighboring libraries to accomplish its
 task and relies heavily on tunnel logic.
 """
-# Copyright 2018 F5 Networks Inc.
+# Copyright (c) 2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/network_cache_handler.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/network_cache_handler.py
@@ -6,7 +6,7 @@ instance and be held within the AgentManager singleton object.
 
 This library simply hosts this cache handler.
 """
-# Copyright 2018 F5 Networks Inc.
+# Copyright (c) 2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/test/test_fdb_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/test/test_fdb_builder.py
@@ -7,7 +7,7 @@ objects.
 Thus, this test module handles all items surrounding the direct testing of
 FdbBuilder.
 """
-# Copyright 2018 F5 Networks Inc.
+# Copyright (c) 2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/test/test_network_cache_handler.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/test/test_network_cache_handler.py
@@ -5,7 +5,7 @@ module in production.  As such, it has the MockBuilder and the ClassTester
 classes needed to do so while using the agent's unit test schema.
 """
 
-# Copyright 2018 F5 Networks Inc.
+# Copyright (c) 2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/test/test_tunnel.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/test/test_tunnel.py
@@ -2,7 +2,7 @@
 
 This test library hosts all things for testing Tunnel operations.
 """
-# Copyright 2018 F5 Networks Inc.
+# Copyright (c) 2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
@@ -8,7 +8,7 @@ This module hosts 3 classes:
 These classes are used to orchestrate the necessary steps for handling the
 BIG-IP's tunnels.
 """
-# Copyright 2018 F5 Networks Inc.
+# Copyright (c) 2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/utils.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/utils.py
@@ -1,5 +1,5 @@
 """Utility classes and functions."""
-# Copyright 2014 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/vcmp.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/vcmp.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/virtual_address.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/virtual_address.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/vlan_binding.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/vlan_binding.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2014-2016 F5 Networks Inc.
+# Copyright (c) 2014-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/utils/clean_partition.py
+++ b/f5_openstack_agent/utils/clean_partition.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/f5_openstack_agent/utils/debug_bundler.py
+++ b/f5_openstack_agent/utils/debug_bundler.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016-2017 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/bigip_interaction.py
+++ b/test/functional/neutronless/bigip_interaction.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/conftest.py
+++ b/test/functional/neutronless/conftest.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016-2017 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/disconnected_service/Dockerfile
+++ b/test/functional/neutronless/disconnected_service/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/disconnected_service/conftest.py
+++ b/test/functional/neutronless/disconnected_service/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/disconnected_service/test_disconnected_service_creation.py
+++ b/test/functional/neutronless/disconnected_service/test_disconnected_service_creation.py
@@ -1,4 +1,4 @@
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/esd/conftest.py
+++ b/test/functional/neutronless/esd/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/esd/test_esd.py
+++ b/test/functional/neutronless/esd/test_esd.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/esd/test_esd_pairs.py
+++ b/test/functional/neutronless/esd/test_esd_pairs.py
@@ -1,4 +1,4 @@
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/esd/test_esd_pools.py
+++ b/test/functional/neutronless/esd/test_esd_pools.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/listener/test_listener_update.py
+++ b/test/functional/neutronless/listener/test_listener_update.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/listener/test_tcp_listener.py
+++ b/test/functional/neutronless/listener/test_tcp_listener.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/loadbalancer/conftest.py
+++ b/test/functional/neutronless/loadbalancer/conftest.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/loadbalancer/test_f5_common_networks.py
+++ b/test/functional/neutronless/loadbalancer/test_f5_common_networks.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer_admin_state.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer_admin_state.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer_disconnected.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer_disconnected.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer_opflex.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer_opflex.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer_rd.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer_rd.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/loadbalancer/test_loadbalancer_snat.py
+++ b/test/functional/neutronless/loadbalancer/test_loadbalancer_snat.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/loadbalancer/test_purge_folder.py
+++ b/test/functional/neutronless/loadbalancer/test_purge_folder.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/loadbalancer/test_snat_common_network.py
+++ b/test/functional/neutronless/loadbalancer/test_snat_common_network.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/member/test_single_member.py
+++ b/test/functional/neutronless/member/test_single_member.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/member/test_single_member_opflex.py
+++ b/test/functional/neutronless/member/test_single_member_opflex.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/member/test_single_member_weight_updates.py
+++ b/test/functional/neutronless/member/test_single_member_weight_updates.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/pool/test_delete_pool.py
+++ b/test/functional/neutronless/pool/test_delete_pool.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/pool/test_pool_lb_method_change.py
+++ b/test/functional/neutronless/pool/test_pool_lb_method_change.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/pool/test_session_persistence.py
+++ b/test/functional/neutronless/pool/test_session_persistence.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2017 F5 Networks Inc.
+# Copyright (c) 2017,2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/pool/test_single_pool.py
+++ b/test/functional/neutronless/pool/test_single_pool.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/testlib/bigip_client.py
+++ b/test/functional/neutronless/testlib/bigip_client.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/testlib/fake_rpc.py
+++ b/test/functional/neutronless/testlib/fake_rpc.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/testlib/resource_validator.py
+++ b/test/functional/neutronless/testlib/resource_validator.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016-2017 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/testlib/service_reader.py
+++ b/test/functional/neutronless/testlib/service_reader.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/vcmp/conftest.py
+++ b/test/functional/neutronless/vcmp/conftest.py
@@ -1,4 +1,4 @@
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/neutronless/vcmp/test_vcmp.py
+++ b/test/functional/neutronless/vcmp/test_vcmp.py
@@ -1,4 +1,4 @@
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/singlebigip/test_cluster.py
+++ b/test/functional/singlebigip/test_cluster.py
@@ -3,7 +3,7 @@ test_requirements = {'devices':         [VE],
                      'openstack_infra': []}
 
 '''
-# Copyright 2015-2018 F5 Networks Inc.
+# Copyright (c) 2015-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/singlebigip/test_network.py
+++ b/test/functional/singlebigip/test_network.py
@@ -4,7 +4,7 @@ test_requirements = {'devices':         [],
                      'openstack_infra': []}
 
 '''
-# Copyright 2015-2106 F5 Networks Inc.
+# Copyright (c) 2015-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/singlebigip/test_ssl_profile.py
+++ b/test/functional/singlebigip/test_ssl_profile.py
@@ -3,7 +3,7 @@ test_requirements = {'devices':         [VE],
                      'openstack_infra': []}
 
 '''
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/functional/singlebigip/test_stats.py
+++ b/test/functional/singlebigip/test_stats.py
@@ -4,7 +4,7 @@ test_requirements = {'devices':         [UNDERCLOUD],
                      'openstack_infra': []}
 
 '''
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/send_to_driver/test_create_tls_container.py
+++ b/test/send_to_driver/test_create_tls_container.py
@@ -4,7 +4,7 @@ test_requirements = {'devices':         [],
                      'openstack_infra': []}
 
 '''
-# Copyright 2016 F5 Networks Inc.
+# Copyright (c) 2016-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/test/send_to_driver/test_listener.py
+++ b/test/send_to_driver/test_listener.py
@@ -4,7 +4,7 @@ test_requirements = {'devices':         [VE],
                      'openstack_infra': []}
 
 '''
-# Copyright 2015-2106 F5 Networks Inc.
+# Copyright (c) 2015-2018, F5 Networks, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Issues: Adding 2018 to all copyright notices.
Fixes #<issueid>

Problem: All the copyright notices were not updated with the latest year.

Analysis: Updated all copyright notices with 2018 year.

Tests: No tests

@jlongstaf 
#### What issues does this address? Updation of all copyright notices with "2018" year.
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?
