### PR TITLE
OPENSTACK-2840:  rebuild lb tree

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager_lite.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager_lite.py
@@ -1372,6 +1372,7 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
         """Handle RPC cast from plugin to create_loadbalancer."""
         lb_id = loadbalancer['id']
         listeners = service.get("listeners", [])
+        members = service.get("members", [])
 
         try:
             bigip_device.set_bigips(service, self.conf)
@@ -1387,6 +1388,14 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                 mgr = resource_manager.ListenerManager(self.lbdriver)
                 mgr.create(lstn, service)
                 LOG.debug("Finish to create listener %s", ls_id)
+
+            for mb in members:
+                mb_id = mb['id']
+                service['member'] = mb
+
+                mgr = resource_manager.MemberManager(self.lbdriver)
+                mgr.create(mb, service)
+                LOG.debug("Finish to create member %s", mb_id)
 
             provision_status = constants_v2.F5_ACTIVE
             operating_status = constants_v2.F5_ONLINE

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager_lite.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager_lite.py
@@ -1375,6 +1375,7 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
         pools = service.get('pools', [])
         members = service.get("members", [])
         monitors = service.get("healthmonitors", [])
+        l7policies = service.get("l7policies", [])
 
         # For 'reuse the create code', the order of rebuild is important
         # pool is needs by all resource when rebuild.
@@ -1432,7 +1433,16 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                 mgr = resource_manager.MonitorManager(
                     self.lbdriver, type=mn['type'])
                 mgr.create(mn, service)
-                LOG.debug("Finish to create member %s", mn_id)
+                LOG.debug("Finish to create monitor %s", mn_id)
+
+            # a l7policy contains l7rules, no need to rebuild l7rule.
+            for plc in l7policies:
+                plc_id = plc['id']
+                service["l7policy"] = plc
+
+                mgr = resource_manager.L7PolicyManager(self.lbdriver)
+                mgr.create(plc, service)
+                LOG.debug("Finish to create l7policy %s", plc_id)
 
             provision_status = constants_v2.F5_ACTIVE
             operating_status = constants_v2.F5_ONLINE

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager_lite.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/agent_manager_lite.py
@@ -1374,6 +1374,7 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
         listeners = service.get("listeners", [])
         pools = service.get('pools', [])
         members = service.get("members", [])
+        monitors = service.get("healthmonitors", [])
 
         # For 'reuse the create code', the order of rebuild is important
         # pool is needs by all resource when rebuild.
@@ -1423,6 +1424,15 @@ class LbaasAgentManager(periodic_task.PeriodicTasks):  # b --> B
                 mgr = resource_manager.MemberManager(self.lbdriver)
                 mgr.create(mb, service)
                 LOG.debug("Finish to create member %s", mb_id)
+
+            for mn in monitors:
+                mn_id = mn['id']
+                service["healthmonitor"] = mn
+
+                mgr = resource_manager.MonitorManager(
+                    self.lbdriver, type=mn['type'])
+                mgr.create(mn, service)
+                LOG.debug("Finish to create member %s", mn_id)
 
             provision_status = constants_v2.F5_ACTIVE
             operating_status = constants_v2.F5_ONLINE

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
@@ -350,10 +350,10 @@ class NetworkServiceBuilder(object):
 
         if 'members' in service:
             for member in service['members']:
-                if 'address' in member:
-                    if rd_id and not self._rd_exist(
-                        member['address']
-                    ):
+                if 'address' in member and not self._rd_exist(
+                    member['address']
+                ):
+                    if rd_id:
                         member['address'] += rd_id
                     else:
                         member['address'] += '%0'

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
@@ -536,17 +536,21 @@ class NetworkServiceBuilder(object):
 
         members = service['members']
         for member in members:
-            member['network'] = service_adapter.get_network_from_service(
-                service, member['network_id'])
-            if member.get('provisioning_status', None) == \
-                    constants_v2.F5_PENDING_DELETE:
-                delete_members.append(member)
-            else:
-                update_members.append(member)
 
-        loadbalancer['network'] = service_adapter.get_network_from_service(
-            service,
-            loadbalancer['network_id']
+            mb_net = member.get('network_id')
+            if mb_net:
+                member['network'] = service_adapter.get_network_from_service(
+                    service, mb_net)
+                if member.get('provisioning_status', None) == \
+                        constants_v2.F5_PENDING_DELETE:
+                    delete_members.append(member)
+                else:
+                    update_members.append(member)
+
+        lb_net = loadbalancer.get('network_id')
+        if lb_net:
+            loadbalancer['network'] = service_adapter.get_network_from_service(
+                service, lb_net
             )
 
         if delete_loadbalancer or delete_members:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/network_service.py
@@ -326,6 +326,7 @@ class NetworkServiceBuilder(object):
         loadbalancer = service['loadbalancer']
         bigips = service['bigips']
         device = service['device']
+        rd_id = None
 
         if 'vip_address' in service['loadbalancer']:
             if 'network_id' in loadbalancer:


### PR DESCRIPTION
the 'network_id' is not in the member dictionary, when we rebuild loadbalancer.

so we need to have pre-conditions for different situations.
