### PR TITLE
Checking integrity

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -37,7 +37,6 @@ except ImportError:
     from neutron import context as ncontext
 
 import f5_openstack_agent.lbaasv2.drivers.bigip.constants_v2 as constants_v2
-import f5_openstack_agent.lbaasv2.drivers.bigip.tunnels.fdb as fdb
 import f5_openstack_agent.lbaasv2.drivers.bigip.tunnels.tunnel as tunnel
 
 from f5_openstack_agent.lbaasv2.drivers.bigip import exceptions as f5_ex
@@ -1298,9 +1297,7 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
         try:
             LOG.debug('received add_fdb_entries: %s host: %s'
                       % (fdb_entries, host))
-            bigips = self.__lbdriver.get_all_bigips()
-            fdb.FdbBuilder.handle_fdbs(fdb_entries, self.tunnel_handler,
-                                       bigips)
+            self.__lbdriver.handle_fdbs(fdb_entries)
         except f5_ex.F5NeutronException as exc:
             LOG.error("fdb_add: NeutronException: %s" % exc.msg)
         except Exception as exc:
@@ -1313,7 +1310,7 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
         try:
             LOG.debug('received remove_fdb_entries: %s host: %s'
                       % (fdb_entries, host))
-            fdb.FdbBuilder.handle_fdbs(fdb_entries, remove=True)
+            self.__lbdriver.handle_fdbs(fdb_entries, remove=True)
         except f5_ex.F5NeutronException as exc:
             LOG.error("remove_fdb_entries: NeutronException: %s" % exc.msg)
         except Exception as exc:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
@@ -343,7 +343,7 @@ class L2ServiceBuilder(object):
                     bigip, payload['name'], payload['partition'],
                     payload['route_domain_id'])
         except Exception as err:
-            LOG.exception("%s", err.message)
+            LOG.error("%s", err.message)
             raise f5_ex.VXLANCreationException(
                 "Failed to create vxlan tunnel: %s" % tunnel_name
             )
@@ -377,7 +377,7 @@ class L2ServiceBuilder(object):
                     bigip, payload['name'], payload['partition'],
                     payload['route_domain_id'])
         except Exception as err:
-            LOG.exception("%s", err.message)
+            LOG.error("%s", err.message)
             raise f5_ex.VXLANCreationException(
                 "Failed to create gre tunnel: %s" % tunnel_name
             )
@@ -509,9 +509,8 @@ class L2ServiceBuilder(object):
                 bigip,
                 tunnel_name,
                 partition=network_folder)
-        except Exception as err:
+        except Exception:
             # Just log the exception, we want to continue cleanup
-            LOG.exception(err)
             LOG.error(
                 "Failed to delete vxlan tunnel: %s" % tunnel_name)
 
@@ -525,9 +524,8 @@ class L2ServiceBuilder(object):
                 tunnel_name,
                 partition=network_folder)
 
-        except Exception as err:
+        except Exception:
             # Just log the exception, we want to continue cleanup
-            LOG.exception(err)
             LOG.error(
                 "Failed to delete gre tunnel: %s" % tunnel_name)
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
@@ -84,17 +84,25 @@ class NetworkServiceBuilder(object):
         if vtep_selfip_name and \
                 not vtep_selfip_name.lower() == 'none':
 
-            # profiles may already exist
-            # create vxlan_multipoint_profile`
-            self.driver.tunnel_handler.create_vxlan_multipoint_profile(
-                bigip,
-                'vxlan_ovs',
-                partition='Common')
-            # create l2gre_multipoint_profile
-            self.driver.tunnel_handler.create_l2gre_multipoint_profile(
-                bigip,
-                'gre_ovs',
-                partition='Common')
+            try:
+                # profiles may already exist
+                # create vxlan_multipoint_profile`
+                self.driver.tunnel_handler.create_vxlan_multipoint_profile(
+                    bigip,
+                    'vxlan_ovs',
+                    partition='Common')
+            except Exception as error:
+                LOG.debug(
+                    "Could not create vxlan profile due to {}".format(error))
+            try:
+                # create l2gre_multipoint_profile
+                self.driver.tunnel_handler.create_l2gre_multipoint_profile(
+                    bigip,
+                    'gre_ovs',
+                    partition='Common')
+            except Exception as error:
+                LOG.debug(
+                    "Could not create gre profile due to {}".format(error))
 
             # find the IP address for the selfip for each box
             local_ip = self.bigip_selfip_manager.get_selfip_addr(

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tenants.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tenants.py
@@ -106,6 +106,7 @@ class BigipTenantManager(object):
         partition = self.service_adapter.get_folder_name(tenant_id)
         domain_names = self.network_helper.get_route_domain_names(bigip,
                                                                   partition)
+        self.driver.tunnel_handler.purge_tunnels([bigip], partition=partition)
         for domain_name in domain_names:
             try:
                 self.network_helper.delete_route_domain(bigip,

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/cache.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/cache.py
@@ -19,9 +19,6 @@ additional, shared functionalities between classes.
 #
 
 import gc
-import os
-import threading
-import time
 
 import f5_openstack_agent.lbaasv2.drivers.bigip.exceptions as f5_ex
 
@@ -32,133 +29,12 @@ class CacheError(f5_ex.F5AgentException):
         message = "{} (gc.garbage: {})".format(message, gc.garbage)
 
 
-def lock(method):
-    def lock_wrapper(cache, *args, **kwargs):
-        """Places a lock on the instance of the object"""
-        cache.acquire_lock()
-        try:
-            attempted_lock_acquire_time = time.time()
-            cache.logger.debug(
-                "Locked {} for {}".format(
-                    cache.__class__.__name__, method.__name__))
-            method_start_time = time.time()
-            ret_val = method(cache, *args, **kwargs)
-        except RuntimeError:
-            cache.logger.exception("A lock-mechanism error has occurred!")
-        finally:
-            method_end_time = time.time()
-            cache.release_lock()
-            lock_end_time = time.time()
-            cache.logger.debug(
-                "Unlocked {} by {} method tool {} seconds lock {} "
-                "seconds".format(
-                    cache.__class__.__name__, method.__name__,
-                    method_start_time - method_end_time,
-                    attempted_lock_acquire_time - lock_end_time))
-        return ret_val
-    return lock_wrapper
-
-
 class CacheBase(object):
     """A base class for all, standalone, cache objects
-
-    This object hosts commonly referenced caching needs including locking,
-    primarily, object-locking capabilities.
-
-    Such locking mechanisms assume that the lock needs to be a thread lock
-    ONLY and does not guarentee safty across multiple PID's.
-
-    This object DOES NOT offer any with block support for locking mechanisms!
-    It is assumed that the cache's API will lock the object if/when necessary
-    for certain operations.
 
     Args:
         None
     Returns:
         None
     """
-    def __init__(self):
-        self.__mechanism = threading.Lock()
-        self.__workers_waiting = 0
-        self.__lock_acquired = None
-        self.__workers_locks = threading.Condition(self.__mechanism)
-        self.__my_pid = os.getpid()
-
-    def acquire_lock(self):
-        """Handles cache locking mechanisms for this object
-
-        This method will take the method call with all of its args, lock the
-        object using the threading library, exceute the method, then unlock
-        the object and return the method-call's results.
-
-        The caller assumes all liability in orchestrating locks appropriately.
-        Thus, this method is not responsible for the enter/exit strategy of
-        this object's locking mechanism.
-
-        Deadlock Prevention:
-            There are several arguments on how to handle deadlock prevention.
-            The biggest taboo; however, is a constraint where objects under
-            lock are modified, a catch that includes what is thrown captures
-            then the exception within to-be locked code.  As such, a Cache
-            SHOULD NEVER catch a RuntimeError or lower!
-
-            Let me repeat: this branch of exceptions should not be caught
-            anywhere within a Cache object instance!
-
-        Args:
-            None
-        Returns:
-            None
-        Wrapping:
-            It is assumed that the caller will wrap things appropriately to
-            unlock this lock when appropriate.
-        """
-        if self.__lock_acquired == threading.current_thread():
-            # perform lock-out safety... This SHOULD NOT happen!
-            msg = str("Attempting to acquire the same lock as I already have "
-                      "(thread-wise)")
-            # self.logger.warning(msg)
-            self.release_lock()
-            raise RuntimeError(msg)
-            # return
-        my_pid = os.getpid()
-        if self.__my_pid != os.getpid():
-            self.logger.warning("Cache object does not support "
-                                "multiprocessing (mypid: {}; create_pid: {})".
-                                format(my_pid, self.__my_pid))
-        with self.__mechanism:
-            while self.__lock_acquired:
-                self.__workers_waiting += 1
-                self.__workers_locks.wait()
-                self.__workers_waiting -= 1
-            self.__lock_acquired = threading.current_thread()
-
-    def release_lock(self):
-        """Releases an afore-created lock
-
-        Expected bahavior of deadlock-prevention code:
-            It is expected, if a deadlock occurs, is a 2 layer exception.  One
-            for when the deadlock is detected, and the second when the locking
-            mechanism that originally existed attempted to unlock the
-            mechanism.
-
-        To prevent this from causing a troubleshooting taboo, there is a
-        mechanism that will produce a Loggr.exception() to capture this
-        information.
-        """
-        with self.__mechanism:
-            my_thread = threading.current_thread()
-            # lock sanity checking...
-            if self.__lock_acquired is None:
-                raise RuntimeError("We can't release a non-acquired lock!")
-            elif not self.__lock_acquired:
-                self.logger.error("Shying away from unlocking an "
-                                  "unlocked-lock!")
-            elif self.__lock_acquired != my_thread and self.__lock_acquired:
-                raise RuntimeError(
-                    "We can't release another's lock "
-                    "(lock({}), thread({}))".format(
-                        self.__lock_acquired, my_thread))
-            self.__lock_acquired = None
-            if self.__workers_waiting > 0:
-                self.__workers_locks.notify()
+    pass

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/decorators.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/decorators.py
@@ -22,6 +22,7 @@ manipulations.
 import gc
 import socket
 import sys
+import time
 import weakref
 
 from requests import HTTPError
@@ -29,6 +30,20 @@ from requests import HTTPError
 import oslo_log.log as logging
 
 LOG = logging.getLogger(__name__)
+
+
+def timed(method):
+    """Adds a decorator that provides timing data for a decorated function"""
+    def timer(*args, **kwargs):
+        start = time.time()
+        inst = args[0]
+        logger = getattr(inst, 'logger', LOG)
+        logger.debug("Executing {m.__name__} at {}".format(start, m=method))
+        retval = method(*args, **kwargs)
+        logger.debug("Executing {m.__name__} at {}".format(
+            time.time() - start, m=method))
+        return retval
+    return timer
 
 
 def weakref_handle(method):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/network_cache_handler.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/network_cache_handler.py
@@ -21,8 +21,6 @@ This library simply hosts this cache handler.
 # limitations under the License.
 #
 
-import weakref
-
 from oslo_log import log as logging
 
 import f5_openstack_agent.lbaasv2.drivers.bigip.tunnels.cache as cache
@@ -31,18 +29,6 @@ import f5_openstack_agent.lbaasv2.drivers.bigip.tunnels.decorators as \
 # import f5_openstack_agent.lbaasv2.drivers.bigip.network_helper
 
 LOG = logging.getLogger(__name__)
-
-
-def handle_weakref(method):
-    def wrapper(instance, network, seg_id, segmentation, cnt):
-        try:
-            return method(instance, network, seg_id, segmentation, cnt)
-        except weakref.ReferenceError:
-            segmentation.pop(cnt)
-            LOG.debug("Network: '{}', Segment: '{}' being cleared from "
-                      "cache".format(network, seg_id))
-            return None
-    return wrapper
 
 
 class NetworkCacheHandler(cache.CacheBase):
@@ -54,64 +40,148 @@ class NetworkCacheHandler(cache.CacheBase):
     """
     @decorators.add_logger
     def __init__(self):
-        self.__existing_tunnels = []
         self.__network_cache = {}
         super(NetworkCacheHandler, self).__init__()
 
-    @cache.lock
+    def __nonzero__(self):
+        return len(self.__network_cache) > 0
+
+    def __iter__(self):
+        tunnels = [
+            cached
+            for net_id in self.__network_cache
+            for seg_id in self.__network_cache[net_id]
+            for cached in self.__network_cache[net_id][seg_id]]
+        self.logger.debug("Iter returned {}".format(tunnels))
+        return iter(tunnels)
+
     def _add_to_network_cache(self, tunnel):
         # Locks and finally stores the new tunnel within the __network_cache.
         # this being the crux of this design, has to be as solid as possible
-        tunnel_proxy = weakref.proxy(tunnel)
         network_id, segment_id = tunnel.network_id, tunnel.segment_id
         network = self.__network_cache.get(network_id, dict())
-        segment = network.get(segment_id, list())
-        segment.append(tunnel_proxy)
+        segment = network.get(segment_id, set())
+        segment.add(tunnel)
         network[segment_id] = segment  # a re-reference is cheap
         self.__network_cache[network_id] = network
-        self.__existing_tunnels.append(tunnel)
+        self.logger.debug(
+            "added {} making {}".format(
+                tunnel, self.__network_cache))
 
     def _get_network_cache(self):
         # A placeholder get method
         raise NotImplementedError("Not currently set up to return the cache")
 
-    @cache.lock
+    def tunnel_sync(self, to_remove):
+        """The only way that tunnels can be removed from the cache for standby
+
+        This method will take a list of tunnels that are no longer viable and
+        will remove them from the __network_cache.  This will still leave
+        the primitive levels (dict/key/value pairs of net/segment present),
+        but will remove the Tunnel object instances themselves.
+
+        Args:
+            to_remove - [Tunnel] objects to be removed
+        Returns:
+            None
+        """
+        for tunnel in to_remove:
+            self.purge_tunnel(tunnel)
+
     def remove_tunnel(self, bigip_host, tunnel=None, name=None,
                       partition=None):
-        """Removes a Tunnel object instance from the cache
+        """Begins prep to start tunnel's removal
 
-        This method will take a Tunnel object and remove it from the list
-        __existing_tunnels.
+        This method will simply return the provided tunnel based upon provided
+        parameters.
 
-        As this is the hard reference to the tunnel object, it will leave the
-        __network_cache's instance pointing to None.  This will be handled in
-        check_fdbs appropriately enough to not fail, and remove them to no
-        longer cause issues.
+        It will not delete the tunnel from the cache or perform any actions
+        of that nature against the tunnel
         """
+        self.logger.debug("Searching for Tunnel({}, {} ,{}, {}) in {}".format(
+            bigip_host, tunnel, name, partition, self.__network_cache))
         retval = None
         if tunnel:
-            try:
-                self.__existing_tunnels.remove(tunnel)
-                retval = tunnel
-            except ValueError:
-                pass
-        elif name and partition:
-            for cnt, tunnel in enumerate(self.__existing_tunnels):
-                if tunnel.tunnel_name == name and \
-                        partition == tunnel.partition:
-                    retval = self.__existing_tunnels.pop(cnt)
+            segment = tunnel.segment_id
+            network = tunnel.network_id
+            net = self.__network_cache.get(network, dict())
+            seg = net.get(segment, set())
+            for itunnel in seg:
+                if tunnel == itunnel:
+                    retval = itunnel
                     break
+        elif name and partition:
+            tunnels = iter(self)
+            found = \
+                filter(lambda t: t.tunnel_name == name and
+                       t.bigip_host == bigip_host and t.partition == partition,
+                       tunnels)
+            if found:
+                retval = found[0]
         else:
-            raise ValueError("Cannot operate without name & partition or "
-                             "tunnel")
+            raise ValueError(
+                "Cannot operate without name & partition or tunnel, "
+                "(host: {}, tunnel: {}, name: {}, partition: {}".format(
+                    bigip_host, tunnel, name, partition))
+        if not retval:
+            self.logger.error(
+                "Could not return proper tunnel match with given args!"
+                "(bigip_host={}, tunnel={}, name={}, partition={})".format(
+                    bigip_host, tunnel, name, partition))
         return retval
 
-    @handle_weakref
+    def purge(self, partition=None):
+        """This method will iterate through all Tunnels and purge
+
+        If a partition is yielded, then only the Tunnels with the same
+        partition will be destroyed.
+
+        Args:
+            None
+        KWArgs:
+            partition - string representing the partiiton's name
+        Returns:
+            None
+        """
+        tunnels = iter(self)
+        for tunnel in tunnels:
+            if partition and tunnel.partition != partition:
+                continue
+            self.purge_tunnel(tunnel)
+
+    def purge_tunnel(self, tunnel):
+        """This method will destory the tunnel perminently from the cache
+
+        This method is NOT a means to destroy the tunnel on the BIG-IP.
+        Instead, it will destory the tunnel locally here on the cached
+        instance on NCH, if it exists.  If it does not exist, then it will
+        handle the set().remove's thrown KeyError and file a debug message.
+
+        Args:
+            tunnel - the Tunnel object ot be purged
+        Returns:
+            None
+        Exceptions:
+            None planned.
+        """
+        segment_id = tunnel.segment_id
+        network_id = tunnel.network_id
+        tunnel_stmt = \
+            str("Tunnel(name: {t.tunnel_name}, net: {}, host: "
+                "{t.bigip_host})").format(network_id, t=tunnel)
+        self.logger.debug("Removing {} from Cache".format(tunnel_stmt))
+        net = self.__network_cache.get(network_id, {})
+        seg = net.get(segment_id, set())
+        try:
+            seg.remove(tunnel)
+        except KeyError:
+            self.logger.debug(
+                "Removal failed due to unfound {}".format(tunnel_stmt))
+
     def __check_network_segment(self, network, seg_id, segment, cnt):
         tunnel = segment[cnt]
         return (tunnel.bigip_host, tunnel.partition, tunnel)
 
-    @cache.lock
     def check_fdb_entries_networks(self, fdbs):
         """Wraps any relevant Fdb object given with its associated tunnel data
 
@@ -131,7 +201,6 @@ class NetworkCacheHandler(cache.CacheBase):
                 continue
         return hosts
 
-    @cache.lock
     def get_tunnels_by_designation(self, network_id, segment):
         try:
             hosts = self._get_tunnels_by_designation(network_id, segment)
@@ -142,13 +211,9 @@ class NetworkCacheHandler(cache.CacheBase):
     def _get_tunnels_by_designation(self, network_id, segment, hosts=dict(),
                                     fdb=None):
         segment = str(segment)
-        tunnels = self.__network_cache[network_id][segment]
-        removal = list()
-        for cnt, tunnel in enumerate(tunnels):
-            try:
-                tunnel.tunnel_name
-            except ReferenceError:
-                removal.append(cnt)
+        tunnels = self.__network_cache.get(network_id, {}).get(segment, [])
+        for tunnel in tunnels:
+            tunnel.tunnel_name
             if fdb and tunnel.local_address == fdb.vtep_ip:
                 return
             host = tunnel.bigip_host
@@ -161,37 +226,6 @@ class NetworkCacheHandler(cache.CacheBase):
                 level = hosts.get(host, [])
                 level.append(tunnel)
                 hosts[host] = level
-        if removal:
-            if len(removal) == len(tunnel):
-                del self.__network_cache[network_id][segment]
-                if not self.__network_cache[network_id]:
-                    del self.__network_cache[network_id]
-            else:
-                for cnt in removal:
-                    tunnels.pop(cnt)
         return hosts
-
-    def clean_network_cache(self):
-        """Performs a thorough sweep against the cache cleaning it of weakrefs
-
-        This method will sweep through all entries in the dict portion of the
-        cache cleaning up weakrefs.
-        """
-        for net in self.__network_cache:
-            network_lvl = self.__network_cache[net]
-            for seg in network_lvl:
-                segment = network_lvl[seg]
-                removals = list()
-                for cnt, entry in enumerate(segment):
-                    try:
-                        segment.tunnel_name
-                    except ReferenceError:
-                        removals.append(cnt)
-                for cnt in removals:
-                    segment.pop(cnt)
-                if not segment:
-                    del network_lvl[seg]
-            if not network_lvl:
-                del self.__network_cache[net]
 
     network_cache = property(_get_network_cache, _add_to_network_cache)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tm_actions.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tm_actions.py
@@ -1,0 +1,655 @@
+"""A library that hosts tm.net action objects
+
+These objects are used to perform a single action on the BIG-IP efficiently.
+"""
+# Copyright 2018 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+
+from requests import HTTPError
+
+import f5_openstack_agent.lbaasv2.drivers.bigip.constants_v2 as const
+import f5_openstack_agent.lbaasv2.drivers.bigip.tunnels.decorators as wrappers
+
+
+class TmNetActionBase(object):
+    """Creates a base tm action object against the BIG-IP
+
+    This is a base action class that will house base functionality of the
+    TmAction specific object.
+
+    obj = TmNetAction(bigip.tm.net.obj, action)
+
+    The action argument is a string of create, load, modify, or delete.
+    The bigip.tm.net.obj is just a shortening of the tm type modification on
+        the BIG-IP.
+    """
+    _possible_actions = []  # replace me in a specific!
+
+    def __init__(self, bigip, action):
+        self.action = action
+        self._set_tm(bigip)
+        self._payloads = []
+
+    def __call__(self, *args, **kwargs):
+        action = self.action
+        execute = None
+        blessed_actions = self._possible_actions
+        if action in blessed_actions:
+            execute = getattr(self, action)
+        else:
+            raise ValueError("Invalid action choice {}".format(self.action))
+        return execute(*args, **kwargs)
+
+    def _set_tm(self, bigip):
+        self.tm = bigip.tm.net
+
+    def _get_tm(self, bigip):
+        raise NotImplementedError("Should be defined in specific")
+
+    def execute(self, action=None, payload={}):
+        """Performs execution on the provided action on object instantiation
+
+        This method will attempt to perform the provided action on the
+        bigip.tm.net...
+        object instance
+
+        Args:
+            None
+        KWArgs:
+            action - string specific of an action that getattr can be applied
+            to for self.tm.  That said, modify and delete will load the object
+            first.
+        """
+        raise NotImplementedError("This object is not implemented!")
+
+    def _execute(self, action=None, payload={}):
+        # performs a BIG-IP action execution in a logger frame...
+        my_action = getattr(self.tm, action)
+        payload = dict() if isinstance(payload, type(None)) else payload
+        self.logger.debug(
+            "Executing {} {}({})".format(action, my_action, payload))
+        ret_val = my_action(**payload)
+        self.logger.debug(
+            "Successfuly executed {} {}({})!".format(
+                action, my_action, payload))
+        return ret_val
+
+    def load_payload(self):
+        """Creates a payload of the general-case's load, which is tunnels"""
+        tunnel = self.tunnel
+        return dict(name=tunnel.tunnel_name, partition=tunnel.partition)
+
+    def load(self):
+        """Performs a load operation for the object, if load is the action"""
+        payload = self.load_payload()
+        return self._execute(action='load', payload=payload)
+
+    def delete(self):
+        """Performs a delete operation for the object, if delete is the action
+
+        There is no validation against the action, persay
+        """
+        payload = self.load_payload()
+        loaded = self.load(**payload)
+        loaded.delete()
+
+    def exists(self):
+        """Performs an exists operation for the object, if that's the action"""
+        payload = self.load_payload()
+        return self._execute(action='exists', payload=payload)
+
+    def create(self):
+        """Performs an create operation for the object, if that's the action"""
+        payload = self.create_payload()
+        return self._execute(action='create', payload=payload)
+
+    def modify(self, *args, **kwargs):
+        """Performs an modify operation for the object, if that's the action"""
+        old_tm = self.tm
+        try:
+            load_payload = self.load_payload()
+            self.tm = self._execute(action='load', payload=load_payload)
+            return self._execute(action='modify', payload=kwargs)
+        finally:
+            self.tm = old_tm
+
+    def get_collection(self, *args, **kwargs):
+        """Performs a get_collection on a collection-based tm object"""
+        payload = self.get_collection_payload()
+        return self.tm.get_collection(**payload)
+
+    def not_supported(self, *args, **kwargs):
+        """A general no-opt raise for actions unrecognized"""
+        raise NotImplementedError(
+            "action '{}' not supported for this object".format(self.action))
+
+
+class TmTunnelsProfiles(TmNetActionBase):
+    """Extract bigip.tm.net.tunnels.vxlans|gres.get_collection"""
+    _possible_actions = ['get_collection']
+
+    @wrappers.add_logger
+    def __init__(self, bigip, action, tunnel_type):
+        self.logger.debug(
+            "Performing {} on {} Profile({}s)".format(
+                action, bigip.hostname, tunnel_type))
+        self.tunnel_type = tunnel_type
+        super(TmTunnelsProfiles, self).__init__(bigip, action)
+
+    def _set_tm(self, bigip):
+        super(TmTunnelsProfiles, self)._set_tm(bigip)
+        self.tm = getattr(self.tm.tunnels, "{}s".format(self.tunnel_type))
+
+    def execute(self):
+        """Performs a call to self and returns"""
+        return self()
+
+    def get_collection_payload(self):
+        """Returns expected payload for get_collection"""
+        return {}
+
+
+class TmTunnelsProfile(TmNetActionBase):
+    """Extract bigip.tm.net.tunnels.vxlans|gres.vxlan|gre.CRUD"""
+    _possible_actions = ['create', 'modify', 'delete', 'load']
+
+    @wrappers.add_logger
+    def __init__(self, bigip, tunnel_type, name, partition, action):
+        self.logger.debug(
+            "Performing {} on {} Profile({}s)".format(
+                action, bigip.hostname, tunnel_type))
+        self.tunnel_type = tunnel_type
+        self.name = name
+        self.partition = partition
+        super(TmTunnelsProfile, self).__init__(bigip, action)
+
+    def _set_tm(self, bigip):
+        super(TmTunnelsProfile, self)._set_tm(bigip)
+        tunnel_type = self.tunnel_type
+        self.logger.debug("tunnel_type: {}".format(tunnel_type))
+        if tunnel_type is 'vxlan':
+            self.tm = self.tm.tunnels.vxlans.vxlan
+        elif tunnel_type is 'gre':
+            self.tm = self.tm.tunnels.gres.gre
+
+    def create_payload(self):
+        ttype = self.tunnel_type
+        base = dict(name=self.name, partition=self.partition,
+                    floodingType='multipoint', defaultsFrom=ttype)
+        if ttype is 'vxlan':
+            base.update(dict(port=const.VXLAN_UDP_PORT))
+        elif ttype is 'gre':
+            base.update(encapsulation='transparent-ethernet-bridging')
+        else:
+            raise ValueError("Unrecognized tunnel-type: '{}'".format(ttype))
+        return base
+
+    def load_payload(self):
+        return dict(name=self.name, partition=self.partition)
+
+    def execute(self):
+        """Performs a call to self and returns"""
+        return self()
+
+
+class FdbTunnel(TmNetActionBase):
+    """Creates a TmTunnel TmNetAction object for manipulating Tunnels
+
+    This object is used to interact with the
+    bigip.tm.net.fdb.tunnels.tunnel objects for basic CRUD operations ONLY
+    and performs no tracking.
+
+    There should be an object per action
+    """
+    _possible_actions = ['load', 'exists', 'modify']
+
+    @wrappers.add_logger
+    def __init__(self, bigip, tunnel, action):
+        self.logger.debug(
+            "Performing {} on {} Tunnel({t.tunnel_name}, "
+            "{t.partition})".format(
+                action, hex(id(tunnel)), t=tunnel))
+        super(FdbTunnel, self).__init__(bigip, action)
+        self.tunnel = tunnel
+
+    def _set_tm(self, bigip):
+        super(FdbTunnel, self)._set_tm(bigip)
+        self.tm = self.tm.fdb.tunnels.tunnel
+
+    def execute(self):
+        """An over-writing execute method that calls self"""
+        return self()
+
+
+class TmTunnel(TmNetActionBase):
+    """Creates a TmTunnel TmNetAction object for manipulating Tunnels
+
+    This object is used to interact with the
+    bigip.tm.net.tunnels.tunnels.tunnel objects for basic CRUD operations ONLY
+    and performs no tracking.
+
+    There should be an object per action
+    """
+    _possible_actions = ['load', 'delete', 'create', 'exists']
+
+    @wrappers.add_logger
+    def __init__(self, bigip, tunnel, action):
+        self.logger.debug(
+            "Performing {} on {} Tunnel({t.tunnel_name}, "
+            "{t.partition})".format(action, hex(id(tunnel)), t=tunnel))
+        super(TmTunnel, self).__init__(bigip, action)
+        self.bigip = bigip
+        self.tunnel = tunnel
+
+    def _set_tm(self, bigip):
+        super(TmTunnel, self)._set_tm(bigip)
+        self.tm = self.tm.tunnels.tunnels.tunnel
+
+    def create_payload(self):
+        """Specifies payload for create action"""
+        tunnel = self.tunnel
+        description = json.dumps(
+            dict(partition=tunnel.partition, network_id=tunnel.network_id,
+                 remote_address=tunnel.remote_address))
+        create_payload = dict(
+            name=tunnel.tunnel_name, description=description,
+            profile=tunnel.profile, key=tunnel.key,
+            partition=tunnel.partition, localAddress=tunnel.local_address,
+            remoteAddress=tunnel.remote_address)
+        return create_payload
+
+    def load(self):
+        payload = self.load_payload()
+        return self.tm.load(**payload)
+
+    def execute(self):
+        """An over-writing execute method that calls self"""
+        return self()
+
+    def delete(self):
+        """Assure action of delete on the TmTunnel"""
+        load_payload = self.load_payload()
+        fdb_tunnel_load = FdbTunnel(self.bigip, self.tunnel, 'load')
+        arps_get_collection = TmArps(self.bigip, 'get_collection',
+                                     self.tunnel)
+        fdb_tunnel = fdb_tunnel_load()
+        records = []
+        if hasattr(fdb_tunnel, 'records_s'):
+            records = fdb_tunnel.records_s.get_collection()
+        arps = arps_get_collection()
+        for record in records:
+            name = record.name
+            for arp in arps:
+                if arp.name == name:
+                    arp.delete()
+                    break
+            record.delete()
+        # Best attempt at eliminating a race...
+        tunnel = self.tm.load(**load_payload)
+        tunnel.delete()
+
+
+class TmTunnels(TmNetActionBase):
+    """Extract bigip.tm.net.tunnels.tunnels.get_collection"""
+    _possible_actions = ['get_collection']
+
+    @wrappers.add_logger
+    def __init__(self, bigip, action, partition):
+        self.logger.debug(
+            "Performing {} on {}'s Tunnels".format(action, bigip.hostname))
+        self.partition = partition
+        super(TmTunnels, self).__init__(bigip, action)
+
+    def get_collection_payload(self):
+        """Specifies a payload of a filter for partition for get_collection"""
+        payload = {}
+        filter_params = {}
+        partition = getattr(self, 'partition', None)
+        if partition and isinstance(partition, (str, type(u''))):
+            filter_params = {'$filter': 'partition eq {}'.format(partition)}
+            payload = dict(requests_params=filter_params)
+        return payload
+
+    def _set_tm(self, bigip):
+        super(TmTunnels, self)._set_tm(bigip)
+        self.tm = self.tm.tunnels.tunnels
+
+    def execute(self):
+        """Performs a call to self and returns"""
+        return self()
+
+
+class TmRecord(TmNetActionBase):
+    """Creates a TmRecords TmNetAction object for manipulating FDB Records
+
+    This object is used to interact with the
+    bigip.tm.net.fdb.tunnels.tunnel.load().records_s.records objects for basic
+    CRUD operations ONLY and performs no tracking.
+
+    There should be an object per action.
+    """
+    _possible_actions = ['load', 'modify', 'delete', 'create', 'exists']
+
+    @wrappers.add_logger
+    def __init__(self, bigip, action, tunnel, fdbs):
+        self.logger.debug("called with ({}, {}, {}, {})".format(
+            bigip, action, tunnel, fdbs))
+        self.logger.debug(
+            "Performing {} on {} Tunnel({t.tunnel_name}, {t.partition}) "
+            "Fdbs({})".format(action, hex(id(tunnel)), fdbs, t=tunnel))
+        self.fdbs = fdbs
+        self.tunnel = tunnel
+        super(TmRecord, self).__init__(bigip, action)
+
+    def _set_tm(self, bigip):
+        super(TmRecord, self)._set_tm(bigip)
+        fdb_tunnel_load = FdbTunnel(bigip, self.tunnel, 'load')
+        self.tm = fdb_tunnel_load()
+
+    def no_opt(self):
+        self.logger.debug(
+            "Attempted '{} on non-existent records for Tunnel({})".format(
+                self.action, self.tunnel.tunnel_name))
+        return False
+
+    def load_payload(self, fdb):
+        return dict(name=fdb.mac_address)
+
+    def create_payload(self, fdb):
+        return fdb.record
+
+    def _get_tm_record(self):
+        records = getattr(self.tm, 'records_s', None)
+        records = getattr(records, 'records', None)
+        if records:
+            self.tm = records
+            return True
+        return False
+
+    def create(self):
+        """Creates a new record or modifies the fdbTunnel's records attr"""
+        tm_confirmed = False
+        fdbs = [self.fdbs] if not isinstance(self.fdbs, list) else self.fdbs
+        for fdb in fdbs:
+            if not tm_confirmed and not self._get_tm_record():
+                break
+            tm_confirmed = True
+            payload = self.create_payload(fdb)
+            self.tm.create(**payload)
+        else:
+            return
+        self._create_records()
+
+    def _create_records(self):
+        fdbs = self.fdbs if isinstance(self.fdbs, list) else [self.fdbs]
+        records = [self.create_payload(fdb) for fdb in fdbs]
+        self.tm.modify(records=records)
+
+    def delete(self):
+        """Deletes the fdbs given from off the FdbTunnel"""
+        tm_confirmed = False
+        fdbs = self.fdbs
+        fdbs = [fdbs] if not isinstance(fdbs, list) else fdbs
+        for fdb in fdbs:
+            global tm_confirmed
+            if not tm_confirmed and not self._get_tm_record():
+                break
+            tm_confirmed = True
+            payload = self.load_payload(fdb)
+            record = self.tm.load(**payload)
+            record.delete()
+        else:
+            return
+        self.logger.debug(
+            "Attempted to delete record where no records resided"
+            " Tunnel({t.tunnel_name}, {t.partition}) Fdbs({})".format(
+                fdbs, t=self.tunnel))
+
+    def modify(self):
+        """Attempts to modify the given fdbs' tunnel records with provided
+
+        This method will take the fdbs given originally (at object init) and
+        attempt to modify the provided fdb records in fdbs.  If there are no
+        such records on the fdb_tunnel, then the records will be created with
+        this list of fdbs.  Otherwise, the ones not found will be created via
+        create().
+
+        Args:
+            None
+        Returns:
+            None
+        Exceptions:
+            requests.HTTPError if something bad happens
+        """
+        fdbs = self.fdbs
+        fdbs = [fdbs] if not isinstance(fdbs, list) else fdbs
+        the_unfound = []
+        tm_confirmed = False
+        for fdb in fdbs:
+            if not tm_confirmed and not self._get_tm_record():
+                the_unfound.extend(fdbs)
+                break
+            tm_confirmed = True
+            payload = self.load_payload(fdb)
+            try:
+                record = self.tm.load(**payload)
+                record.modify(endpoint=fdb.vtep_ip)
+            except HTTPError as error:
+                if int(error.response.status_code) is 404:
+                    the_unfound.append(fdb)
+        if the_unfound:
+            self.fdbs = the_unfound
+            if not hasattr(self, 'records_s'):
+                self._create_records()
+            else:
+                self.create()
+
+    def execute(self):
+        """An over-writing execute method that calls self"""
+        return self()
+
+
+class TmArp(TmNetActionBase):
+    """Creates a TmArp TmNetAction object for manipulating Arp objects
+
+    This object is used to interact with the bigip.net.arps.arp objects for
+    basic CRUD operations ONLY and performs no tracking.
+
+    There should be an object per action.
+    """
+    _possible_actions = ['load', 'modify', 'delete', 'create', 'exists']
+    _collision_explanation = str(
+        "IP Address collision with IP: {} for arp.  This is likely due to an"
+        " FDB update from a loadbalancer's VIP being updated in the ARP and "
+        "is not a concern.  Especially if the last octet is +1-3 of the"
+        " subnet's allocation pool's starting point.  If it is higher than "
+        "that, look to your member ip static allocation or DHCP agent.")
+
+    @wrappers.add_logger
+    def __init__(self, bigip, action, fdbs, partition):
+        self.logger.debug(
+            "Performing {} on Arp({})".format(action, fdbs))
+        super(TmArp, self).__init__(bigip, action)
+        self.fdbs = fdbs
+        self.partition = partition
+
+    def _set_tm(self, bigip):
+        super(TmArp, self)._set_tm(bigip)
+        self.tm = self.tm.arps.arp
+
+    def load_payload(self, fdb):
+        """Creates a 'load' payload for the TmArp action"""
+        return dict(name=fdb.mac_address, partition=self.partition)
+
+    def create_payload(self, fdb):
+        """Creates a dict of the correct payload for the fdb given
+
+        It is important to note that v3.0.8 of the sdk requires a name
+        argument.  It may be in future releases that name, like in pervious,
+        is not required, and, in fact, cause bugs.
+        """
+        return dict(ipAddress=fdb.ip_address, partition=self.partition,
+                    macAddress=fdb.mac_address, name=fdb.mac_address)
+
+    def create(self):
+        """Attempts to perform a create on the provided list of fdb target"""
+        errors = list()
+        created = list()
+        fdbs = [self.fdbs] if not isinstance(self.fdbs, list) else self.fdbs
+        for fdb in fdbs:
+            try:
+                payload = self.create_payload(fdb)
+                created.append(self._execute(action='create', payload=payload))
+            except HTTPError as error:
+                status_code = int(error.response.status_code)
+                msg = str(error)
+                if status_code is 409:
+                    continue  # already exists
+                elif status_code is 400 and "Invalid IP address" in msg:
+                    self.logger.error(self._collision_explanation.format(
+                        fdb.ip_address))
+                elif status_code is 409:
+                    self.logger.debug("ARP already exists for {}".format(
+                        fdb.mac_address))
+                elif "'name'" in str(error):
+                    try:
+                        # some versions of SDK does not support 'name' field
+                        payload.pop('name')
+                        created.append(self._execute(
+                            action='create', payload=payload))
+                    except HTTPError as error:
+                        status_code = int(error.response.status_code)
+                        msg = str(error)
+                        if status_code is 409:
+                            continue  # already exists
+                        elif status_code is 400 and \
+                                "Invalid IP address" in msg:
+                            self.logger.error(
+                                self._collision_explanation.format(
+                                    fdb.ip_address))
+                        elif status_code is 409:
+                            self.logger.debug(
+                                "ARP already exists for {}".format(
+                                    fdb.mac_address))
+                        else:
+                            errors.append(error)
+                    except Exception as error:
+                        errors.append(error)
+                else:
+                    errors.append(error)
+            except Exception as error:
+                errors.append(error)
+        if errors:
+            raise Exception(
+                "{}\n{}".format(fdbs, ', '.join([str(x) for x in errors])))
+        return created
+
+    def load(self):
+        """Performs a load on a TmArp object"""
+        loaded = []
+        fdbs = [self.fdbs] if not isinstance(self.fdbs, list) else self.fdbs
+        for fdb in fdbs:
+            try:
+                payload = self.load_payload(fdb)
+                loaded.append(self._execute(action='load', payload=payload))
+            except Exception as error:
+                self.logger.warning(str(error))
+        return loaded
+
+    def delete(self):
+        """Performs a delete on a TmArp object"""
+        old_tm = self.tm
+        fdbs = [self.fdbs] if not isinstance(self.fdbs, list) else self.fdbs
+        for fdb in fdbs:
+            try:
+                payload = self.load_payload(fdb)
+                self.tm = self._execute(action='load', payload=payload)
+                self._execute(action='delete')
+            except HTTPError as error:
+                if int(error.response.status_code) in [404, 400]:
+                    self.logger.debug(
+                        "Could not find Arp({}) to delete it".format(payload))
+                else:
+                    self.logger.warning(str(error))
+            except Exception as error:
+                self.logger.warning(str(error))
+            finally:
+                self.tm = old_tm
+
+    def modify(self):
+        """Performs a modify on the TmArp object or creates non-existant
+
+        This is a DC action as there is no simple U for an arp object in
+        the SDK or on the BIG-IP.
+
+        If the arp is not found in load to D phase, it will store it and later
+        try a C on it.
+        """
+        old_tm = self.tm
+        fdbs = [self.fdbs] if not isinstance(self.fdbs, list) else self.fdbs
+        not_found = list()
+        for fdb in fdbs:
+            try:
+                payload = self.create_payload(fdb)
+                self.tm = self.tm.load(**payload)
+                self.tm.delete()
+                old_tm.create(**payload)
+            except HTTPError as error:
+                msg = str(error)
+                status_code = int(error.response.status_code)
+                if status_code in [404, 400]:
+                    not_found.append(fdb)
+                elif status_code is 400 and "Invalid IP address" in msg:
+                    self.logger.error(self._collision_explanation.format(
+                        fdb.ip_address))
+            finally:
+                self.tm = old_tm
+        if not_found:
+            self.fdbs = not_found
+            self.create()
+
+    def exists(self):
+        """Performs an exists check on TmArp object"""
+        fdbs = [self.fdbs] if not isinstance(self.fdbs, list) else self.fdbs
+        exists = []
+        for fdb in fdbs:
+            payload = self.load_payload(fdb)
+            exists.append(self.tm.exists(**payload))
+        return exists
+
+
+class TmArps(TmNetActionBase):
+    """Creates an action for TmArps and allows user to execute it"""
+    _possible_actions = ['get_collection']
+
+    def __init__(self, bigip, action, tunnel):
+        super(TmArps, self).__init__(bigip, action)
+        self.tunnel = tunnel
+
+    def _set_tm(self, bigip):
+        super(TmArps, self)._set_tm(bigip)
+        self.tm = self.tm.arps
+
+    def get_collection_payload(self):
+        """Specifies a payload of a filter for partition for get_collection"""
+        payload = {}
+        filter_params = {}
+        partition = getattr(self.tunnel, 'partition', None)
+        if partition and isinstance(partition, (str, type(u''))):
+            filter_params = {'$filter': 'partition eq {}'.format(partition)}
+            payload = dict(requests_params=filter_params)
+        return payload

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
@@ -721,10 +721,10 @@ class TunnelHandler(cache.CacheBase):
         """
         def inc_and_remove(current, to_remove):
             current.exists = False
-            if current.inc_exists_check < 3:
-                current.inc_exists_check += 1
-            else:
-                to_remove.append(current)
+            # if current.inc_exists_check < 1:
+            #    current.inc_exists_check += 1
+            # else:
+            to_remove.append(current)
 
         cached_tunnels = iter(self.__network_cache_handler)
         definitive_tunnels = list()

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,6 @@ setuptools.setup(
             'f5-oslbaasv2-agent = f5_openstack_agent.lbaasv2.drivers.bigip.agent:main'
         ]
     },
-    install_requires=['f5-sdk==2.3.3']
+    install_requires=['f5-sdk==3.0.8']
 )
 


### PR DESCRIPTION
@jlongstaf 
#### What issues does this address?
All the int-test tunnel problems...

#### What's this change do?
See commit statement
#### Where should the reviewer start?
at tunnels...
#### Any background context?
Congruency issues and timing issues along with greenthreads not being entirely lockable resulted in a need to make the NCH and TH to no longer depend on locks.  This may result in a flooding of logs for debug status if/when the use has debug level and they have just deleted a tunnel, but error logs should be kept to a minimum. 