### PR TITLE
bugfix: select and use a global route domain id instead of local.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,4 +125,4 @@ logs
 .project
 .pydevproject
 .settings/
-
+.vscode/

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
@@ -278,9 +278,12 @@ class NetworkHelper(object):
         return ret_rd
 
     @log_helpers.log_method_call
-    def _get_next_domain_id(self, bigip):
+    def get_next_domain_id(self, bigips):
         """Get next route domain id """
-        rd_ids = sorted(self.get_route_domain_ids(bigip, partition=''))
+        rd_ids = []
+        for bigip in bigips:
+            rd_ids += self.get_route_domain_ids(bigip, partition='')
+        rd_ids = sorted(set(rd_ids))
         rd_ids.remove(0)
 
         lowest_available_index = 1
@@ -296,7 +299,8 @@ class NetworkHelper(object):
         return lowest_available_index
 
     @log_helpers.log_method_call
-    def create_route_domain(self, bigip, partition=const.DEFAULT_PARTITION,
+    def create_route_domain(self, bigip, rd_id,
+                            partition=const.DEFAULT_PARTITION,
                             strictness=False, is_aux=False, name=None):
         """Creates the route domain based upon settings in config
 
@@ -318,13 +322,12 @@ class NetworkHelper(object):
         else:
             name = partition
         rd = bigip.tm.net.route_domains.route_domain
-        id = self._get_next_domain_id(bigip)
         if is_aux:
-            name += '_aux_' + str(id)
+            name += '_aux_' + str(rd_id)
         payload = NetworkHelper.route_domain_defaults
         payload['name'] = name
         payload['partition'] = '/' + partition
-        payload['id'] = id
+        payload['id'] = rd_id
         if strictness:
             payload['strict'] = 'enabled'
         else:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
@@ -359,10 +359,13 @@ class NetworkServiceBuilder(object):
     def _create_aux_rd(self, tenant_id):
         # Create a new route domain
         route_domain_id = None
-        for bigip in self.driver.get_all_bigips():
+        bigips = self.driver.get_all_bigips()
+        rd_id = self.network_helper.get_next_domain_id(bigips)
+        for bigip in bigips:
             partition_id = self.service_adapter.get_folder_name(tenant_id)
             bigip_route_domain_id = self.network_helper.create_route_domain(
                 bigip,
+                rd_id,
                 partition=partition_id,
                 strictness=self.conf.f5_route_domain_strictness,
                 is_aux=True)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tenants.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tenants.py
@@ -72,12 +72,15 @@ class BigipTenantManager(object):
 
         # create tenant route domain
         if self.conf.use_namespaces:
-            for bigip in self.driver.get_all_bigips():
+            bigips = self.driver.get_all_bigips()
+            rd_id = self.network_helper.get_next_domain_id(bigips)
+            for bigip in bigips:
                 if not self.network_helper.route_domain_exists(bigip,
                                                                folder_name):
                     try:
                         self.network_helper.create_route_domain(
                             bigip,
+                            rd_id,
                             folder_name,
                             self.conf.f5_route_domain_strictness)
                     except Exception as err:

--- a/test/functional/singlebigip/test_network.py
+++ b/test/functional/singlebigip/test_network.py
@@ -79,6 +79,7 @@ def setup(request, mgmt_root):
 
     te = ExecTestEnv
     te.mgmt_root = mgmt_root
+    te.rd_id = 1
     te.request = request
     te.partition = default_partition
     return te
@@ -200,7 +201,7 @@ class TestRouteDomain(object):
     def test_route_domain_CRUD(self, setup):
         te = setup
         rd_create = network_helper.create_route_domain(
-            te.mgmt_root, te.partition)
+            te.mgmt_root, te.rd_id, te.partition)
         add_resource_teardown(te.request, rd_create)
         rd_read = network_helper.get_route_domain(te.mgmt_root, te.partition)
         assert(rd_read.name == rd_read.name)
@@ -221,7 +222,9 @@ class TestRouteDomain(object):
         num_route_domains = 5
         exp_rd_ids = []
         for i in range(0, num_route_domains):
-            rd = network_helper.create_route_domain(te.mgmt_root, te.partition,
+            rd = network_helper.create_route_domain(te.mgmt_root,
+                                                    te.rd_id,
+                                                    te.partition,
                                                     is_aux=True)
             add_resource_teardown(te.request, rd)
             exp_rd_ids.append(rd.id)
@@ -237,7 +240,9 @@ class TestRouteDomain(object):
         num_route_domains = 5
         exp_rd_names = []
         for i in range(0, num_route_domains):
-            rd = network_helper.create_route_domain(te.mgmt_root, te.partition,
+            rd = network_helper.create_route_domain(te.mgmt_root,
+                                                    te.rd_id,
+                                                    te.partition,
                                                     is_aux=True)
             add_resource_teardown(te.request, rd)
             exp_rd_names.append(rd.name)
@@ -254,7 +259,9 @@ class TestRouteDomain(object):
         v_obj = te.mgmt_root.tm.net.vlans.vlan
         v = v_obj.create(name=vname, partition=te.partition)
         add_resource_teardown(te.request, v)
-        rd = network_helper.create_route_domain(te.mgmt_root, te.partition)
+        rd = network_helper.create_route_domain(te.mgmt_root,
+                                                te.rd_id,
+                                                te.partition)
         add_resource_teardown(te.request, rd)
         network_helper.add_vlan_to_domain(te.mgmt_root, vname,
                                           te.partition)


### PR DESCRIPTION
What issues does this address?

PROBLEM
After testing new driver for HPB in our lab and technical environment, we just deployed the packages in Production. Unfortunately we are not able to create lbaas objects in internal networks. After some tests we discovered the problem is f5 agent is trying to create self ips using the same route domain id in both f5 units , however ids are assgined locally and they are different in both units, and therefore self ip can't be created in both units using the same route domain ids.
What's this change do?

Currently the f5-openstack-agent creates route domains in two cases:

- Whenever a tenant is created (tenants.py -> assure_tenant_create 74:87)

- Whenever a service request is made for a tenant where the neutron subnet ID associated with a loadbalancer or pool member overlaps the CIDR block for a previously requests subnet ID (network_service -> _create_aux_rd 349:362)

Both of these cases interate through each bigip associated with the agent calling the network_helper.py -> create_route_domain method. This method in turn calls the _get_next_domain_id method which finds the lowest available route domain ID on that specific bigip device. This method does not check that the route domain ID returned by a particular bigip is consistant with the other bigips associated wtih the agent. If for some reason, the ids are not consistant, this creates a provisioning (create and delete) error.

The recommendation is that the calls to network_helper.py create_route_domain and _get_next_domain_id be altered to include all bigips, removing the iteration. Within the _get_next_domain_id method, the available route domain IDs are collect from all associated bigip devices, the lowest route domain which is coherent on all devices selected and returned. The recommendation is to only return a route domain which is consistant on all bigips.
Initial test result in local sandbox: works ok:

2018-12-11 02:34:53.976 13383 DEBUG f5_openstack_agent.lbaasv2.drivers.bigip.network_service [req-2a5af1f1-2861-48be-a308-e522b241d8a3 2d26c96aa0f345eaafc      3f5b50d2bbd8e fde45211da0a44ecbf38cb0b644ab30d - - -] Allocated route domain 3 for tenant fde45211da0a44ecbf38cb0b644ab30d _create_aux_rd /usr/lib/python2      .7/site-packages/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py:380
2018-12-11 02:34:53.976 13383 DEBUG f5_openstack_agent.lbaasv2.drivers.bigip.network_service [req-2a5af1f1-2861-48be-a308-e522b241d8a3 2d26c96aa0f345eaafc      3f5b50d2bbd8e fde45211da0a44ecbf38cb0b644ab30d - - -] Tenant fde45211da0a44ecbf38cb0b644ab30d now has 1 route domains assign_route_domain /usr/lib/python2      .7/site-packages/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py:345What issues does this address?

PROBLEM
After testing new driver for HPB in our lab and technical environment, we just deployed the packages in Production. Unfortunately we are not able to create lbaas objects in internal networks. After some tests we discovered the problem is f5 agent is trying to create self ips using the same route domain id in both f5 units , however ids are assgined locally and they are different in both units, and therefore self ip can't be created in both units using the same route domain ids.
What's this change do?

Currently the f5-openstack-agent creates route domains in two cases:

    Whenever a tenant is created (tenants.py -> assure_tenant_create 74:87)

    Whenever a service request is made for a tenant where the neutron subnet ID associated with a loadbalancer or pool member overlaps the CIDR block for a previously requests subnet ID (network_service -> _create_aux_rd 349:362)

Both of these cases interate through each bigip associated with the agent calling the network_helper.py -> create_route_domain method. This method in turn calls the _get_next_domain_id method which finds the lowest available route domain ID on that specific bigip device. This method does not check that the route domain ID returned by a particular bigip is consistant with the other bigips associated wtih the agent. If for some reason, the ids are not consistant, this creates a provisioning (create and delete) error.

The recommendation is that the calls to network_helper.py create_route_domain and _get_next_domain_id be altered to include all bigips, removing the iteration. Within the _get_next_domain_id method, the available route domain IDs are collect from all associated bigip devices, the lowest route domain which is coherent on all devices selected and returned. The recommendation is to only return a route domain which is consistant on all bigips.
Initial test result in local sandbox: works ok:

2018-12-11 02:34:53.976 13383 DEBUG f5_openstack_agent.lbaasv2.drivers.bigip.network_service [req-2a5af1f1-2861-48be-a308-e522b241d8a3 2d26c96aa0f345eaafc      3f5b50d2bbd8e fde45211da0a44ecbf38cb0b644ab30d - - -] Allocated route domain 3 for tenant fde45211da0a44ecbf38cb0b644ab30d _create_aux_rd /usr/lib/python2      .7/site-packages/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py:380
2018-12-11 02:34:53.976 13383 DEBUG f5_openstack_agent.lbaasv2.drivers.bigip.network_service [req-2a5af1f1-2861-48be-a308-e522b241d8a3 2d26c96aa0f345eaafc      3f5b50d2bbd8e fde45211da0a44ecbf38cb0b644ab30d - - -] Tenant fde45211da0a44ecbf38cb0b644ab30d now has 1 route domains assign_route_domain /usr/lib/python2      .7/site-packages/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py:345