### PR TITLE
performance issue fix: only do action on pending listeners.

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -179,6 +179,13 @@ class LBaaSBuilder(object):
         bigips = self.driver.get_config_bigips()
 
         for listener in listeners:
+            # only take action on pending_xx status listeners.
+            provisioning_status = listener['provisioning_status']
+            if not provisioning_status in [
+                constants_v2.F5_PENDING_CREATE,
+                constants_v2.F5_PENDING_UPDATE,
+                constants_v2.F5_PENDING_DELETE]:
+                continue
             error = False
             if self._is_not_pending_delete(listener):
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/listener_service.py
@@ -16,6 +16,7 @@
 
 from oslo_log import log as logging
 
+from f5_openstack_agent.lbaasv2.drivers.bigip import constants_v2
 from f5_openstack_agent.lbaasv2.drivers.bigip import resource_helper
 from f5_openstack_agent.lbaasv2.drivers.bigip import ssl_profile
 from requests import HTTPError
@@ -268,6 +269,13 @@ class ListenerServiceBuilder(object):
         else:
             listeners = service['listeners']
             for listener in listeners:
+                # only take action on pending_xx status listeners.
+                provisioning_status = listener['provisioning_status']
+                if not provisioning_status in [
+                    constants_v2.F5_PENDING_CREATE,
+                    constants_v2.F5_PENDING_UPDATE,
+                    constants_v2.F5_PENDING_DELETE]:
+                    continue
                 svc = {"loadbalancer": service["loadbalancer"],
                        "listener": listener}
                 vip = self.service_adapter.get_virtual(svc)


### PR DESCRIPTION
When Creating / Deleting listeners, all the listeners would be taken action repeatly. 
In fact, only pending status should be take care of.

Moreover, pool, member, healthmonitor are also be the same situation. 
Test result: 

<img width="284" alt="default" src="https://user-images.githubusercontent.com/17761849/50250813-e5a67e80-041c-11e9-98f3-19ea8e39c88e.png">
