### PR TITLE
Provide IPv6 mask for IPv6 virtual servers.

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -451,8 +451,11 @@ class ServiceModelAdapter(object):
                 vip['destination'] = ip_address + ":" + str(port)
         else:
             LOG.error("No VIP address or port specified")
-
-        vip["mask"] = '255.255.255.255'
+        
+        if ':' in ip_address:
+            vip["mask"] = 'FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF'
+        else:
+            vip["mask"] = '255.255.255.255'
 
         if "admin_state_up" in listener:
             if listener["admin_state_up"]:


### PR DESCRIPTION
The VIP netmask was always given as 255.255.255.255 which caused errors
when placing a Neutron LB on an IPv6 subnet. This passes the proper /128
mask for IPv6 virtual server IP addresses.

@richbrowne 
#### What issues does this address?
Fixes #1294 
...

#### What's this change do?
This change causes the agent to pass "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff" as the netmask for IPv6 VIPs rather than the previous value of 255.255.255.255. I did not do testing with IPv6 pool members.

#### Where should the reviewer start?
service_adapter.py

#### Any background context?
This resolves a failure to provision a Neutron LB on an IPv6 subnet. In the test scenario, the LB is placed on a shared IPv6 subnet while the backends are on an IPv4 tenant network. 