### PR TITLE
Fix flake8 errors

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/exceptions.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/exceptions.py
@@ -442,7 +442,7 @@ class F5MissingDependencies(F5AgentException):
                     line = fh.readline()
                     print('line', line)
                     debug_re = \
-                        re.compile('debug\s*=\s*([Tt]rue|[Ff]alse|[01])')
+                        re.compile(r'debug\s*=\s*([Tt]rue|[Ff]alse|[01])')
                     while line:
                         match = debug_re.search(line)
                         if match:  # there should only be one!

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py
@@ -53,7 +53,7 @@ class LBaaSBaseDriver(object):
 
     def backend_integrity(self):
         """Return True, if the agent is be considered viable for services."""
-        raise NotImplemented()
+        raise NotImplementedError()
 
     def backup_configuration(self):
         """Persist backend configuratoins."""
@@ -61,15 +61,15 @@ class LBaaSBaseDriver(object):
 
     def generate_capacity_score(self, capacity_policy):
         """Generate the capacity score of connected devices."""
-        raise NotImplemented
+        raise NotImplementedError()
 
     def update_operating_status(self):
         """Update pool member operational status from devices to controller."""
-        raise NotImplemented
+        raise NotImplementedError()
 
     def recover_errored_devices(self):
         """Trigger attempt to reconnect any errored devices."""
-        raise NotImplemented
+        raise NotImplementedError()
 
     def get_stats(self, service):
         """Get Stats for a loadbalancer Service."""
@@ -77,12 +77,12 @@ class LBaaSBaseDriver(object):
 
     def get_all_deployed_loadbalancers(self, purge_orphaned_folders=True):
         """Get all Loadbalancers defined on devices."""
-        raise NotImplemented
+        raise NotImplementedError()
 
     def purge_orphaned_loadbalancer(self, tenant_id, loadbalancer_id,
                                     hostnames):
         """Remove all loadbalancers without references in Neutron."""
-        raise NotImplemented
+        raise NotImplementedError()
 
     def service_exists(self, service):
         """Check If LBaaS Service is Defined on Driver Target."""

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_icontrol_driver_opts.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_icontrol_driver_opts.py
@@ -30,7 +30,7 @@ expected = {'f5_common_networks': dict(default=False, help=True),
 
 def test_opts_type():
     """Check that all opts are a oslo_config.cfg.* object"""
-    type_check = re.compile('oslo_config\.cfg\.(\w+Opt)')
+    type_check = re.compile(r'oslo_config\.cfg\.(\w+Opt)')
     for opt in opts:
         match = type_check.search(str(opt))
         assert match, str("{} is not recognized as a oslo_config.cfg.*"


### PR DESCRIPTION
#### What issues does this address?
Fixes #1357 

#### What's this change do?

Fix flake8 errors

```
$ flake8 ./f5_openstack_agent
./f5_openstack_agent/lbaasv2/drivers/bigip/exceptions.py:444:27: W605 invalid escape sequence '\s'
./f5_openstack_agent/lbaasv2/drivers/bigip/exceptions.py:444:31: W605 invalid escape sequence '\s'
./f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py:56:9: F901 'raise NotImplemented' should be 'raise NotImplementedError'
./f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py:64:9: F901 'raise NotImplemented' should be 'raise NotImplementedError'
./f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py:68:9: F901 'raise NotImplemented' should be 'raise NotImplementedError'
./f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py:72:9: F901 'raise NotImplemented' should be 'raise NotImplementedError'
./f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py:80:9: F901 'raise NotImplemented' should be 'raise NotImplementedError'
./f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_driver.py:85:9: F901 'raise NotImplemented' should be 'raise NotImplementedError'
./f5_openstack_agent/lbaasv2/drivers/bigip/test/test_icontrol_driver_opts.py:33:17: W605 invalid escape sequence '\.'
./f5_openstack_agent/lbaasv2/drivers/bigip/test/test_icontrol_driver_opts.py:33:22: W605 invalid escape sequence '\.'
./f5_openstack_agent/lbaasv2/drivers/bigip/test/test_icontrol_driver_opts.py:33:25: W605 invalid escape sequence '\w'
```
#### Where should the reviewer start?

#### Any background context?
