### PR TITLE
[OPENSTACK-2807] fix: snatpool partition was wrong

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
@@ -851,9 +851,16 @@ class SNATHelper(object):
             self.driver.service_adapter.get_folder_name(
                 self.service['loadbalancer'].get('id')
             )
-        partition = self.driver.service_adapter.get_folder_name(
-            self.service['loadbalancer'].get('tenant_id')
-        )
+
+        if self.l2_service.is_common_network(
+            self.snat_net['network']
+        ):
+            partition = 'Common'
+        else:
+            partition = self.driver.service_adapter.get_folder_name(
+                self.service['loadbalancer'].get('tenant_id')
+            )
+
         bigips = self.service['bigips']
 
         result = False
@@ -943,13 +950,14 @@ class SNATHelper(object):
         snat_info[
             'pool_name'
         ] = self.driver.service_adapter.get_folder_name(lb_id)
-        snat_info['pool_folder'] = self.partition
         snat_info['addrs'] = snat_addrs
 
         if self.l2_service.is_common_network(self.snat_net['network']):
             snat_info['network_folder'] = 'Common'
+            snat_info['pool_folder'] = 'Common'
         else:
             snat_info['network_folder'] = self.partition
+            snat_info['pool_folder'] = self.partition
 
         for bigip in bigips:
             self.snat_manager.assure_bigip_snats(


### PR DESCRIPTION
for shared net.
shared net: snatpool in Common partition,
unshared net: snatpool in LB tenant partition.

(cherry picked from commit 71553fbab7cb18a45f030abf47b8ae6f41007cc3)
 
