### PR TITLE
hotfix: delete previous code change for deleting last one loadbalancer in agent 2.0

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -1539,12 +1539,6 @@ class iControlDriver(LBaaSBaseDriver):
         """Delete loadbalancer."""
         LOG.debug("Deleting loadbalancer")
 
-        # if the lb is the last one in partition, 'last_one' will
-        #  be set True, then partition and route domain can be deleted
-        last_lb = {"last_one": loadbalancer["last_one"]}
-        lb = service.get("loadbalancer")
-        lb.update(last_lb)
-
         return self._common_service_handler(
             service,
             delete_partition=True,
@@ -2107,14 +2101,10 @@ class iControlDriver(LBaaSBaseDriver):
         except Exception as err:
             LOG.exception(err)
         finally:
-            # only delete partition if the last loadbalancer
-            # is being deleted
+
             if lb_provisioning_status == f5const.F5_PENDING_DELETE:
-                if loadbalancer.get('last_one'):
-                    self.tenant_manager.assure_tenant_cleanup(
-                        service,
-                        all_subnet_hints
-                    )
+                self.tenant_manager.assure_tenant_cleanup(service,
+                                                          all_subnet_hints)
 
             if do_service_update:
                 self.update_service_status(service)

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/lbaas_builder.py
@@ -32,7 +32,7 @@ LOG = logging.getLogger(__name__)
 
 class LBaaSBuilder(object):
     # F5 LBaaS Driver using iControl for BIG-IP to
-    # create objects (vips, pools) - not using an iApp."""
+    # create objects (vips, pools) - not using an iApp.
 
     def __init__(self, conf, driver, l2_service=None):
         self.conf = conf


### PR DESCRIPTION
Previous delete last one loadbalancer, the partition needs to be purged,
agent 2.0 has an approach to solve the problem by finding the last one lb in neutron DB.

However, we found another approach to solve the problem in agent 3.0 and
2.0.

I forget to delete the previous code change in f5 agent 2.0, and test. and it causes a bug.
