### PR TITLE
Fix rds cache polluted problem

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager_lite.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager_lite.py
@@ -986,6 +986,9 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                             "by exception: %s, delete loadbalancer in Neutron",
                             id, ex.response.content)
                 provision_status = constants_v2.F5_ACTIVE
+        except f5_ex.ProjectIDException as ex:
+            LOG.debug("Delete loadbalancer with ProjectIDException")
+            provision_status = constants_v2.F5_ACTIVE
         except Exception as ex:
             LOG.error("Fail to delete loadbalancer %s "
                       "Exception: %s", id, ex.message)
@@ -1308,6 +1311,9 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                 LOG.debug("Finish to delete multiple members")
             else:
                 LOG.debug("Finish to delete member %s", id)
+        except f5_ex.ProjectIDException as ex:
+            LOG.debug("Delete Member with ProjectIDException")
+            provision_status = constants_v2.F5_ACTIVE
         except Exception as ex:
             if multiple:
                 LOG.error("Fail to delete multiple members "

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/exceptions.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/exceptions.py
@@ -536,3 +536,7 @@ class F5InvalidConfigurationOption(F5AgentException):
     message = translators.primary(
         "An invalid value was provided for %(opt_name)s: "
         "%(opt_value)s.")
+
+
+class ProjectIDException(F5AgentException):
+    pass

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/resource_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/resource_manager.py
@@ -224,6 +224,8 @@ class LoadBalancerManager(ResourceManager):
             self.driver.network_builder.update_bigip_l2(service)
 
     def _pre_create(self, service):
+
+        self._check_nonshared_network(service)
         loadbalancer = service["loadbalancer"]
         # allow address pair
         if self.driver.l3_binding:
@@ -238,6 +240,24 @@ class LoadBalancerManager(ResourceManager):
         if not self.driver.conf.f5_global_routed_mode:
             self.driver.network_builder.prep_service_networking(
                 service, traffic_group)
+
+    def _check_nonshared_network(self, service):
+        loadbalancer = service["loadbalancer"]
+        tenant_id = loadbalancer['tenant_id']
+
+        lb_net_id = loadbalancer['network_id']
+        network = self.driver.service_adapter.get_network_from_service(
+            service, lb_net_id)
+
+        if not self.driver.network_builder.l2_service.is_common_network(
+                network):
+            net_project_id = network["project_id"]
+            if tenant_id != net_project_id:
+                raise f5_ex.ProjectIDException(
+                    "The tenant project id is %s. "
+                    "The nonshared netwok/subnet project id is %s. "
+                    "They are not belong to the same tenant." %
+                    (tenant_id, net_project_id))
 
     @serialized('LoadBalancerManager.update')
     @log_helpers.log_method_call
@@ -256,6 +276,7 @@ class LoadBalancerManager(ResourceManager):
         # assign neutron network object in service
         # with route domain first
         # self.driver.network_builder is None in global routed mode
+        self._check_nonshared_network(service)
         if self.driver.network_builder:
             self.driver.network_builder._annotate_service_route_domains(
                 service)
@@ -1030,6 +1051,9 @@ class MemberManager(ResourceManager):
     @serialized('MemberManager.create')
     @log_helpers.log_method_call
     def create(self, resource, service, **kwargs):
+
+        self._check_nonshared_network(service)
+
         create_in_bulk = False
         if 'multiple' in service:
             create_in_bulk = service.get('multiple')
@@ -1126,9 +1150,32 @@ class MemberManager(ResourceManager):
             self._pool_mgr._update(bigip, pool_payload, None, None, service)
         LOG.debug("Finish to create %s %s", self._resource, resource['id'])
 
+    def _check_nonshared_network(self, service):
+        loadbalancer = service["loadbalancer"]
+        tenant_id = loadbalancer["tenant_id"]
+
+        members = service["members"]
+        for meb in members:
+            meb_net_id = meb["network_id"]
+            network = self.driver.service_adapter.get_network_from_service(
+                service, meb_net_id)
+
+            if not self.driver.network_builder.l2_service.is_common_network(
+                    network):
+                net_project_id = network["project_id"]
+                if tenant_id != net_project_id:
+                    raise f5_ex.ProjectIDException(
+                        "The tenant project id is %s. "
+                        "The nonshared netwok/subnet project id of "
+                        "member %s is %s. "
+                        "They are not belong to the same tenant." %
+                        (tenant_id, meb, net_project_id))
+
     @serialized('MemberManager.delete')
     @log_helpers.log_method_call
     def delete(self, resource, service, **kwargs):
+
+        self._check_nonshared_network(service)
 
         self.driver.annotate_service_members(service)
         if not service.get(self._key):

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_network_service.py
@@ -353,48 +353,58 @@ class TestNetworkServiceBuilder(object):
         # valid name
         net_short_name = network_service.get_neutron_net_short_name(network)
         assert net_short_name == 'vlan-608'
+        tenant_id = '57e89acdfb6e40a2bc7f6185645dbbdd'
 
         # invalid network type
         with pytest.raises(f5_ex.InvalidNetworkType) as excinfo:
             network['provider:network_type'] = ''
-            network_service.get_route_domain_from_cache(network)
+            network_service.get_route_domain_from_cache(tenant_id, network)
             assert 'provider:network_type' in str(excinfo.value)
 
         # invalid segmentation ID
         with pytest.raises(f5_ex.InvalidNetworkType) as excinfo:
             network['provider:network_type'] = 'vlan'
             network['provider:segmentation_id'] = ''
-            network_service.get_route_domain_from_cache(network)
+            network_service.get_route_domain_from_cache(tenant_id, network)
             assert 'provider:network_type - vlan' in str(excinfo.value)
 
     def test_get_route_domain_from_cache(self, network_service, network):
         # valid cache entries
-        rd = network_service.get_route_domain_from_cache(network)
+
+        tenant_id = "f2a944c28b5d43ad808cc28ba1f03cce"
+        rd = network_service.get_route_domain_from_cache(tenant_id,
+                                                         network)
         assert rd == 2
 
         network['provider:segmentation_id'] = 604
-        rd = network_service.get_route_domain_from_cache(network)
+        tenant_id = "cf705431f2a944c28ba1f03cce26d5f6"
+        rd = network_service.get_route_domain_from_cache(tenant_id,
+                                                         network)
         assert rd == 1
 
         # vlan not in cache
         with pytest.raises(f5_ex.RouteDomainCacheMiss) as excinfo:
             network['provider:segmentation_id'] = 600
-            network_service.get_route_domain_from_cache(network)
+            network_service.get_route_domain_from_cache(tenant_id,
+                                                        network)
         assert 'vlan-600' in str(excinfo.value)
 
         # empty cache
         with pytest.raises(f5_ex.RouteDomainCacheMiss) as excinfo:
+            tenant_id = "f2a944c28b5d43ad808cc28ba1f03cce"
             network['provider:segmentation_id'] = 606
             network['provider:network_type'] = 'vlan'
             network_service.rds_cache = {}
-            network_service.get_route_domain_from_cache(network)
+            network_service.get_route_domain_from_cache(tenant_id,
+                                                        network)
         assert 'vlan-606' in str(excinfo.value)
 
         # invalid network data
         with pytest.raises(f5_ex.InvalidNetworkType):
             network['provider:segmentation_id'] = 604
             network['provider:network_type'] = ''
-            network_service.get_route_domain_from_cache(network)
+            network_service.get_route_domain_from_cache(tenant_id,
+                                                        network)
 
     def test_assign_route_domain(self, network_service, network, subnet):
         """Test assign_route_domain()


### PR DESCRIPTION
This patch will only allow users to use their own nonshared
network, otherwise it will raise ProjectIDException and nothing
is created on bigip.
