### PR TITLE
only replace name with partiton when name is empty

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
@@ -349,7 +349,8 @@ class NetworkHelper(object):
         if hasattr(self, 'conf') and self.conf.external_gateway_mode:
             name = self._get_route_domain_name(name) if name else partition
         else:
-            name = partition
+            if not name:
+                name = partition
         r = bigip.tm.net.route_domains.route_domain
         obj = r.load(name=name, partition=partition)
         obj.delete()


### PR DESCRIPTION
otherwise, seems when deleting rd with name like
Project_21c2550efe324765822917bda7abd3b5_aux_X, if
we replace rd name with partition, it would lead to:
Not Found for uri
net/route-domain/~Project_21c2550efe324765822917bda7abd3
b5~Project_21c2550efe324765822917bda7abd3b5
