### PR TITLE
Removing temp code around fdb macs

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1601,33 +1601,18 @@ class iControlDriver(LBaaSBaseDriver):
 
     def fdb_add(self, fdb):
         # Add (L2toL3) forwarding database entries
-        self.remove_ips_from_fdb_update(fdb)
         for bigip in self.get_all_bigips():
             self.network_builder.add_bigip_fdb(bigip, fdb)
 
     def fdb_remove(self, fdb):
         # Remove (L2toL3) forwarding database entries
-        self.remove_ips_from_fdb_update(fdb)
         for bigip in self.get_all_bigips():
             self.network_builder.remove_bigip_fdb(bigip, fdb)
 
     def fdb_update(self, fdb):
         # Update (L2toL3) forwarding database entries
-        self.remove_ips_from_fdb_update(fdb)
         for bigip in self.get_all_bigips():
             self.network_builder.update_bigip_fdb(bigip, fdb)
-
-    # remove ips from fdb update so we do not try to
-    # add static arps for them because we do not have
-    # enough information to determine the route domain
-    def remove_ips_from_fdb_update(self, fdb):
-        for network_id in fdb:
-            network = fdb[network_id]
-            mac_ips_by_vtep = network['ports']
-            for vtep in mac_ips_by_vtep:
-                mac_ips = mac_ips_by_vtep[vtep]
-                for mac_ip in mac_ips:
-                    mac_ip[1] = None
 
     def tunnel_update(self, **kwargs):
         # Tunnel Update from Neutron Core RPC

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
@@ -751,9 +751,10 @@ class NetworkHelper(object):
                                           "MAC addess %s" % (arp_ip_address,
                                                              mac_address))
                                 arp = bigip.tm.net.arps.arp
-                                arp.create(ip_address=arp_ip_address,
-                                           mac_address=mac_address,
-                                           partition=partition)
+                                arp.create(ipAddress=arp_ip_address,
+                                           macAddress=mac_address,
+                                           partition=partition,
+                                           name=mac_address)
                             except Exception as e:
                                 LOG.error('add_fdb_entry',
                                           'could not create static arp: %s'
@@ -806,11 +807,16 @@ class NetworkHelper(object):
             folder = fdb_entries[tunnel_name]['folder']
             tunnel_records = fdb_entries[tunnel_name]['records']
             for mac in tunnel_records:
+                record = tunnel_records[mac]
+                ip_address = record['ip_address']
+                if ip_address == '0.0.0.0':
+                    ip_address = ''
                 self.add_fdb_entry(
                     bigip,
                     tunnel_name,
                     mac_address=mac,
-                    vtep_ip_address=tunnel_records[mac]['endpoint'],
+                    vtep_ip_address=record['endpoint'],
+                    arp_ip_address=ip_address,
                     partition=folder)
 
     @log_helpers.log_method_call


### PR DESCRIPTION
Issues:
Arps not getting populated from FDB updates

Problem:
* For earlier versions of BIG-IP static IP/MAC combos were not supported
* arp ip address was not being propogated
* name not being passed to bigip.tm.net.arps.arp.create

Analysis:
* Now that they are and arps need to be generated from FDB events, temp
        code should be removed
* added logic to get the ip address to the arp logic to create the arp
* name now being passed as a dup of the mac_address
  * Note that this may need to be tested on more than one BIG-IP

Tests:
None besides ad hoc tests:
root@(host-)(cfg-sync Changes Pending)(Active)(/Project_bcb32e0414a64d2cacf429edc9c7575e)(tmos)# list net arp
net arp /Project_bcb32e0414a64d2cacf429edc9c7575e/aa:bb:cc:dd:ee:11 {
    ip-address 10.22.22.8%1
    mac-address aa:bb:cc:dd:ee:11
    partition Project_bcb32e0414a64d2cacf429edc9c7575e
}
net arp /Project_bcb32e0414a64d2cacf429edc9c7575e/aa:bb:cc:dd:ee:ff {
    ip-address 10.22.30.8%1
    mac-address aa:bb:cc:dd:ee:ff
    partition Project_bcb32e0414a64d2cacf429edc9c7575e
}

@jlongstaf 
#### What issues does this address?
ARPs not being populated in cross-network traffic

#### What's this change do?
Fixes args for arp.create() call as well as a handful of other items.

#### Where should the reviewer start?
icontrol_driver.py for a few items and network_helper.py for another group of items

#### Any background context?
This is in reference to ad hoc testing discoveries with cross-network member sharing with associated ports on different subnets/networks combo