### PR TITLE
[OPENSTACK-2892] release 9.8.50 again to include 2 fixes

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -30,6 +30,8 @@ Bug Fixes
 * [OPENSTACK-2482] Delete cafile for mtls profile.
 * [OPENSTACK-2482] Remove certs and keys as removing ssl profiles.
 * [OPENSTACK-2483] Fix confusing logs to avoid misunderstanding.
+* [OPENSTACK-2892] interface was set incorrectly
+* [OPENSTACK-2928] arbitrary desc breaks creation
 
 Limitations
 ```````````


### PR DESCRIPTION
1. interface was set to None incorrectly
2. 'unexpected' --description broke listener creation

