### PR TITLE
[OPENSTACK-2344 ] feat: use '--transparent' to enable/disable xff

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/http_profile.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/http_profile.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+
+class HTTPProfileHelper(object):
+
+    def __init__(self):
+        self.insertXforwardedFor = ""
+
+    def set_xff(self, listener):
+        xff_enable = self.http_xff_enable(listener)
+        if xff_enable:
+            self.insertXforwardedFor = "enabled"
+        else:
+            self.insertXforwardedFor = "disabled"
+
+        return {
+            "insertXforwardedFor": self.insertXforwardedFor
+        }
+
+    def http_xff_enable(self, listener):
+        if listener['protocol'] in ['HTTP', 'TERMINATED_HTTPS']:
+            return listener.get('transparent', False)
+        return False
+
+    def need_update_xff(self, old_listener, listener):
+        if listener['protocol'] in ['HTTP', 'TERMINATED_HTTPS']:
+            new_transparent = listener['transparent']
+            old_transparent = old_listener['transparent']
+            if new_transparent != old_transparent:
+                return True
+        return False

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/tcp_profile.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/tcp_profile.py
@@ -44,8 +44,7 @@ class TCPProfileHelper(object):
         if listener.get('transparent'):
             protocol = listener.get('protocol')
             if protocol not in self.allowed_protocols:
-                raise Exception("%s listener is not allowed TOA" %
-                                protocol)
+                return False
             return True
         else:
             return False
@@ -67,8 +66,7 @@ class TCPProfileHelper(object):
         if old_listener['transparent'] != listener['transparent']:
             protocol = listener.get('protocol')
             if protocol not in self.allowed_protocols:
-                raise Exception("%s listener is not allowed TOA" %
-                                protocol)
+                return False
             return True
         else:
             return False

--- a/requirements.style.txt
+++ b/requirements.style.txt
@@ -1,3 +1,4 @@
+lazy-object-proxy==1.6.0
 flake8
 hacking
 pep257


### PR DESCRIPTION
Public cloud only allow to use '--transparent' to enable and
disable x-forward-for for HTTP and HTTPS listener.
