### PR TITLE
WIP: add check and sync data (need more tests)

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent.py
@@ -97,15 +97,21 @@ def main():
         manager=mgr
     )
 
-    def handler(*args):
+    def esd_handler(*args):
         LOG.info("receive signal to refresh ESD files!")
         if mgr.lbdriver.esd_processor:
             mgr.lbdriver.init_esd()
             LOG.info("ESD has been refreshed")
 
+    def neutron_sync_handler(*args):
+        LOG.info("receive signal to sync data from neutron !")
+        mgr.neutron_db_sync()
+        LOG.info("neutron data has been synced")
+
     service_launch = service_launcher.F5ServiceLauncher(cfg.CONF)
 
-    service_launch.signal_handler.add_handler('SIGUSR1', handler)
+    service_launch.signal_handler.add_handler('SIGUSR1', esd_handler)
+    service_launch.signal_handler.add_handler('SIGUSR2', neutron_sync_handler)
     service_launch.launch_service(svc)
     service_launch.wait()
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
@@ -186,8 +186,9 @@ class L2ServiceBuilder(object):
                       'Attempted to assure a network with no id..skipping.')
             return
 
-        if network['id'] in bigip.assured_networks:
-            return
+        # pzhang: 3.0 and sync do not need cache here
+        # if network['id'] in bigip.assured_networks:
+        #     return
 
         if network['id'] in self.conf.common_network_ids:
             LOG.debug('assure_bigip_network: '
@@ -311,6 +312,7 @@ class L2ServiceBuilder(object):
         if self.vcmp_manager and self.vcmp_manager.get_vcmp_host(bigip):
             interface = None
         try:
+            # pzhang check exist first ?
             model = {'name': vlan_name,
                      'interface': interface,
                      'tag': vlanid,

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
@@ -47,6 +47,7 @@ class BigipSelfIpManager(object):
             created = True
         else:
             try:
+                # pzhang: check exists first ?
                 self.selfip_manager.create(bigip, model)
                 created = True
             except HTTPError as err:
@@ -102,15 +103,19 @@ class BigipSelfIpManager(object):
                       'for network with not id...')
             raise KeyError("network and subnet need to be specified")
 
-        tenant_id = service['loadbalancer']['tenant_id']
+        # tenant_id = service['loadbalancer']['tenant_id']
         lb_id = service['loadbalancer']['id']
 
+        # pzhang for agent 3.0 and sync
+        # pzhang we do not need cache here
+        # pzhang if sync, then the selfip of the same vlan will be different
+        # pzhang on different bigip device
         # If we have already assured this subnet.. return.
         # Note this cache is periodically cleared in order to
         # force assurance that the configuration is present.
-        if tenant_id in bigip.assured_tenant_snat_subnets and \
-                subnet['id'] in bigip.assured_tenant_snat_subnets[tenant_id]:
-            return True
+        # if tenant_id in bigip.assured_tenant_snat_subnets and \
+        #         subnet['id'] in bigip.assured_tenant_snat_subnets[tenant_id]:
+        #     return True
 
         selfip_address = self._get_bigip_selfip_address(bigip, subnet, lb_id)
         if 'route_domain_id' not in network:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
@@ -53,7 +53,7 @@ class BigipSnatManager(object):
         return ''
 
     def _get_snat_traffic_group(self, tenant_id):
-        # Get the snat name based on HA type """
+        # Get the snat name based on HA type
         if self.driver.conf.f5_ha_type == 'standalone':
             return 'traffic-group-local-only'
         elif self.driver.conf.f5_ha_type == 'pair':
@@ -67,7 +67,7 @@ class BigipSnatManager(object):
 
     def get_snat_addrs(self, subnetinfo, tenant_id, snat_count, lb_id,
                        provider_name):
-        # Get the ip addresses for snat """
+        # Get the ip addresses for snat
         if self.driver.conf.unlegacy_setting_placeholder:
             LOG.debug('setting vnic_type to normal instead of baremetal')
             vnic_type = "normal"
@@ -224,7 +224,7 @@ class BigipSnatManager(object):
                                         provider_name)
 
     def _remove_assured_tenant_snat_subnet(self, bigip, tenant_id, subnet):
-        # Remove ref for the subnet for this tenant"""
+        # Remove ref for the subnet for this tenant
         if tenant_id in bigip.assured_tenant_snat_subnets:
             tenant_snat_subnets = \
                 bigip.assured_tenant_snat_subnets[tenant_id]
@@ -245,7 +245,7 @@ class BigipSnatManager(object):
                 'bigip.assured_tenant_snat_subnets' % tenant_id)
 
     def _delete_bigip_snats(self, bigip, subnetinfo, tenant_id, provider_name):
-        # Assure snats deleted in standalone mode """
+        # Assure snats deleted in standalone mode
         subnet = subnetinfo['subnet']
         network = subnetinfo['network']
         if self.l2_service.is_common_network(network):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/sync_data.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/sync_data.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python
+
+# Copyright (c) 2014-2018, F5 Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import signal
+import subprocess
+
+
+def sync_data():
+
+    """The usage of sync_data command.
+
+    this command use admin user to get all services to sync,
+    this command cannot sync the L2 resources without route
+    domain on bigip devices.
+
+    be caution of this command, when route domain is missing.
+    """
+
+    cmd = ['pgrep', '-f', 'f5-oslbaasv2-ag']
+    child_process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    resp = child_process.communicate()[0].split()
+
+    for pid in resp:
+        os.kill(int(pid), signal.SIGUSR2)
+        print("Sync data from neutron for f5-oslbaasv2-agent (PID): %s." % pid)
+
+
+if __name__ == "__main__":
+    sync_data()

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tenants.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tenants.py
@@ -60,6 +60,7 @@ class BigipTenantManager(object):
         # create tenant folder
         folder_name = self.service_adapter.get_folder_name(tenant_id)
         LOG.debug("Creating tenant folder %s" % folder_name)
+
         for bigip in self.driver.get_config_bigips():
             if not self.system_helper.folder_exists(bigip, folder_name):
                 folder = self.service_adapter.get_folder(service)
@@ -75,6 +76,8 @@ class BigipTenantManager(object):
                         "Folder creation error for tenant %s" %
                         (tenant_id))
 
+        # pzhang we can sync route domain from one to the other
+        # pzhang but we can not create next route domain when sync data
         if self.conf.use_namespaces and sync \
                 and not self.conf.f5_global_routed_mode:
             # pzhang sync all route domain on an active bigip to all
@@ -120,11 +123,13 @@ class BigipTenantManager(object):
 
             else:
                 LOG.warning(
-                    "Not found any route domain ids \
-                    of partitiion %s in L2 mode",
+                    "Not found any route domain ids"
+                    "of partitiion %s in L2 mode",
                     folder_name
                 )
 
+        # pzhang we can sync route domain from one to the other
+        # pzhang but we can not create next route domain when sync data
         # create tenant route domain
         if self.conf.use_namespaces and not sync:
             bigips = self.driver.get_all_bigips()


### PR DESCRIPTION
    This feature has some limitations:

    1. If only vips are missing, the sync_data.py command will recover them.

    2. when vlan or selfip are missing, if we want to recover them,
       the associated vips need to be deleted.

    3. the route domain can not be missing, or it will cause route domain
       creation problem.

    4. This requires more test in case of affections of 2.0 agent, since
       some caches are deleted in some commonly used function in 2.0 agent.