### PR TITLE
Fix rds cache polluted problem

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager_lite.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager_lite.py
@@ -38,6 +38,8 @@ from f5_openstack_agent.lbaasv2.drivers.bigip import constants_v2
 from f5_openstack_agent.lbaasv2.drivers.bigip import exceptions as f5_ex
 from f5_openstack_agent.lbaasv2.drivers.bigip import plugin_rpc
 from f5_openstack_agent.lbaasv2.drivers.bigip import resource_manager
+from icontrol.exceptions import iControlUnexpectedHTTPError
+import re
 
 LOG = logging.getLogger(__name__)
 
@@ -1007,6 +1009,29 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
             mgr.delete(loadbalancer, service)
             provision_status = constants_v2.F5_ACTIVE
             LOG.debug("Finish to delete loadbalancer %s", id)
+        except iControlUnexpectedHTTPError as ex:
+            fd_matched = re.search(
+                "The requested folder (.*) was not found.",
+                ex.response.content
+            )
+            rd_matched = re.search(
+                "The requested route domain (.*) was not found.",
+                ex.response.content
+            )
+            provision_status = constants_v2.F5_ERROR
+            if ex.response.status_code == 400 and fd_matched:
+                LOG.warning("Not Found Exception to delete loadbalancer %s "
+                            "by exception: %s, delete loadbalancer in Neutron",
+                            id, ex.response.content)
+                provision_status = constants_v2.F5_ACTIVE
+            if ex.response.status_code == 404 and rd_matched:
+                LOG.warning("Not Found Exception to delete loadbalancer %s "
+                            "by exception: %s, delete loadbalancer in Neutron",
+                            id, ex.response.content)
+                provision_status = constants_v2.F5_ACTIVE
+        except f5_ex.ProjectIDException as ex:
+            LOG.debug("Delete loadbalancer with ProjectIDException")
+            provision_status = constants_v2.F5_ACTIVE
         except Exception as ex:
             LOG.error("Fail to delete loadbalancer %s "
                       "Exception: %s", id, ex.message)
@@ -1329,6 +1354,9 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                 LOG.debug("Finish to delete multiple members")
             else:
                 LOG.debug("Finish to delete member %s", id)
+        except f5_ex.ProjectIDException as ex:
+            LOG.debug("Delete Member with ProjectIDException")
+            provision_status = constants_v2.F5_ACTIVE
         except Exception as ex:
             if multiple:
                 LOG.error("Fail to delete multiple members "

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/exceptions.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/exceptions.py
@@ -536,3 +536,7 @@ class F5InvalidConfigurationOption(F5AgentException):
     message = translators.primary(
         "An invalid value was provided for %(opt_name)s: "
         "%(opt_value)s.")
+
+
+class ProjectIDException(F5AgentException):
+    pass

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/test/test_network_service.py
@@ -353,48 +353,58 @@ class TestNetworkServiceBuilder(object):
         # valid name
         net_short_name = network_service.get_neutron_net_short_name(network)
         assert net_short_name == 'vlan-608'
+        tenant_id = '57e89acdfb6e40a2bc7f6185645dbbdd'
 
         # invalid network type
         with pytest.raises(f5_ex.InvalidNetworkType) as excinfo:
             network['provider:network_type'] = ''
-            network_service.get_route_domain_from_cache(network)
+            network_service.get_route_domain_from_cache(tenant_id, network)
             assert 'provider:network_type' in str(excinfo.value)
 
         # invalid segmentation ID
         with pytest.raises(f5_ex.InvalidNetworkType) as excinfo:
             network['provider:network_type'] = 'vlan'
             network['provider:segmentation_id'] = ''
-            network_service.get_route_domain_from_cache(network)
+            network_service.get_route_domain_from_cache(tenant_id, network)
             assert 'provider:network_type - vlan' in str(excinfo.value)
 
     def test_get_route_domain_from_cache(self, network_service, network):
         # valid cache entries
-        rd = network_service.get_route_domain_from_cache(network)
+
+        tenant_id = "f2a944c28b5d43ad808cc28ba1f03cce"
+        rd = network_service.get_route_domain_from_cache(tenant_id,
+                                                         network)
         assert rd == 2
 
         network['provider:segmentation_id'] = 604
-        rd = network_service.get_route_domain_from_cache(network)
+        tenant_id = "cf705431f2a944c28ba1f03cce26d5f6"
+        rd = network_service.get_route_domain_from_cache(tenant_id,
+                                                         network)
         assert rd == 1
 
         # vlan not in cache
         with pytest.raises(f5_ex.RouteDomainCacheMiss) as excinfo:
             network['provider:segmentation_id'] = 600
-            network_service.get_route_domain_from_cache(network)
+            network_service.get_route_domain_from_cache(tenant_id,
+                                                        network)
         assert 'vlan-600' in str(excinfo.value)
 
         # empty cache
         with pytest.raises(f5_ex.RouteDomainCacheMiss) as excinfo:
+            tenant_id = "f2a944c28b5d43ad808cc28ba1f03cce"
             network['provider:segmentation_id'] = 606
             network['provider:network_type'] = 'vlan'
             network_service.rds_cache = {}
-            network_service.get_route_domain_from_cache(network)
+            network_service.get_route_domain_from_cache(tenant_id,
+                                                        network)
         assert 'vlan-606' in str(excinfo.value)
 
         # invalid network data
         with pytest.raises(f5_ex.InvalidNetworkType):
             network['provider:segmentation_id'] = 604
             network['provider:network_type'] = ''
-            network_service.get_route_domain_from_cache(network)
+            network_service.get_route_domain_from_cache(tenant_id,
+                                                        network)
 
     def test_assign_route_domain(self, network_service, network, subnet):
         """Test assign_route_domain()


### PR DESCRIPTION
This patch will only allow users to use their own nonshared
network, otherwise it will raise ProjectIDException and nothing
is created on bigip.

(cherry picked from commit 3cd24b627aeaf4b96ae14bbfbc52cfe50378e81e)

Conflicts:
	f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager_lite.py
	f5_openstack_agent/lbaasv2/drivers/bigip/resource_manager.py
