### PR TITLE
fix the travis build issue.

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -23,8 +23,8 @@ Added Functionality
 Bug Fixes
 `````````
 
-- Self ip can't be created in both units using the same route domain ids.
-- Deletes incorrect route domain.
+- Can't create self ip in both units using the same route domain ids.
+- Agent deletes incorrect route domain.
 
 Limitations
 ```````````


### PR DESCRIPTION
#### What issues does this address?

In ./docs/RELEASE-NOTES.rst
=============
- Self ip can't be created in both units using the same route domain ids.
                ^^^^^^^^^^
"be created" may be passive voice on line 26 at column 16
Script failed with status 1
