### PR TITLE
make update_operating_status_interval configurable

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/constants_v2.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/constants_v2.py
@@ -16,8 +16,6 @@
 
 # Service resync interval
 RESYNC_INTERVAL = 300
-UPDATE_OPERATING_STATUS_INTERVAL = 30
-
 
 # Topic for tunnel notifications between the plugin and agent
 TUNNEL = 'tunnel'


### PR DESCRIPTION
the original setting is per 30 seconds. This still keep it
as the default value, but make it configurable so that
customers like can configure the interval according to
their own deployment(e.g. in case of heavy pressure).