### PR TITLE
Device tests fail against BIG-IP 13.0.0

### DIFF
--- a/test/functional/singlebigip/test_cluster.py
+++ b/test/functional/singlebigip/test_cluster.py
@@ -39,7 +39,9 @@ def test_devices(mgmt_root, symbols):
     for k, v in symbols.__dict__.items():
         print('key: {}'.format(k))
         print('value: {}'.format(v))
-    assert devices[0].managementIp == symbols.bigip_mgmt_ips[0]
+    # for 13.0.0, mgmt IP will always be 192.168.1.245
+    assert (devices[0].managementIp == symbols.bigip_mgmt_ips[0] or
+            devices[0].managementIp == '192.168.1.245')
 
 
 def test_get_sync_status(mgmt_root):
@@ -78,4 +80,6 @@ def test_get_mgmt_addr_by_device(symbols, mgmt_root):
     pp(dir(symbols))
     device_name = mgmt_root._meta_data['device_name']
     addr = cm.get_mgmt_addr_by_device(mgmt_root, device_name)
-    assert addr == symbols.bigip_mgmt_ips[0]
+    # for 13.0.0, mgmt IP will always be 192.168.1.245
+    assert (addr == symbols.bigip_mgmt_ips[0] or
+            addr == '192.168.1.245')


### PR DESCRIPTION

#### What issues does this address?
Device tests fail when checking BIG-IP management address.

#### What's this change do?
 13.0.0. introduced a change where the management IP defaults
to 192.168.1.245 when the BIG-IP (in our test environment) cannot
get an IP address from DNS. This IP address is not defined in
our test symbols and the tests fail. Modified test to check
for either symbol address or 192.168.1.245.

#### Where should the reviewer start?
test_cluster.py

#### Any background context?
No.