### PR TITLE
DO-NOT-MERGE: sdn-base to 9.8-stable 46e2320 with only f5_openstack_agent directory and exclude tests files

### DIFF
--- a/f5_openstack_agent/__init__.py
+++ b/f5_openstack_agent/__init__.py
@@ -1,1 +1,2 @@
+# actually patched to 46e2320 of 9.8-stable althougn it is 5.0.0 here
 __version__ = "5.0.0"

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager.py
@@ -129,6 +129,16 @@ OPTS = [
         default=60,
         help=(
             'Amount of time to wait for a errored service to become active')
+    ),
+    cfg.BoolOpt(
+        'password_cipher_mode',
+        default=False,
+        help='The flag indicating the password is plain text or not.'
+    ),
+    cfg.BoolOpt(
+        'esd_auto_refresh',
+        default=True,
+        help='Enable ESD file periodic refresh'
     )
 ]
 
@@ -324,6 +334,9 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                 self._report_state)
             heartbeat.start(interval=report_interval)
 
+        if self.lbdriver:
+            self.lbdriver.connect()
+
     def _load_driver(self, conf):
         self.lbdriver = None
 
@@ -488,6 +501,13 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
         """Trigger driver connect attempts to all devices."""
         if self.lbdriver:
             self.lbdriver.connect()
+
+    @periodic_task.periodic_task(spacing=PERIODIC_TASK_INTERVAL)
+    def refresh_esd(self, context):
+        """Refresh ESD files."""
+        if self.lbdriver.esd_processor and self.conf.esd_auto_refresh:
+            LOG.info("refresh ESD files automatically")
+            self.lbdriver.init_esd()
 
     @periodic_task.periodic_task(spacing=PERIODIC_TASK_INTERVAL)
     def recover_errored_devices(self, context):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import base64
 import datetime
 import hashlib
 import json
@@ -334,7 +335,7 @@ class iControlDriver(LBaaSBaseDriver):
     def __init__(self, conf, registerOpts=True):
         # The registerOpts parameter allows a test to
         # turn off config option handling so that it can
-        # set the options manually instead. """
+        # set the options manually instead.
         super(iControlDriver, self).__init__(conf)
         self.conf = conf
         if registerOpts:
@@ -368,6 +369,7 @@ class iControlDriver(LBaaSBaseDriver):
 
         # to store the verified esd names
         self.esd_names = []
+        self.esd_processor = None
 
         # service component managers
         self.tenant_manager = None
@@ -388,6 +390,12 @@ class iControlDriver(LBaaSBaseDriver):
             resource_helper.ResourceType.virtual)
         self.pool_manager = resource_helper.BigIPResourceHelper(
             resource_helper.ResourceType.pool)
+
+        if self.conf.password_cipher_mode:
+            self.conf.icontrol_password = \
+                base64.b64decode(self.conf.icontrol_password)
+            if self.conf.os_password:
+                self.conf.os_password = base64.b64decode(self.conf.os_password)
 
         try:
 
@@ -492,6 +500,11 @@ class iControlDriver(LBaaSBaseDriver):
         self.cluster_manager = ClusterManager()
         self.system_helper = SystemHelper()
         self.lbaas_builder = LBaaSBuilder(self.conf, self)
+
+        # Set esd_processor object as soon as ServiceModelAdapter and
+        # LBaaSBuilder class instantiated, otherwise manager RPC exception
+        # will break setting esd_porcessor procedure.
+        self.init_esd()
 
         if self.conf.f5_global_routed_mode:
             self.network_builder = None
@@ -668,7 +681,7 @@ class iControlDriver(LBaaSBaseDriver):
             raise
 
     def _open_bigip(self, hostname):
-        # Open bigip connection """
+        # Open bigip connection
         try:
             bigip = self.__bigips[hostname]
             if bigip.status not in ['creating', 'error']:
@@ -824,27 +837,37 @@ class iControlDriver(LBaaSBaseDriver):
         if self.network_builder:
             self.network_builder.post_init()
 
-        # read enhanced services definitions
-        esd_dir = os.path.join(self.get_config_dir(), 'esd')
-        esd = EsdTagProcessor(esd_dir)
-        try:
-            esd.process_esd(self.get_all_bigips())
-            self.lbaas_builder.init_esd(esd)
-            self.service_adapter.init_esd(esd)
+        self._set_agent_status(False)
 
-            LOG.debug('esd details here after process_esd(): ')
-            LOG.debug(esd)
-            self.esd_names = esd.esd_dict.keys() or []
-            LOG.debug('##### self.esd_names obtainded here:')
-            LOG.debug(self.esd_names)
+    def init_esd(self):
+        # read all esd file from esd dir
+        # init esd object in lbaas_builder
+        # init esd object in service_adapter
+        esd_dir = os.path.join(self.get_config_dir(), 'esd')
+        # EsdTagProcessor is a singleton, so nothing new
+        self.esd_processor = EsdTagProcessor()
+        try:
+            self.esd_processor.process_esd(self.get_all_bigips(), esd_dir)
+            self.lbaas_builder.init_esd(self.esd_processor)
+            self.service_adapter.init_esd(self.esd_processor)
+
         except f5ex.esdJSONFileInvalidException as err:
             LOG.error("unable to initialize ESD. Error: %s.", err.message)
-        self._set_agent_status(False)
+        except IOError as ioe:
+            LOG.error("unable to process ESD file. Error: %s.", ioe.message)
+        except Exception as exc:
+            LOG.error("unknown Error happens. Error: %s.", exc.message)
+
+        LOG.debug('ESD details here after process_esd(): ')
+        LOG.debug(self.esd_processor)
+        self.esd_names = self.esd_processor.esd_dict.keys() or []
+        LOG.debug('self.esd_names obtainded here:')
+        LOG.debug(self.esd_names)
 
     def _validate_ha(self, bigip):
         # if there was only one address supplied and
         # this is not a standalone device, get the
-        # devices trusted by this device. """
+        # devices trusted by this device.
         device_group_name = None
         if self.conf.f5_ha_type == 'standalone':
             if len(self.hostnames) != 1:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l7policy_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l7policy_adapter.py
@@ -74,7 +74,140 @@ class Condition(object):
         if condition['invert']:
             setattr(self, 'not', condition['invert'])
         self.__dict__.update(cond_type_map[condition['type']])
-        setattr(self, self.cond_comp_type_map[condition['compare_type']], True)
+        if condition['compare_type'] in self.cond_comp_type_map:
+            setattr(self,
+                    self.cond_comp_type_map[condition['compare_type']],
+                    True)
+            setattr(self, "not_regex", True)
+
+
+class iRule(object):
+    """Describes a single iRule for REGEX l7policy"""
+
+    action_mapping = {
+        "REDIRECT_TO_POOL": '''when HTTP_REQUEST {
+            if {[HTTP::%s] matches_regex "%s"} {
+                pool %s
+            }
+        }''',
+        "REDIRECT_TO_URL": '''when HTTP_REQUEST {
+            if {[HTTP::%s] matches_regex "%s"} {
+                HTTP::redirect "%s"
+            }
+        }''',
+        "REJECT": '''when HTTP_REQUEST {
+            if {[HTTP::%s] matches_regex "%s"} {
+                drop
+            }
+        } '''
+    }
+
+    file_action_mapping = {
+        "REDIRECT_TO_POOL": '''when HTTP_REQUEST {
+            if {[HTTP::%s] ends_with "%s"} {
+                pool %s
+            }
+        }''',
+        "REDIRECT_TO_URL": '''when HTTP_REQUEST {
+            if {[HTTP::%s] ends_with "%s"} {
+                HTTP::redirect "%s"
+            }
+        }''',
+        "REJECT": '''when HTTP_REQUEST {
+            if {[HTTP::%s] ends_with "%s"} {
+                drop
+            }
+        } '''
+    }
+
+    type_mapping = {
+        "HOST_NAME": "host",
+        "PATH": "path",
+        "FILE_TYPE": "uri",
+        "HEADER": "header %s",
+        "COOKIE": "cookie %s"
+    }
+
+    def __init__(self, policy):
+        self.listener = policy["listener_id"]
+        self.action = policy["action"]
+        self.action_pool = policy.get("redirect_pool_id")
+        self.action_uri = policy.get("redirect_url")
+        self.value = None
+        self.type = None
+        self.apiAnonymous = None
+        self.key = None
+        self.template = None
+
+    def adapt_regex_to_irule(
+            self, policy, service, partition, env_prefix):
+        """Adapt OpenStack rules into conditions and actions."""
+        irule_list = []
+        for os_rule_dict in policy['rules']:
+            rule_id = os_rule_dict['id']
+            os_rule = self._get_l7rule(rule_id, service)
+            if os_rule['provisioning_status'] != 'PENDING_DELETE' and \
+               os_rule['admin_state_up']:
+                if os_rule['compare_type'] == "REGEX":
+                    self.value = os_rule["value"]
+                    self.key = os_rule.get("key")
+
+                    if os_rule["type"] in ("HEADER", "COOKIE"):
+                        self.type = self.type_mapping[
+                            os_rule["type"]] % self.key
+                    else:
+                        self.type = self.type_mapping[os_rule["type"]]
+
+                    if os_rule["type"] == "FILE_TYPE":
+                        self.template = self.file_action_mapping[self.action]
+                    else:
+                        self.template = self.action_mapping[self.action]
+
+                    irule_object = self._l7rule_to_irule(
+                        partition,
+                        env_prefix,
+                        rule_id)
+
+                    irule_list.append(irule_object)
+        return irule_list
+
+    def _l7rule_to_irule(self, partition, env_prefix, rule_id):
+        irule_object = {}
+
+        if self.action == "REDIRECT_TO_POOL":
+            pool_name = self._get_pool_name(
+                partition, env_prefix, self.action_pool)
+            self.apiAnonymous = self.template % (self.type,
+                                                 self.value,
+                                                 pool_name)
+        if self.action == "REDIRECT_TO_URL":
+            self.apiAnonymous = self.template % (self.type,
+                                                 self.value,
+                                                 self.action_uri)
+        if self.action == "REJECT":
+            self.apiAnonymous = self.template % (self.type,
+                                                 self.value)
+        irule_object["listener"] = self.listener
+        irule_object["apiAnonymous"] = self.apiAnonymous
+        # irule_object["action_pool"] = self.action_pool
+        # irule_object["action_uri"] = self.action_uri
+        irule_object["partition"] = partition
+        irule_object["name"] = "irule_" + rule_id
+        irule_object["fullPath"] = self._get_fullPath(partition, rule_id)
+        return irule_object
+
+    def _get_l7rule(self, rule_id, service):
+        """Get rule dict from service list."""
+        for rule in service['l7rules']:
+            if rule['id'] == rule_id:
+                return rule
+
+    def _get_pool_name(self, partition, env_prefix, action_value):
+        """Construct pool name from partition and OpenStack pool name."""
+        return '/{0}/{1}{2}'.format(partition, env_prefix, action_value)
+
+    def _get_fullPath(self, partition, name):
+        return '/{0}/{1}'.format(partition, name)
 
 
 class Rule(object):
@@ -96,7 +229,8 @@ class Rule(object):
             if os_rule['provisioning_status'] != 'PENDING_DELETE' and \
                os_rule['admin_state_up']:
                 cond = Condition(os_rule, str(idx))
-                self.conditions.append(cond.__dict__)
+                if cond.__dict__.get("not_regex", False):
+                    self.conditions.append(cond.__dict__)
         act_type, act_val = self._get_action_and_value(policy['id'], service)
         action = Action(act_type, '0', partition, env_prefix, act_val)
         self.actions.append(action.__dict__)
@@ -137,12 +271,16 @@ class L7PolicyServiceAdapter(ServiceModelAdapter):
     """Map OpenStack policies and rules to policy and rules on device."""
     def _adapt_policies_to_rules(self):
         """OS Policies are translated into Rules on the device."""
+        self.iRules = []
         for policy in self.service['l7policies']:
             if policy['provisioning_status'] != 'PENDING_DELETE' and \
                policy['admin_state_up']:
                 bigip_rule = Rule(
                     policy, self.service, self.folder, self.prefix)
                 self.policy_dict['rules'].append(bigip_rule.__dict__)
+                irule = iRule(policy)
+                self.iRules += irule.adapt_regex_to_irule(
+                    policy, self.service, self.folder, self.prefix)
         if not self.policy_dict['rules']:
             msg = 'All policies were in a PENDING_DELETE or admin_state ' \
                 'DOWN.  Deleting wrapper_policy.'

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l7policy_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l7policy_service.py
@@ -35,6 +35,7 @@ class L7PolicyService(object):
     def __init__(self, conf):
         self.conf = conf
         self.policy_helper = BigIPResourceHelper(ResourceType.l7policy)
+        self.rule_helper = BigIPResourceHelper(ResourceType.rule)
 
     def create_l7policy(self, f5_l7policy, bigips):
         LOG.debug("L7PolicyService: create_l7policy")
@@ -102,7 +103,12 @@ class L7PolicyService(object):
 
         l7policy_adapter = L7PolicyServiceAdapter(self.conf)
 
-        os_policies = {'l7rules': [], 'l7policies': [], 'f5_policy': {}}
+        os_policies = {
+            'l7rules': [],
+            'l7policies': [],
+            'f5_policy': {},
+            'iRules': []
+        }
 
         # get all policies and rules for listener referenced by this policy
         listener = lbaas_service.get_listener(l7policy['listener_id'])
@@ -117,6 +123,74 @@ class L7PolicyService(object):
 
         if os_policies['l7policies']:
             os_policies['f5_policy'] = l7policy_adapter.translate(os_policies)
+            if getattr(l7policy_adapter, 'iRules', None):
+                os_policies['iRules'] = l7policy_adapter.iRules
 
         LOG.debug(pprint.pformat(os_policies, indent=2))
         return os_policies
+
+    def create_irule(self, irules, bigips):
+        LOG.debug("L7PolicyService: create_iRule")
+
+        error = None
+        for bigip in bigips:
+            for rule in irules:
+                try:
+                    self.rule_helper.create(bigip, rule)
+                except HTTPError as err:
+                    status_code = err.response.status_code
+                    if status_code == 409:
+                        LOG.debug(
+                            "L7 rule (REGEX irule) already exists...updating")
+                        try:
+                            self.rule_helper.update(bigip, rule)
+                        except Exception as err:
+                            error = f5_ex.L7PolicyUpdateException(err.message)
+                    else:
+                        error = f5_ex.L7PolicyCreationException(err.message)
+                except Exception as err:
+                    error = f5_ex.L7PolicyCreationException(err.message)
+
+                if error:
+                    LOG.error("L7 rule (REGEX irule) creation error: %s" %
+                              error.message)
+
+        return error
+
+    def delete_irule(self, delete_irules, bigips):
+        LOG.debug("L7PolicyService:delete_iRule")
+
+        error = False
+        for bigip in bigips:
+            for rule in delete_irules:
+                try:
+                    self.rule_helper.delete(bigip,
+                                            name=rule.get('name'),
+                                            partition=rule.get('partition'))
+                except HTTPError as err:
+                    status_code = err.response.status_code
+                    if status_code == 404:
+                        LOG.warn(
+                            "Deleting L7 policy (iRule) "
+                            + "failed...not found: %s",
+                            err.message
+                        )
+                    elif status_code == 400:
+                        LOG.debug(
+                            "Deleting L7 policy (iRule) failed...unknown "
+                            "client error: %s", err.message
+                        )
+                        error = f5_ex.L7PolicyDeleteException(err.message)
+                    else:
+                        error = f5_ex.L7PolicyDeleteException(err.message)
+                except Exception as err:
+                    LOG.exception(err)
+                    error = f5_ex.L7PolicyDeleteException(err.message)
+
+                if error:
+                    LOG.error(
+                        "L7 Policy (iRule) deletion error: %s",
+                        error.message
+                    )
+
+        return error

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/refersh_esd.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/refersh_esd.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python
+
+# Copyright (c) 2014-2018, F5 Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import signal
+import subprocess
+
+
+def refresh_esd():
+
+    cmd = ['pgrep', '-f', 'f5-oslbaasv2-ag']
+    child_process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    resp = child_process.communicate()[0].split()
+
+    for pid in resp:
+        os.kill(int(pid), signal.SIGUSR1)
+        print("Refreshed ESD for f5-oslbaasv2-agent (PID): %s." % pid)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -123,11 +123,16 @@ class ServiceModelAdapter(object):
             listener["session_persistence"] = pool["session_persistence"]
 
         listener_policies = self.get_listener_policies(service)
+        listener_irules = self.get_listener_irules(service)
 
         vip = self._map_virtual(loadbalancer, listener, pool=pool,
-                                policies=listener_policies)
+                                policies=listener_policies,
+                                irules=list(listener_irules))
 
         return vip
+
+    def get_listener_irules(self, service):
+        return [r["name"] for r in service.get("irules", [])]
 
     def get_listener_policies(self, service):
         """Return a map of listener L7 policy ids to a list of L7 rules."""
@@ -424,7 +429,8 @@ class ServiceModelAdapter(object):
         else:
             return 'round-robin'
 
-    def _map_virtual(self, loadbalancer, listener, pool=None, policies=None):
+    def _map_virtual(self, loadbalancer, listener,
+                     pool=None, policies=None, irules=[]):
         if policies:
             LOG.debug("L7_debug: policies: %s", policies)
         vip = self._init_virtual_name(loadbalancer, listener)
@@ -473,7 +479,9 @@ class ServiceModelAdapter(object):
         self._add_vlan_and_snat(listener, vip)
         self._add_profiles_session_persistence(listener, pool, vip)
 
-        vip['rules'] = list()
+        existed_irules = vip.get('rules', [])
+        irules += existed_irules
+        vip['rules'] = irules
         vip['policies'] = list()
         if policies:
             self._apply_l7_and_esd_policies(listener, policies, vip)
@@ -679,9 +687,8 @@ class ServiceModelAdapter(object):
             vip['fallbackPersistence'] = esd['lbaas_fallback_persist']
 
         # iRules
-        vip['rules'] = list()
         if 'lbaas_irule' in esd:
-            irules = []
+            irules = vip.get('rules', [])
             for irule in esd['lbaas_irule']:
                 irules.append('/Common/' + irule)
             vip['rules'] = irules
@@ -759,9 +766,8 @@ class ServiceModelAdapter(object):
             vip['fallbackPersistence'] = esd['lbaas_fallback_persist']
 
         # iRules
-        vip['rules'] = list()
         if 'lbaas_irule' in esd:
-            irules = []
+            irules = vip.get('rules', [])
             for irule in esd['lbaas_irule']:
                 irules.append('/Common/' + irule)
             vip['rules'] = irules

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_launcher.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_launcher.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2014-2018, F5 Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from oslo_service import service
+from oslo_service import systemd
+
+
+class F5ServiceLauncher(service.ServiceLauncher):
+
+    def __init__(self, conf):
+        super(F5ServiceLauncher, self).__init__(conf)
+
+    def handle_signal(self):
+        self.signal_handler.add_handler('SIGTERM', self._graceful_shutdown)
+        self.signal_handler.add_handler('SIGINT', self._fast_exit)
+        self.signal_handler.add_handler('SIGHUP', self._reload_service)
+        self.signal_handler.add_handler('SIGALRM', self._on_timeout_exit)
+
+    def wait(self):
+        systemd.notify_once()
+        while True:
+            self.handle_signal()
+            status, signo = self._wait_for_exit_or_signal()
+            if not service._is_sighup_and_daemon(signo):
+                break
+            self.restart()
+
+        self.services.wait()
+        return status


### PR DESCRIPTION
this PR provides the diff between sdn-base and 9.8-stable(46e2320).

this provides the possible patch to be used.

NOTE: this is not the exact diff because __init__.py still has 5.0.0.
This diff only includes the files from f5_openstack_agent directory,
other directories are not included into this PR.

Also  it excludes 3 diff test files from f5_openstack_agent directory:
f5_openstack_agent/lbaasv2/drivers/bigip/test/test_esd_filehandler.py
f5_openstack_agent/lbaasv2/drivers/bigip/test/test_lbaas_builder.py
f5_openstack_agent/lbaasv2/drivers/bigip/test/test_service_adapter.py

NOTE: This PR should never be merged into sdn-base branch.
The sdn-base branch should never be touched/merged.
sdn-base is now at 14d8557.

This should only server as the PR to download the patch file.