### PR TITLE
[OPENSTACK-2912] not append if already exists

### DIFF
--- a/f5_openstack_agent/lbaasv2/drivers/bigip/sip_profile.py
+++ b/f5_openstack_agent/lbaasv2/drivers/bigip/sip_profile.py
@@ -74,7 +74,8 @@ class SIPProfileHelper(object):
             )
             self.sip_helper.create(bigip, payload)
 
-        vs['profiles'].append(profile)
+        if profile not in vs['profiles']:
+            vs['profiles'].append(profile)
 
     def remove_profile(self, vs, bigip):
         partition = vs['partition']


### PR DESCRIPTION
not to append the profile if it is already
in the profiles list. Seems it tried to append
the same profile again when there were
more devices.