### PR TITLE
Remove code which clears IP for static ARP in fdb add/remove

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1601,33 +1601,18 @@ class iControlDriver(LBaaSBaseDriver):
 
     def fdb_add(self, fdb):
         # Add (L2toL3) forwarding database entries
-        self.remove_ips_from_fdb_update(fdb)
         for bigip in self.get_all_bigips():
             self.network_builder.add_bigip_fdb(bigip, fdb)
 
     def fdb_remove(self, fdb):
         # Remove (L2toL3) forwarding database entries
-        self.remove_ips_from_fdb_update(fdb)
         for bigip in self.get_all_bigips():
             self.network_builder.remove_bigip_fdb(bigip, fdb)
 
     def fdb_update(self, fdb):
         # Update (L2toL3) forwarding database entries
-        self.remove_ips_from_fdb_update(fdb)
         for bigip in self.get_all_bigips():
             self.network_builder.update_bigip_fdb(bigip, fdb)
-
-    # remove ips from fdb update so we do not try to
-    # add static arps for them because we do not have
-    # enough information to determine the route domain
-    def remove_ips_from_fdb_update(self, fdb):
-        for network_id in fdb:
-            network = fdb[network_id]
-            mac_ips_by_vtep = network['ports']
-            for vtep in mac_ips_by_vtep:
-                mac_ips = mac_ips_by_vtep[vtep]
-                for mac_ip in mac_ips:
-                    mac_ip[1] = None
 
     def tunnel_update(self, **kwargs):
         # Tunnel Update from Neutron Core RPC


### PR DESCRIPTION
Problem: Need to remove code which prevented static ARP updates.

Analysis: This code was added when earlier versions of BIG-IP (11.x) did not
support updating static ARP entries. Because we no longer support
11.x, we need to remove this code.

@ssorenso 
#### What issues does this address?
Manual test failure.

#### What's this change do?
Removes function which clears IP address in mac data structure. This code was
intended to prevent trying to update static ARPs, even if the populate static ARP
setting was configured by the end user.

#### Where should the reviewer start?
icontrol_driver.py

#### Any background context?
This code was removed in the Libery fdb update, but was not included by mistake when the fdb update code was migrated from liberty into master.
