### PR TITLE
[OPENSTACK-2350] feat: disable --customized to update xff

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/resource_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/resource_manager.py
@@ -432,8 +432,7 @@ class ListenerManager(ResourceManager):
                 new_customized)
 
     def _filter_depercated(self, customized):
-        # depercated = {"http_profile": ["insertXforwardedFor"]}
-        depercated = {}
+        depercated = {"http_profile": ["insertXforwardedFor"]}
 
         cust = json.loads(customized)
         for profile, depercated_vals in depercated.items():


### PR DESCRIPTION
this change will disable --customized to update xff,
it will disable xff function of the old listener,
if the listener is updated without '--transparent True' explicitly


