### PR TITLE
[OPENSTACK-2282]Fix resources creation conflict issue.

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/l2_service.py
@@ -15,6 +15,7 @@
 #
 
 import random
+from requests import HTTPError
 from time import time
 
 from oslo_log import log as logging
@@ -319,6 +320,12 @@ class L2ServiceBuilder(object):
                      'description': network['id'],
                      'route_domain_id': network['route_domain_id']}
             self.network_helper.create_vlan(bigip, model)
+        except HTTPError as err:
+            if err.response.status_code == 409:
+                LOG.info("vlan %s already exists: %s, ignored.." % (
+                        vlan_name, err.message))
+            else:
+                raise
         except Exception as err:
             LOG.exception("%s", err.message)
             raise f5_ex.VLANCreationException(

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
@@ -70,8 +70,11 @@ class BigipSelfIpManager(object):
                                           err.response.status_code,
                                           err.message))
                         raise f5_ex.SelfIPCreationException("selfip")
+                elif err.response.status_code == 409:
+                    created = True
+                    LOG.info("selfip %s already exists: %s, ignored.." % (
+                        model['name'], err.message))
                 else:
-                    # here may post 400
                     LOG.error("selfip creation error message: %s" %
                               err.message)
                     LOG.error("selfip creation error status: %s" %


### PR DESCRIPTION
This issue happens in multiple agents environment.
When there are 2 or more loadbalancers are created at the same time,
the 2 loadbalancer creation logic from different agents may run into
the situation that both of them want to create the resources(of the same name).

This issue is similiar with route domain creation conflict described in PR 1654.
But the solution is different.
