### PR TITLE
[OPENSTACK-2868] add password_cipher_mode back

### DIFF
--- a/etc/neutron/services/f5/f5-openstack-agent.ini
+++ b/etc/neutron/services/f5/f5-openstack-agent.ini
@@ -459,6 +459,11 @@ f5_bigip_lbaas_device_driver = f5_openstack_agent.lbaasv2.drivers.bigip.icontrol
 #
 # icontrol_vcmp_hostname = 192.168.1.245
 #
+# When password_cipher_mode is True, the password 'os_password'
+# should be base64 encoded state. If not, they should be plain
+# text.
+password_cipher_mode = False
+#
 ###############################################################################
 # Certificate Manager
 ###############################################################################

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/icontrol_driver.py
@@ -380,6 +380,9 @@ class iControlDriver(LBaaSBaseDriver):
         self.pool_manager = resource_helper.BigIPResourceHelper(
             resource_helper.ResourceType.pool)
 
+        if self.conf.password_cipher_mode and self.conf.os_password:
+            self.conf.os_password = base64.b64decode(self.conf.os_password)
+
         try:
             # debug logging of service requests recieved by driver
             if self.conf.trace_service_requests:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/opts.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/opts.py
@@ -165,6 +165,11 @@ OPTS = [
         help=(
             'Amount of time to wait for a errored service to become active')
     ),
+    cfg.BoolOpt(
+        'password_cipher_mode',
+        default=False,
+        help='The flag indicating the password is plain text or not.'
+    ),
     cfg.StrOpt(
         'f5_extended_profile',
         default='',


### PR DESCRIPTION
PR #1945 removed password_cipher_mode, which is actually still needed for os_password.
