### PR TITLE
[OPENSTACK-2928] add *-stable branch check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,12 +54,16 @@ script:
     # pzhang: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
     - f5-openstack-agent-dist/scripts/test_install.sh "ubuntu" "14.04" ${PKG_RELEASE_1404}
     - |
-      if [[ "$TRAVIS_BRANCH" =~ ^v[0-9]+\.[0-9]+\.[0-9]* ]]; then
+      if [[ "$TRAVIS_BRANCH" == *"-stable" ]]; then
+        export CTLR_VERSION=v$(echo $TRAVIS_BRANCH | sed s/-stable//g)
+      elif [[ "$TRAVIS_BRANCH" =~ ^v[0-9]+\.[0-9]+\.[0-9]* ]]; then
         va=( ${TRAVIS_BRANCH//./ } ) # replace decimals and split into array
         export CTLR_VERSION="${va[0]}.${va[1]}.${va[2]}"
       else
         export CTLR_VERSION=$TRAVIS_BRANCH
       fi
+    - echo $TRAVIS_BRANCH
+    - echo $CTLR_VERSION
 
 after_success:
   - md5sum ${PKG_RELEASE_EL7} > ${PKG_RELEASE_EL7}.md5 && md5sum --check ${PKG_RELEASE_EL7}.md5


### PR DESCRIPTION
seems commit 3989546fd7b2213d220560e0a860ea47eb59988e would cause the doc to release to url path:
products/openstack/agent/9.10.5-stable
when branch is e.g. 9.10.5-stable .
Example log can be found at builds/267194786 .

The intended url path for 9.10.5-stable
would be products/openstack/agent/v9.10.5
