### PR TITLE
for the v6 case, we should ignore the netmask

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -452,7 +452,15 @@ class ServiceModelAdapter(object):
         else:
             LOG.error("No VIP address or port specified")
 
-        vip["mask"] = '255.255.255.255'
+        # for the v6 ip address, do not explicitly assign the mask
+        try:
+            socket.inet_pton(socket.AF_INET,ip_address)
+            vip["mask"] = '255.255.255.255'
+        except socket.error:
+            try:
+                socket.inet_pton(socket.AF_INET6,ip_address)
+            except socket.error:
+                LOG.error("Not a validate ip address")
 
         if "admin_state_up" in listener:
             if listener["admin_state_up"]:


### PR DESCRIPTION


#### What's this change do?
For the v6 host  address, we could just ignore the netmask instead of using the fix "255.255.255.255“ which is for v4 case.

