### PR TITLE
project_id was not there， only tenant_id

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/resource_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/resource_manager.py
@@ -249,7 +249,9 @@ class LoadBalancerManager(ResourceManager):
         lb_net_id = loadbalancer['network_id']
         network = self.driver.service_adapter.get_network_from_service(
             service, lb_net_id)
-        net_project_id = network["project_id"]
+        net_project_id = network.get('project_id', None) or \
+            network.get('tenant_id')
+        LOG.debug(net_project_id)
 
         if self.driver.conf.f5_global_routed_mode:
             shared = network["shared"]
@@ -1199,7 +1201,9 @@ class MemberManager(ResourceManager):
             meb_net_id = meb["network_id"]
             network = self.driver.service_adapter.get_network_from_service(
                 service, meb_net_id)
-            net_project_id = network["project_id"]
+            net_project_id = network.get('project_id', None) or \
+                network.get('tenant_id')
+            LOG.debug(net_project_id)
 
             if self.driver.conf.f5_global_routed_mode:
                 shared = network["shared"]


### PR DESCRIPTION
tenant_id only.
we might avoid pushing into 9.8 for now
if we do not want to regress around here.
Although for compatibility issues, we could.