### PR TITLE
Diameter listener, Diameter monitor, SIP listener function

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1603,6 +1603,10 @@ class iControlDriver(LBaaSBaseDriver):
     def create_health_monitor(self, health_monitor, service):
         """Create pool health monitor."""
         LOG.debug("Creating health monitor")
+        monitors = service.get("healthmonitors", list())
+        for mn in monitors:
+            if mn.get("name") == "diameter":
+                mn["type"] = "DIAMETER"
         return self._common_service_handler(service)
 
     @serialized('update_health_monitor')
@@ -1611,6 +1615,10 @@ class iControlDriver(LBaaSBaseDriver):
                               health_monitor, service):
         """Update pool health monitor."""
         LOG.debug("Updating health monitor")
+        monitors = service.get("healthmonitors", list())
+        for mn in monitors:
+            if mn.get("name") == "diameter":
+                mn["type"] = "DIAMETER"
         return self._common_service_handler(service)
 
     @serialized('delete_health_monitor')
@@ -1618,6 +1626,10 @@ class iControlDriver(LBaaSBaseDriver):
     def delete_health_monitor(self, health_monitor, service):
         """Delete pool health monitor."""
         LOG.debug("Deleting health monitor")
+        monitors = service.get("healthmonitors", list())
+        for mn in monitors:
+            if mn.get("name") == "diameter":
+                mn["type"] = "DIAMETER"
         return self._common_service_handler(service)
 
     @is_operational

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/pool_service.py
@@ -45,6 +45,8 @@ class PoolServiceBuilder(object):
             resource_helper.ResourceType.udp_monitor)
         self.sip_mon_helper = resource_helper.BigIPResourceHelper(
             resource_helper.ResourceType.sip_monitor)
+        self.diameter_mon_helper = resource_helper.BigIPResourceHelper(
+            resource_helper.ResourceType.diameter_monitor)
         self.ping_mon_helper = resource_helper.BigIPResourceHelper(
             resource_helper.ResourceType.ping_monitor)
         self.pool_helper = resource_helper.BigIPResourceHelper(
@@ -252,6 +254,8 @@ class PoolServiceBuilder(object):
             hm = self.udp_mon_helper
         elif monitor_type == "SIP":
             hm = self.sip_mon_helper
+        elif monitor_type == "DIAMETER":
+            hm = self.diameter_mon_helper
         else:
             hm = self.http_mon_helper
         return hm

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
@@ -63,6 +63,7 @@ class ResourceType(Enum):
     oneconnect = 37
     udp_monitor = 38
     sip_monitor = 39
+    diameter_monitor = 40
 
 
 class BigIPResourceHelper(object):
@@ -211,6 +212,8 @@ class BigIPResourceHelper(object):
                 lambda bigip: bigip.tm.ltm.monitor.udps.udp,
             ResourceType.sip_monitor:
                 lambda bigip: bigip.tm.ltm.monitor.sips.sip,
+            ResourceType.diameter_monitor:
+                lambda bigip: bigip.tm.ltm.monitor.diameters.diameter,
             ResourceType.ping_monitor:
                 lambda bigip: bigip.tm.ltm.monitor.gateway_icmps.gateway_icmp,
             ResourceType.node: lambda bigip: bigip.tm.ltm.nodes.node,

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -603,13 +603,10 @@ class ServiceModelAdapter(object):
             vip['profiles'] = ['/Common/fastL4']
         elif virtual_type == 'standard' and protocol == 'TCP':
             vip['profiles'] = ['/Common/tcp']
-            # vip['profiles'] = []
         elif virtual_type == 'standard' and protocol == 'UDP':
             vip['profiles'] = ['/Common/udp']
-            # vip['profiles'] = []
         elif virtual_type == 'mr' and protocol == 'TCP':
             vip['profiles'] = ['/Common/tcp']
-            # vip['profiles'] = ['/Common/tcp']
         else:
             # add profiles for HTTP, TERMINATED_HTTPS protocols
             vip['profiles'] = ['/Common/http', '/Common/oneconnect']
@@ -653,7 +650,6 @@ class ServiceModelAdapter(object):
         if add_diameter:
             diameter_session = extra_options.get('ds')
             diameter_router = extra_options.get('dr')
-            # tcp_profile = extra_options.get('dtcp')
 
             if not diameter_session:
                 diameter_session = '/Common/diametersession'
@@ -667,7 +663,6 @@ class ServiceModelAdapter(object):
                     diameter_router not in vip['profiles']:
                 vip['profiles'] += [diameter_session,
                                     diameter_router]
-                                   #  tcp_profile]
 
     def get_vlan(self, vip, bigip, network_id):
         if network_id in bigip.assured_networks:
@@ -793,8 +788,6 @@ class ServiceModelAdapter(object):
             if '/Common/tcp' in vip['profiles']:
                 vip['profiles'].remove('/Common/tcp')
 
-            # if '/Common/udp' not in vip['profiles'] and \
-                    # '/Common/tcp' not in vip['profiles']:
             vip['profiles'].append({'name':  ctcp_profile,
                                     'partition': 'Common',
                                     'context': ctcp_context})

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -561,11 +561,6 @@ class ServiceModelAdapter(object):
             LOG.warning("Listener protocol unrecognized: %s",
                         listener["protocol"])
 
-        if protocol == "UDP":
-            vip["ipProtocol"] = "udp"
-        else:
-            vip["ipProtocol"] = "tcp"
-
         # if protocol is HTTPS, also use fastl4
         if protocol in ['TCP', 'HTTPS', 'UDP']:
             virtual_type = 'fastl4'
@@ -574,20 +569,47 @@ class ServiceModelAdapter(object):
 
         extra_options = self.parse_descript_opts(listener)
 
+        add_sip = False
+        add_diameter = False
         # according to the extra_options,
         # some vip profile will be overwrite
         if extra_options:
-            tcp_type = extra_options.get('TCP-type')
+            listener_type = extra_options.get('Listener-type')
+            extra_profile = extra_options.get('Add-profile')
+
+            other_proto = extra_options.get('Listener-proto')
             # add this for TCP source ip transparent
-            if tcp_type == 'standard' and protocol == 'TCP':
+            if other_proto == 'UDP':
+                # TCP with UDP description, it will become UDP
+                protocol = "UDP"
+                # change listener protocol here
+                listener["protocol"] = "UDP"
+
+            if listener_type == 'standard':
                 virtual_type = 'standard'
+
+            if extra_profile == 'SIP':
+                add_sip = True
+            elif extra_profile == 'Diameter':
+                virtual_type = "mr"
+                add_diameter = True
+
+        if protocol == "UDP":
+            vip["ipProtocol"] = "udp"
+        else:
+            vip["ipProtocol"] = "tcp"
 
         if virtual_type == 'fastl4':
             vip['profiles'] = ['/Common/fastL4']
-        # standard type TCP listener canot have http and oneconnect profile
-        # or ssh lb members will be diconnected
         elif virtual_type == 'standard' and protocol == 'TCP':
-            vip['profiles'] = []
+            vip['profiles'] = ['/Common/tcp']
+            # vip['profiles'] = []
+        elif virtual_type == 'standard' and protocol == 'UDP':
+            vip['profiles'] = ['/Common/udp']
+            # vip['profiles'] = []
+        elif virtual_type == 'mr' and protocol == 'TCP':
+            vip['profiles'] = ['/Common/tcp']
+            # vip['profiles'] = ['/Common/tcp']
         else:
             # add profiles for HTTP, TERMINATED_HTTPS protocols
             vip['profiles'] = ['/Common/http', '/Common/oneconnect']
@@ -623,6 +645,29 @@ class ServiceModelAdapter(object):
 
             if persistence_type in ['HTTP_COOKIE', 'APP_COOKIE']:
                 vip['profiles'] = ['/Common/http', '/Common/oneconnect']
+
+        if add_sip:
+            if '/Common/sip' not in vip['profiles']:
+                vip['profiles'].append('/Common/sip')
+
+        if add_diameter:
+            diameter_session = extra_options.get('ds')
+            diameter_router = extra_options.get('dr')
+            # tcp_profile = extra_options.get('dtcp')
+
+            if not diameter_session:
+                diameter_session = '/Common/diametersession'
+            else:
+                diameter_session = '/Common/' + diameter_session
+
+            if not diameter_router:
+                diameter_router = '/Common/diameterrouter'
+
+            if diameter_session not in vip['profiles'] and \
+                    diameter_router not in vip['profiles']:
+                vip['profiles'] += [diameter_session,
+                                    diameter_router]
+                                   #  tcp_profile]
 
     def get_vlan(self, vip, bigip, network_id):
         if network_id in bigip.assured_networks:
@@ -726,9 +771,7 @@ class ServiceModelAdapter(object):
             else:
                 vip['profiles'] = ["/Common/" + esd['lbaas_http_profile']]
 
-        # fastL4 listener cannot configure server and client
-        # protocol, or it will throw errors
-        # start with server tcp profile
+        # for standard type tcp listener
         if "/Common/fastL4" not in vip['profiles']:
             if 'lbaas_stcp' in esd:
                 # set serverside tcp profile
@@ -746,6 +789,12 @@ class ServiceModelAdapter(object):
                 ctcp_profile = esd['lbaas_ctcp']
             else:
                 ctcp_profile = 'tcp'
+
+            if '/Common/tcp' in vip['profiles']:
+                vip['profiles'].remove('/Common/tcp')
+
+            # if '/Common/udp' not in vip['profiles'] and \
+                    # '/Common/tcp' not in vip['profiles']:
             vip['profiles'].append({'name':  ctcp_profile,
                                     'partition': 'Common',
                                     'context': ctcp_context})
@@ -807,9 +856,12 @@ class ServiceModelAdapter(object):
             ctcp_profile = esd['lbaas_ctcp']
         else:
             ctcp_profile = 'tcp'
-        profiles.append({'name':  ctcp_profile,
-                         'partition': 'Common',
-                         'context': ctcp_context})
+
+        # in case of udp listener cahanges back to 'tcp'
+        if '/Common/udp' not in vip["profiles"]:
+            profiles.append({'name':  ctcp_profile,
+                             'partition': 'Common',
+                             'context': ctcp_context})
 
         if 'lbaas_oneconnect_profile' in esd:
             profiles.remove('/Common/oneconnect')

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/conftest.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/conftest.py
@@ -118,7 +118,7 @@ class TestingWithServiceConstructor(object):
                  device_id=device_id, divcie_owner='newutron:LOADBALANCERV2',
                  dns_assignment=dns_assignment, dns_name=None,
                  extra_dhcp_opts=[], id=cls.new_id(), network_id=network_id,
-                 name='loadbalancer-'.format(new_id), security_groups=[],
+                 name='loadbalancer-' + new_id, security_groups=[],
                  mac_address='xx:xx:xx:xx:xx:xx', status='UP',
                  tenant_id=tenant_id, fixed_ips=fixed_ips)
         new_lb = \

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/mock_builder_base_class.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/mock_builder_base_class.py
@@ -426,7 +426,7 @@ class MockBuilderBase(object):
             except AssertionError:
                 raise AssertionError(
                     "Expected '{}.{}' method to be called {} times.  Was "
-                    "actually called {} times.  Impacted builder: {}".format(
+                    "actually called {} times. ".format(
                         stored.target_mod, stored.mocked_method,
                         stored.expected.call_cnt, stored.mock_builder))
 


### PR DESCRIPTION
transparent IP TCP standard listener

Add sip udp listener:

```
neutron lbaas-listener-create --name test-udp-sip \
--loadbalancer test-lb \
--protocol TCP \
--protocol-port 24 \
--description "{'Add-profile':'SIP', 'Listener-proto':'UDP', 'Listener-type':'standard'}"
```

`neutron lbaas-l7policy-create --listener test-udp-sip --name sip_persistence --action REJECT`

Add daimeter listener:

```
neutron lbaas-listener-create --name test-tcp-diameter \
--loadbalancer test-lb \
--protocol TCP \
--protocol-port 1234 \
--description "{'Add-profile':'Diameter', 'ds':'diameter-it-session', 'dr':'diameterrouter-it'}"
```

`neutron lbaas-l7policy-create --listener test-tcp-diameter --name diameter_tcp --action REJECT`

Change transparent IP TCP standard listener CLI to:

```
neutron lbaas-listener-create --name test-tcp-transparent \
--loadbalancer test-lb \
--protocol TCP \
--protocol-port 8899 \
--description "{'Listener-type':'standard'}"
```

`neutron lbaas-l7policy-create --listener test-tcp-transparent --name insert_sip_tcp-option --action REJECT`

ESD file:

cat /etc/neutron/services/f5/esd/demo.json

```
{
	"sip_persistence": {
		"lbaas_persist": "custom_sip_persist"
	},

	"diameter_tcp": {
		"lbaas_ctcp": "tcp-idle-800"
	},
	  
	"insert_sip_tcp-option": {
		"lbaas_stcp": "tcp_option_28",
		"lbaas_irule": ["insert-clientIP-TCP-option"]
	}
}
```

--------------------------------------------------------------------------------------
create diameter healthmonitor on BIGIP:
```
  neutron lbaas-healthmonitor-create --pool a4b9e446-4350-4652-8d20-e6d087e784e6
                                     --type TCP
                                     --delay 20
                                     --timeout 30
                                     --max-retries 1
                                     --name diameter
```