### PR TITLE
[OPENSTACK-2341] fix: get all nodes in a partition

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_helper.py
@@ -727,7 +727,15 @@ class NetworkHelper(object):
 
         node_addrs = []
         for node in nodes:
-            node_addrs.append(node.address)
+            # If the node resides in the Common partition,
+            # all users can access it.
+            # any6 may not belong to any neutron subnet
+            # but we still need to translate
+            if node.partition == partition:
+                if node.address == 'any6':
+                    node_addrs.append("::")
+                else:
+                    node_addrs.append(node.address)
 
         return node_addrs
 


### PR DESCRIPTION
1. If the node resides in the Common partition,
all users can access it.

2. Bigip 'Any6' can be translate to '::',
although '::' may not belong to any neturon subnet

(cherry picked from commit 713d3e7154aeab048a75121c9b868c9fd274d358)

