### PR TITLE
[OPENSTACK-2912] SIP manipulation and remove description way

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
@@ -75,6 +75,7 @@ class ResourceType(Enum):
     device = 47
     cipher_group = 48
     cipher_rule = 49
+    sip_profile = 50
 
 
 def retry_icontrol(function):
@@ -407,6 +408,8 @@ class BigIPResourceHelper(object):
                 lambda bigip: bigip.tm.sys.file.ssl_certs.ssl_cert,
             ResourceType.ftp_profile:
                 lambda bigip: bigip.tm.ltm.profile.ftps.ftp,
+            ResourceType.sip_profile:
+                lambda bigip: bigip.tm.ltm.profile.sips.sip,
             ResourceType.bwc_policy:
                 lambda bigip: bigip.tm.net.bwc.policys.policy,
             ResourceType.internal_data_group:

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/resource_helper.py
@@ -391,7 +391,7 @@ class BigIPResourceHelper(object):
             ResourceType.msrdp_persistence:
                 lambda bigip: bigip.tm.ltm.persistence.msrdp,
             ResourceType.sip_persistence:
-                lambda bigip: bigip.tm.ltm.persistence.sips,
+                lambda bigip: bigip.tm.ltm.persistence.sips.sip,
             ResourceType.source_addr_persistence:
                 lambda bigip:
                     bigip.tm.ltm.persistence.source_addrs.source_addr,

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/resource_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/resource_manager.py
@@ -661,6 +661,8 @@ class ListenerManager(ResourceManager):
             resource_helper.ResourceType.cookie_persistence)
         self.source_addr_persist_helper = resource_helper.BigIPResourceHelper(
             resource_helper.ResourceType.source_addr_persistence)
+        self.sip_persist_helper = resource_helper.BigIPResourceHelper(
+            resource_helper.ResourceType.sip_persistence)
         self.ftp_helper = FTPProfileHelper()
         self.http_helper = HTTPProfileHelper()
         self.acl_helper = ACLHelper()
@@ -876,6 +878,8 @@ class ListenerManager(ResourceManager):
             return self._create_http_cookie_persist_profile(bigip, vs, persist)
         elif persist_type == "SOURCE_IP":
             return self._create_source_addr_persist_profile(bigip, vs, persist)
+        elif persist_type == "CALL_ID":
+            return self._create_sip_persist_profile(bigip, vs, persist)
 
     def _create_app_cookie_persist_profile(self, bigip, vs, persist):
         listener_builder = self.listener_builder
@@ -886,6 +890,29 @@ class ListenerManager(ResourceManager):
         listener_builder = self.listener_builder
         listener_builder._add_source_ip_port_persist_rule(vs, persist, bigip)
         return "source_ip_port_" + vs['name']
+
+    def _create_sip_persist_profile(self, bigip, vs, persist):
+        name = "call_id_" + vs['name']
+
+        try:
+            timeout = int(persist.get("persistence_timeout") or 0)
+        except ValueError as ex:
+            LOG.warning(ex.message)
+            timeout = 0
+        if timeout <= 0:
+            timeout = self.driver.conf.persistence_timeout
+
+        payload = {
+            "name": name,
+            "partition": vs['partition'],
+            "timeout": str(timeout),
+            "mirror": "enabled",
+            "sipInfo": "Call-ID"
+        }
+        super(ListenerManager, self)._create(
+            bigip, payload, None, None,
+            helper=self.sip_persist_helper)
+        return name
 
     def _create_http_cookie_persist_profile(self, bigip, vs, persist):
         name = "http_cookie_" + vs['name']
@@ -974,11 +1001,21 @@ class ListenerManager(ResourceManager):
             bigip, payload, None, None,
             helper=self.source_addr_persist_helper)
 
+    def _delete_sip_persist_profile(self, bigip, vs):
+        payload = {
+            "name": "call_id_" + vs['name'],
+            "partition": vs['partition'],
+        }
+        super(ListenerManager, self)._delete(
+            bigip, payload, None, None,
+            helper=self.sip_persist_helper)
+
     def _delete_persist_profile(self, bigip, vs):
         self._delete_app_cookie_persist_profile(bigip, vs)
         self._delete_source_ip_port_persist_profile(bigip, vs)
         self._delete_http_cookie_persist_profile(bigip, vs)
         self._delete_source_addr_persist_profile(bigip, vs)
+        self._delete_sip_persist_profile(bigip, vs)
 
     def _delete_ssl_profiles(self, bigip, vs, service):
         listener_builder = self.listener_builder

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/resource_manager.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/resource_manager.py
@@ -41,6 +41,8 @@ from f5_openstack_agent.lbaasv2.drivers.bigip.resource \
 from f5_openstack_agent.lbaasv2.drivers.bigip.resource \
     import CipherRule
 from f5_openstack_agent.lbaasv2.drivers.bigip import resource_helper
+from f5_openstack_agent.lbaasv2.drivers.bigip.sip_profile \
+    import SIPProfileHelper
 from f5_openstack_agent.lbaasv2.drivers.bigip.tcp_profile \
     import TCPProfileHelper
 from f5_openstack_agent.lbaasv2.drivers.bigip import tenants
@@ -670,6 +672,7 @@ class ListenerManager(ResourceManager):
             resource_helper.ResourceType.rule)
         self.tcp_helper = TCPProfileHelper()
         self.tcp_irule_helper = iRuleHelper()
+        self.sip_helper = SIPProfileHelper()
 
         self.listener_builder = ListenerServiceBuilder(
             self.driver.conf,
@@ -1371,6 +1374,10 @@ class ListenerManager(ResourceManager):
         if ftp_enable:
             self.ftp_helper.add_profile(service, vs, bigip)
 
+        is_sip = self.sip_helper.enable_sip(service)
+        if is_sip:
+            self.sip_helper.add_profile(vs, bigip)
+
         loadbalancer = service.get('loadbalancer', dict())
         network_id = loadbalancer.get('network_id', "")
         self.driver.service_adapter.get_vlan(vs, bigip, network_id)
@@ -1562,6 +1569,11 @@ class ListenerManager(ResourceManager):
         ftp_enable = self.ftp_helper.enable_ftp(service)
         if ftp_enable:
             self.ftp_helper.remove_profile(service, vs, bigip)
+
+        is_sip = self.sip_helper.enable_sip(service)
+        if is_sip:
+            self.sip_helper.remove_profile(vs, bigip)
+
         tcp_ip_enable = self.tcp_helper.need_delete_tcp(service)
         if tcp_ip_enable:
             self.tcp_helper.remove_profile(

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -123,6 +123,7 @@ class ServiceModelAdapter(object):
 
         pool = self.get_vip_default_pool(service)
 
+        # here it replaced the sp with pool's sp.
         if pool and "session_persistence" in pool:
             listener["session_persistence"] = pool["session_persistence"]
 
@@ -381,7 +382,11 @@ class ServiceModelAdapter(object):
             # source IP loadbalancing. See issue #344 for details.
             if lbaas_pool['lb_algorithm'].upper() == 'SOURCE_IP':
                 # SOURCE_IP lb algorithm use source-ip persist profile
-                lbaas_pool['session_persistence'] = {'type': 'SOURCE_IP'}
+                # not replace this for CALL_ID
+                if lbaas_pool.get('session_persistence', None) and lbaas_pool['session_persistence'].get('type') == 'CALL_ID': # noqa
+                    LOG.debug('not replace for call_id')
+                else:
+                    lbaas_pool['session_persistence'] = {'type': 'SOURCE_IP'}
 
         if lbaas_hm:
             hm = self.init_monitor_name(loadbalancer, lbaas_hm)
@@ -553,7 +558,7 @@ class ServiceModelAdapter(object):
 
         protocol = listener.get('protocol', "")
         if protocol not in ["HTTP", "HTTPS", "TCP", 'FTP',
-                            "TERMINATED_HTTPS", "UDP"]:
+                            "TERMINATED_HTTPS", "UDP", "SIP"]:
             LOG.warning("Listener protocol unrecognized: %s",
                         listener["protocol"])
 
@@ -589,7 +594,7 @@ class ServiceModelAdapter(object):
                 virtual_type = "mr"
                 add_diameter = True
 
-        if protocol == "UDP":
+        if protocol == "UDP" or protocol == "SIP":
             vip["ipProtocol"] = "udp"
         else:
             vip["ipProtocol"] = "tcp"
@@ -598,7 +603,7 @@ class ServiceModelAdapter(object):
             vip['profiles'] = ['/Common/fastL4']
         elif virtual_type == 'standard' and protocol == 'TCP':
             vip['profiles'] = ['/Common/tcp']
-        elif virtual_type == 'standard' and protocol == 'UDP':
+        elif virtual_type == 'standard' and protocol in ('UDP', 'SIP'):
             vip['profiles'] = ['/Common/udp']
         elif virtual_type == 'mr' and protocol == 'TCP':
             vip['profiles'] = ['/Common/tcp']
@@ -614,9 +619,7 @@ class ServiceModelAdapter(object):
             persistence = pool.get('session_persistence', None)
             lb_algorithm = pool.get('lb_algorithm', 'ROUND_ROBIN')
 
-        valid_persist_types = [
-            'SOURCE_IP', 'APP_COOKIE', 'HTTP_COOKIE', 'SOURCE_IP_PORT'
-        ]
+        valid_persist_types = ['SOURCE_IP', 'APP_COOKIE', 'HTTP_COOKIE', 'SOURCE_IP_PORT', 'CALL_ID'] # noqa
         if persistence:
             persistence_type = persistence.get('type', "")
             if persistence_type not in valid_persist_types:
@@ -633,6 +636,10 @@ class ServiceModelAdapter(object):
             elif persistence_type == 'SOURCE_IP':
                 vip['persist'] = [{'name': '/Common/source_addr'}]
 
+            elif persistence_type == 'CALL_ID':
+                LOG.debug('CALL_ID here')
+                vip['persist'] = [{'name': 'call_id_' + vip['name']}]
+
             elif persistence_type == 'HTTP_COOKIE':
                 vip['persist'] = [{'name': '/Common/cookie'}]
 
@@ -643,7 +650,8 @@ class ServiceModelAdapter(object):
             if persistence_type in ['HTTP_COOKIE', 'APP_COOKIE']:
                 vip['profiles'] = ['/Common/http', '/Common/oneconnect']
 
-        if add_sip:
+        if add_sip or protocol == 'SIP':
+            LOG.debug('adding sip profile')
             if '/Common/sip' not in vip['profiles']:
                 vip['profiles'].append('/Common/sip')
 

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/service_adapter.py
@@ -602,11 +602,6 @@ class ServiceModelAdapter(object):
             if persistence_type in ['HTTP_COOKIE', 'APP_COOKIE']:
                 vip['profiles'] = ['/Common/http', '/Common/oneconnect']
 
-        if protocol == 'SIP':
-            LOG.debug('adding sip profile')
-            if '/Common/sip' not in vip['profiles']:
-                vip['profiles'].append('/Common/sip')
-
     def get_vlan(self, vip, bigip, network_id):
         if network_id in bigip.assured_networks:
             vip['vlans'].append(

--- a/f5_openstack_agent/lbaasv2/drivers/bigip/sip_profile.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/sip_profile.py
@@ -1,0 +1,102 @@
+# coding=utf-8
+# Copyright (c) 2016-2023, F5 Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from f5_openstack_agent.lbaasv2.drivers.bigip import resource_helper
+from oslo_log import log as logging
+
+LOG = logging.getLogger(__name__)
+
+
+class SIPProfileHelper(object):
+    """A tool class for SIP profile process"""
+
+    def __init__(self):
+        self.sip_helper = resource_helper.BigIPResourceHelper(
+            resource_helper.ResourceType.sip_profile
+        )
+
+    @staticmethod
+    def enable_sip(service):
+        listener = service.get('listener')
+        if listener and listener.get('protocol') == 'SIP':
+            return True
+        return False
+
+    def add_profile(self, vs, bigip):
+        partition = vs['partition']
+
+        profile_name = self.get_profile_name(vs)
+        profile = "/" + partition + "/" + profile_name
+
+        profile_exists = self.sip_helper.exists(
+            bigip,
+            name=profile_name,
+            partition=partition
+        )
+
+        destination = vs.get("destination", "")
+
+        if '%' in destination:
+            address = destination.split('%')[0]
+            if ':' in destination:
+                port = destination.split(':')[-1]
+                destination = address + ":" + port
+
+        userViaHeader = "SIP/2.0/UDP " + destination
+        LOG.debug("userViaHeader is %s", userViaHeader)
+
+        if not profile_exists:
+            payload = dict(
+                name=profile_name,
+                partition=partition,
+                insertViaHeader="enabled",
+                userViaHeader=userViaHeader
+
+            )
+            LOG.debug(
+                "Add new SIP profile: {} for "
+                "BIGIP: {} ".format(
+                    profile, bigip.hostname
+                )
+            )
+            self.sip_helper.create(bigip, payload)
+
+        vs['profiles'].append(profile)
+
+    def remove_profile(self, vs, bigip):
+        partition = vs['partition']
+        profile_name = SIPProfileHelper.get_profile_name(
+            vs)
+        profile = "/" + partition + "/" + profile_name
+
+        LOG.debug(
+            "Remove SIP profile: {} from "
+            "BIGIP: {}".format(
+                profile, bigip.hostname
+            )
+        )
+        self.sip_helper.delete(
+            bigip,
+            name=profile_name,
+            partition=partition
+        )
+
+    @staticmethod
+    def get_profile_name(vs):
+        vs_name = vs.get('name', 'vs_name')
+        prefix = "sip_"
+        profile_name = prefix + vs_name
+        return profile_name


### PR DESCRIPTION
1. based on protocol type(SIP), create sip profile named sip_$VS_NAME, and persistence profile 
call_id_$VS_NAME. The sip profile sets insertViaHeader and userViaHeader.
insertViaHeader = enabled ;  userViaHeader = 'SIP/2.0/UDP $VS_IP:$VS_PORT' .
VS_IP, VS_PORT is the ip address and port of the listener.

2. remove old description way to create sip/diameter listener using listener's description.
