### PR TITLE
Cherry-Pick: Enable OpenStack tenant deploys Passphrase to TLS offload to protect …

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/barbican_cert.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/barbican_cert.py
@@ -166,6 +166,18 @@ class BarbicanCertManager(object):
         container = self.barbican.containers.get(container_ref)
         return container.private_key.payload
 
+    def get_private_key_passphrase(self, container_ref):
+        """Retrieves key passphrase from certificate manager.
+
+        :param string container_ref: Reference to key stored in a
+        certificate manager.
+        :returns string: Key passphrase data.
+        This method MUST be implemented, in agent-compliant cert managers.
+        """
+        container = self.barbican.containers.get(container_ref)
+        if container.private_key_passphrase:
+            return container.private_key_passphrase.payload
+
     def get_name(self, container_ref, prefix):
         """Returns a name that uniquely identifies cert/key pair.
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/ssl_profile.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/ssl_profile.py
@@ -28,8 +28,8 @@ class SSLProfileHelper(object):
 
     @staticmethod
     def create_client_ssl_profile(
-            bigip, name, cert, key, sni_default=False,
-            intermediates=None, parent_profile=None):
+            bigip, name, cert, key, key_passphrase=None,
+            sni_default=False, intermediates=None, parent_profile=None):
         uploader = bigip.shared.file_transfer.uploads
         cert_registrar = bigip.tm.sys.crypto.certs
         key_registrar = bigip.tm.sys.crypto.keys
@@ -84,7 +84,9 @@ class SSLProfileHelper(object):
             chain = [{'name': name,
                       'cert': '/Common/' + certfilename,
                       'chain': chain_path,
-                      'key': '/Common/' + keyfilename}]
+                      'key': '/Common/' + keyfilename,
+                      'passphrase': key_passphrase}]
+
             ssl_client_profile.create(name=name,
                                       partition='Common',
                                       certKeyChain=chain,

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_ssl_profile.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_ssl_profile.py
@@ -52,7 +52,8 @@ class TestSSLProfileHelper(object):
                 {'name': 'testprofile',
                  'cert': '/Common/testprofile.crt',
                  'chain': None,
-                 'key': '/Common/testprofile.key'}
+                 'key': '/Common/testprofile.key',
+                 'passphrase': None}
             ],
             sniDefault=False,
             defaultsFrom=None,
@@ -80,7 +81,8 @@ class TestSSLProfileHelper(object):
                 {'name': 'testprofile',
                  'cert': '/Common/testprofile.crt',
                  'chain': None,
-                 'key': '/Common/testprofile.key'}
+                 'key': '/Common/testprofile.key',
+                 'passphrase': None}
             ],
             sniDefault=False,
             defaultsFrom=None,
@@ -102,7 +104,8 @@ class TestSSLProfileHelper(object):
                 {'name': 'testprofile',
                  'cert': '/Common/testprofile.crt',
                  'chain': None,
-                 'key': '/Common/testprofile.key'}
+                 'key': '/Common/testprofile.key',
+                 'passphrase': None}
             ],
             sniDefault=False,
             defaultsFrom='parentprofile',
@@ -118,7 +121,7 @@ class TestSSLProfileHelper(object):
         with pytest.raises(SSLProfileError):
             SSLProfileHelper.create_client_ssl_profile(
                 bigip, 'testprofile', 'testcert', 'testkey',
-                intermediates=None,
+                intermediates=None, key_passphrase=None,
                 parent_profile="parentprofile"
             )
 
@@ -127,7 +130,8 @@ class TestSSLProfileHelper(object):
         bigip.tm.ltm.profile.client_ssls.client_ssl = mock.MagicMock()
         bigip.tm.ltm.profile.client_ssls.client_ssl.exists.return_value = False
         SSLProfileHelper.create_client_ssl_profile(
-            bigip, 'testprofile', 'testcert', 'testkey', intermediates=None)
+            bigip, 'testprofile', 'testcert', 'testkey',
+            key_passphrase="password", intermediates=None)
         bigip.tm.ltm.profile.client_ssls.client_ssl.create.assert_called_with(
             name='testprofile',
             partition='Common',
@@ -135,7 +139,8 @@ class TestSSLProfileHelper(object):
                 {'name': 'testprofile',
                  'cert': '/Common/testprofile.crt',
                  'chain': None,
-                 'key': '/Common/testprofile.key'}
+                 'key': '/Common/testprofile.key',
+                 'passphrase': "password"}
             ],
             sniDefault=False,
             defaultsFrom=None,
@@ -154,7 +159,8 @@ class TestSSLProfileHelper(object):
                 {'name': 'testprofile',
                  'cert': '/Common/testprofile.crt',
                  'chain': '/Common/testprofile_inter.crt',
-                 'key': '/Common/testprofile.key'}
+                 'key': '/Common/testprofile.key',
+                 'passphrase': None}
             ],
             sniDefault=False,
             defaultsFrom=None,
@@ -177,7 +183,75 @@ class TestSSLProfileHelper(object):
                 {'name': 'testprofile',
                  'cert': '/Common/testprofile.crt',
                  'chain': '/Common/testprofile_inter.crt',
-                 'key': '/Common/testprofile.key'}
+                 'key': '/Common/testprofile.key',
+                 'passphrase': None}
+            ],
+            sniDefault=False,
+            defaultsFrom=None,
+        )
+
+    def test_create_client_ssl_passphrase_none(self):
+        bigip = mock.MagicMock()
+        bigip.tm.ltm.profile.client_ssls.client_ssl = mock.MagicMock()
+        bigip.tm.ltm.profile.client_ssls.client_ssl.exists.return_value = False
+        SSLProfileHelper.create_client_ssl_profile(
+            bigip, 'testprofile', 'testcert', 'testkey',
+            key_passphrase=None, intermediates="inter")
+        bigip.tm.ltm.profile.client_ssls.client_ssl.create.assert_called_with(
+            name='testprofile',
+            partition='Common',
+            certKeyChain=[
+                {'name': 'testprofile',
+                 'cert': '/Common/testprofile.crt',
+                 'chain': '/Common/testprofile_inter.crt',
+                 'key': '/Common/testprofile.key',
+                 'passphrase': None}
+            ],
+            sniDefault=False,
+            defaultsFrom=None,
+        )
+
+    def test_create_client_ssl_passphrase(self):
+        bigip = mock.MagicMock()
+        bigip.tm.ltm.profile.client_ssls.client_ssl = mock.MagicMock()
+        bigip.tm.ltm.profile.client_ssls.client_ssl.exists.return_value = False
+        SSLProfileHelper.create_client_ssl_profile(
+            bigip, 'testprofile', 'testcert', 'testkey',
+            key_passphrase='password', intermediates=None)
+        bigip.tm.ltm.profile.client_ssls.client_ssl.create.assert_called_with(
+            name='testprofile',
+            partition='Common',
+            certKeyChain=[
+                {'name': 'testprofile',
+                 'cert': '/Common/testprofile.crt',
+                 'chain': None,
+                 'key': '/Common/testprofile.key',
+                 'passphrase': "password"}
+            ],
+            sniDefault=False,
+            defaultsFrom=None,
+        )
+
+    def test_create_client_ssl_inter_passphrase_profile(self):
+        bigip = mock.MagicMock()
+        bigip.tm.ltm.profile.client_ssls.client_ssl = mock.MagicMock()
+        bigip.tm.ltm.profile.client_ssls.client_ssl.exists.side_effect =\
+            self.exists_parent
+        SSLProfileHelper.create_client_ssl_profile(
+            bigip, 'testprofile', 'testcert', 'testkey',
+            key_passphrase='password',
+            parent_profile="testparentprofile",
+            intermediates='inter'
+        )
+        bigip.tm.ltm.profile.client_ssls.client_ssl.create.assert_called_with(
+            name='testprofile',
+            partition='Common',
+            certKeyChain=[
+                {'name': 'testprofile',
+                 'cert': '/Common/testprofile.crt',
+                 'chain': '/Common/testprofile_inter.crt',
+                 'key': '/Common/testprofile.key',
+                 'passphrase': 'password'}
             ],
             sniDefault=False,
             defaultsFrom=None,


### PR DESCRIPTION
…the Private Key

This patch enables private key passphrase upload within ssl profile.

(cherry picked from commit 5e514ab5997550604293e8599e740125e5908853)
