### PR TITLE
9.8 stable rj

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
@@ -71,7 +71,7 @@ class BigipSelfIpManager(object):
                                           err.message))
                         raise f5_ex.SelfIPCreationException("selfip")
                 else:
-                    # pzhang: post 400
+                    # here may post 400
                     LOG.error("selfip creation error message: %s" %
                               err.message)
                     LOG.error("selfip creation error status: %s" %

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
@@ -71,8 +71,13 @@ class BigipSelfIpManager(object):
                                           err.message))
                         raise f5_ex.SelfIPCreationException("selfip")
                 else:
-                    LOG.exception("selfip creation error: %s(%s)" %
-                                  (err.message, err.response.status_code))
+                    # pzhang: post 400
+                    LOG.error("selfip creation error message: %s" %
+                              err.message)
+                    LOG.error("selfip creation error status: %s" %
+                              err.reponse.status_code)
+                    LOG.error("selfip creation error text: %s" %
+                              err.response.text)
                     raise
             except Exception as err:
                 LOG.error("Failed to create selfip")

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_service_adapter.py
@@ -1155,7 +1155,9 @@ class TestServiceAdapter(object):
         assert "policies" not in vip
 
         assert vip['persist'] == [dict(name="hash")]
-        assert vip['profiles'] == ["/Common/http", "/Common/fastL4"]
+        assert vip['profiles'] == [{'partition': 'Common',
+                                    'context': 'all',
+                                    'name': 'tcp'}]
 
     def test_apply_l4_esd_persist_profile_collision(adapter):
         adapter = ServiceModelAdapter(mock.MagicMock())
@@ -1169,7 +1171,9 @@ class TestServiceAdapter(object):
         assert "policies" not in vip
 
         assert vip['persist'] == [dict(name="hash")]
-        assert vip['profiles'] == ["/Common/http", "/Common/fastL4"]
+        assert vip['profiles'] == [{'partition': 'Common',
+                                    'context': 'all',
+                                    'name': 'tcp'}]
 
     def test_apply_l4_esd_fallback_persist_profile(adapter):
         adapter = ServiceModelAdapter(mock.MagicMock())
@@ -1184,7 +1188,9 @@ class TestServiceAdapter(object):
 
         assert vip['persist'] == [dict(name="sourceip")]
         assert vip['fallbackPersistence'] == 'hash'
-        assert vip['profiles'] == ["/Common/http", "/Common/fastL4"]
+        assert vip['profiles'] == [{'partition': 'Common',
+                                    'context': 'all',
+                                    'name': 'tcp'}]
 
     def test_apply_l4_esd_fallback_persist_profile_collision(adapter):
         adapter = ServiceModelAdapter(mock.MagicMock())
@@ -1199,7 +1205,9 @@ class TestServiceAdapter(object):
 
         assert vip['persist'] == [dict(name="sourceip")]
         assert vip['fallbackPersistence'] == 'hash'
-        assert vip['profiles'] == ["/Common/http", "/Common/fastL4"]
+        assert vip['profiles'] == [{'partition': 'Common',
+                                    'context': 'all',
+                                    'name': 'tcp'}]
 
     def test_apply_l4_esd_http_profile(adapter):
         adapter = ServiceModelAdapter(mock.MagicMock())
@@ -1213,7 +1221,10 @@ class TestServiceAdapter(object):
         assert "persist" not in vip
         assert "fallbackPersistence" not in vip
 
-        assert vip['profiles'] == ["/Common/http_profile", "/Common/fastL4"]
+        assert vip['profiles'] == ["/Common/http_profile",
+                                   {'partition': 'Common',
+                                    'context': 'all',
+                                    'name': 'tcp'}]
 
     def test_apply_l4_esd_fallback_persist_profile_nopersist(adapter):
         adapter = ServiceModelAdapter(mock.MagicMock())


### PR DESCRIPTION
    In order to support TCP IP transmission.
    SE give suggestion to configuration ESD like below:

      "insert_sip_tcp-option": {
        "lbaas_stcp": "tcp_option_28",
        "lbaas_irule": ["insert-clientIP-TCP-option"]
      }

    we have to change TCP to standard type to use lbaas_stcp tag (Protocol
    profile (Sever)) by using --description options.

    Command lines:
    neutron lbaas-listener-create --name tcp-standard
                                  --loadbalancer source-ip-lb
                                  --protocol TCP
                                  --protocol-port 24
                                  --description "{'TCP-type':'standard'}"

    neutron lbaas-l7policy-create --listener tcp-standard
                                  --name insert_sip_tcp-option
                                  --action REJECT

    CAUTION: update description is not allow.