### PR TITLE
[OPENSTACK-2344 ] feat: use '--transparent' to enable/disable xff of …

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tcp_profile.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tcp_profile.py
@@ -44,8 +44,7 @@ class TCPProfileHelper(object):
         if listener.get('transparent'):
             protocol = listener.get('protocol')
             if protocol not in self.allowed_protocols:
-                raise Exception("%s listener is not allowed TOA" %
-                                protocol)
+                return False
             return True
         else:
             return False
@@ -67,8 +66,7 @@ class TCPProfileHelper(object):
         if old_listener['transparent'] != listener['transparent']:
             protocol = listener.get('protocol')
             if protocol not in self.allowed_protocols:
-                raise Exception("%s listener is not allowed TOA" %
-                                protocol)
+                return False
             return True
         else:
             return False


### PR DESCRIPTION
…listener

Public cloud only allow to use '--transparent' to enable and
disable x-forward-for for HTTP and HTTPS listener.

'--transparent' is used to enable TOA of TCP and DUP listeners.