### PR TITLE
Filling in missing pydocs for class-level methods

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/decorators.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/decorators.py
@@ -47,6 +47,7 @@ def timed(method):
 
 
 def weakref_handle(method):
+    """Handles a ReferenceError automatically and returns"""
     def wrapper(*args, **kwargs):
         try:
             return method(*args, **kwargs)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/fdb.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/fdb.py
@@ -68,7 +68,6 @@ class Fdb(object):
         self._set_ip_address(ip_address, force=force)
         self.vtep_ip = vtep_ip
         self.__partitions = []
-        self.__hosts = []
 
     def __str__(self):
         """Returns string representation of object"""
@@ -172,19 +171,16 @@ class Fdb(object):
 
     @property
     def record(self):
+        """Returns the record representation of the Fdb"""
         return dict(endpoint=self.vtep_ip, name=self.mac_address)
 
     @property
     def fdb_entry(self):
+        """Returns the entry representation of the Fdb"""
         ports = [{self.ip_address: [[self.mac_address, self.vtep_ip]]}]
         return dict(
             ports=ports, segmentation_id=self.segment_id,
             network_id=self.network_id, network_type=self.network_type)
-
-    @property
-    def hosts(self):
-        """Returns the list of BIG-IP hostnames linked to this FDB VTEP"""
-        return self.__hosts
 
     @property
     def partitions(self):
@@ -197,12 +193,14 @@ class Fdb(object):
         return self.hosts and self.partitions
 
     def log_create(self, bigip, partition):
+        """Creates a new logger entry for debug stating the FDB was created"""
         self.logger.debug(
             "Successfully Created Fdb({b.hostname}, {} {s.ip_address}("
             "{s.mac_address}, {s.vtep_ip})".format(
                 partition, b=bigip, s=self))
 
     def log_remove(self, bigip, partition):
+        """Creates a new logger entry for debug stating FDB was deleted"""
         self.logger.debug(
             "Successfully Removed Fdb({b.hostname}, {} {s.ip_address}("
             "{s.mac_address}, {s.vtep_ip})".format(

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/network_cache_handler.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/network_cache_handler.py
@@ -202,6 +202,11 @@ class NetworkCacheHandler(cache.CacheBase):
         return hosts
 
     def get_tunnels_by_designation(self, network_id, segment):
+        """Retrieves a {bigip_host:[Tunnel]} for network_id and segment given
+
+        This will return the described dict structure for a given network and
+        segment as constructed by objects in the cache.
+        """
         try:
             hosts = self._get_tunnels_by_designation(network_id, segment)
         except KeyError:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tm_actions.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tm_actions.py
@@ -187,6 +187,7 @@ class TmTunnelsProfile(TmNetActionBase):
             self.tm = self.tm.tunnels.gres.gre
 
     def create_payload(self):
+        """Returns a create operation's payload"""
         ttype = self.tunnel_type
         base = dict(name=self.name, partition=self.partition,
                     floodingType='multipoint', defaultsFrom=ttype)
@@ -199,6 +200,7 @@ class TmTunnelsProfile(TmNetActionBase):
         return base
 
     def load_payload(self):
+        """Returns a load operation's payload"""
         return dict(name=self.name, partition=self.partition)
 
     def execute(self):
@@ -273,6 +275,7 @@ class TmTunnel(TmNetActionBase):
         return create_payload
 
     def load(self):
+        """Performs a load operations and returns result"""
         payload = self.load_payload()
         return self.tm.load(**payload)
 
@@ -361,15 +364,18 @@ class TmRecord(TmNetActionBase):
         self.tm = fdb_tunnel_load()
 
     def no_opt(self):
+        """A no-opt that logs a debugger message when called"""
         self.logger.debug(
             "Attempted '{} on non-existent records for Tunnel({})".format(
                 self.action, self.tunnel.tunnel_name))
         return False
 
     def load_payload(self, fdb):
+        """Creates and returns a load operation's payload"""
         return dict(name=fdb.mac_address)
 
     def create_payload(self, fdb):
+        """Creates and returns a create operation's payload"""
         return fdb.record
 
     def _get_tm_record(self):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tunnels/tunnel.py
@@ -208,12 +208,15 @@ class Tunnel(cache.CacheBase):
         known_macs = set(map(lambda x: x.mac_address, self.__fdbs))
 
         def append_fdb(self, fdb):
+            """Adds an Fdb object to the list of fdbs on the Tunnel"""
             self.__fdbs.append(fdb)
 
         def extend_fdbs(self, fdbs):
+            """Extends the list of Fdbs to the current Tunnel's Fdbs"""
             self.__fdbs.extend(fdbs)
 
         def add_fdb(fdb):
+            """Adds an Fdb to the deployment"""
             self.logger.debug("{}: adding {}".format(self.tunnel_name, fdb))
             tunnel_method = TunnelBuilder.add_fdb_to_tunnel
             fdb_method = fdb_mod.FdbBuilder.add_fdb_to_arp
@@ -275,10 +278,12 @@ class Tunnel(cache.CacheBase):
 
     @property
     def fdbs(self):
+        """Returns current list of Fdbs's"""
         return self.__fdbs
 
     @property
     def profile(self):
+        """Returns the tunnel's profile"""
         return getattr(self, '_Tunnel__profile',
                        "{}_ovs".format(self.tunnel_type))
 
@@ -407,6 +412,7 @@ class TunnelBuilder(object):
 
     @classmethod
     def get_records_from_tunnel(cls, bigip, tunnel):
+        """Gets a list of FDB records from the given tunnel of of BIG-IP"""
         fdb_tunnel = cls.__tm_fdb_tunnel(bigip, tunnel, 'load')
         records = getattr(fdb_tunnel, 'records', [])
         return records
@@ -501,6 +507,7 @@ class TunnelBuilder(object):
 
     @classmethod
     def create_tunnel_obj(cls, bigip, params):
+        """Generates a Tunnel objet and returns"""
         tunnel = cls.__create_tunnel_from_dict(params, bigip)
         return tunnel
 
@@ -634,6 +641,7 @@ class TunnelBuilder(object):
     @wrappers.http_error(
         debug={404: "Attempted delete on non-existent record"})
     def remove_record_from_arp(cls, bigip, tunnel, fdb):
+        """Removes the given Fdb's info from the ARP table"""
         def remove(fdb):
             cls.__tm_records(bigip, 'delete', tunnel, fdb)
 


### PR DESCRIPTION
Issues:
Filling in documentation

Problem:
* Some pydocs were missing from some methods and functions

Analysis:
* This fills in these missing pydocs in the tunnels/ namespace

Tests:
None, this does not impact runtime code

@jlongstaf 
#### What issues does this address?
Fills in documentation via pydocs

#### What's this change do?
Adds documentation and removes `Fdb.__hosts`, which is never used.

#### Where should the reviewer start?
tunnels/ namespace

#### Any background context?
This is just filling in missing documentation.