### PR TITLE
[OPENSTACK-2282] Cleanup redundant neutron port of self ip and snat ip (9.8.47)

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/selfips.py
@@ -180,6 +180,16 @@ class BigipSelfIpManager(object):
                 host_passed=host_passed
             )
 
+            if port:
+                ports = self.driver.plugin_rpc.get_port_by_name(
+                    port_name=selfip_name)
+                # If the port created by me is not the first, that means
+                # another agent process creates a new port before me.
+                # Delete my port and use the first one.
+                if len(ports) > 0 and ports[0]['id'] != port['id']:
+                    self.driver.plugin_rpc.delete_port(port_id=port['id'])
+                    port = ports[0]
+
         if port and 'fixed_ips' in port:
             fixed_ip = port['fixed_ips'][0]
             selfip_address = fixed_ip['ip_address']

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/snats.py
@@ -105,7 +105,17 @@ class BigipSnatManager(object):
                     vnic_type=vnic_type
                 )
                 if new_port is not None:
-                    ip_address = new_port['fixed_ips'][0]['ip_address']
+                    ports = self.driver.plugin_rpc.get_port_by_name(
+                        port_name=index_snat_name)
+                    # If the port created by me is not the first, that means
+                    # another agent process creates a new port before me.
+                    # Delete my port and use the first one.
+                    if len(ports) > 0 and ports[0]['id'] != new_port['id']:
+                        self.driver.plugin_rpc.delete_port(
+                            port_id=new_port['id'])
+                        ip_address = ports[0]['fixed_ips'][0]['ip_address']
+                    else:
+                        ip_address = new_port['fixed_ips'][0]['ip_address']
 
             # Push the IP address on the list if the port was acquired.
             if len(ip_address) > 0:


### PR DESCRIPTION
(cherry picked from commit 13ec6e5e44c07b6b8949d8acf0fb94f129df228a)

@<reviewer_id>
#### What issues does this address?
Fixes #<issueid>
WIP #<issueid>
...

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?
