### PR TITLE
Fix the wrong prerequisite version in agent doc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,7 +76,7 @@ version = VERSION
 release = VERSION
 
 # F5 SDK release version should be set here
-f5_sdk_version = '2.3.3'
+f5_sdk_version = '3.0.11'
 # F5 icontrol REST version should be set here
 f5_icontrol_version = '1.3.0'
 


### PR DESCRIPTION
Re-apply this patch, commit e4d78c556d3d0e83f6799361e393259882d8c1b6 was incorrectly reseted.

Link #1337 
